### PR TITLE
Add configurable flip card game module with result screen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import logo from './logo.svg';
 import './App.css';
 import { BrowserRouter as Router, Route, Link, Routes } from 'react-router-dom';
-import MatchingGame from './components/games/matching-game/matching-game';
+import MatchingGameInit from './components/games/matching-game/matching-game-init';
 import HomeNav from './components/home/home-nav';
 import StwGame from './components/games/stw-game/stw-game';
 import MysteryManorGame from './components/games/mystery-manor-game/mystery-manor-game';
@@ -14,7 +14,7 @@ function App() {
           <div>
             <Routes>
               <Route path="/" element={<HomeNav />} />
-              <Route path="/game1" element={<MatchingGame />} />
+              <Route path="/game1" element={<MatchingGameInit />} />
               <Route path="/game2" element={<StwGame />} />
               <Route path="/game3" element={<MysteryManorGame />} />
             </Routes>

--- a/src/components/games/matching-game/match-card.js
+++ b/src/components/games/matching-game/match-card.js
@@ -2,7 +2,15 @@ import React from 'react';
 import { IoCheckmarkCircle } from "react-icons/io5";
 
 
-const Card = ({ onClick, card, index, isInactive, isFlipped, isDisabled }) => {
+const Card = ({
+    onClick,
+    card,
+    index,
+    isInactive,
+    isFlipped,
+    isDisabled,
+    cardBackImage
+}) => {
     const handleClick = () => {
         !isFlipped && !isDisabled && onClick(index);
     };
@@ -23,7 +31,7 @@ const Card = ({ onClick, card, index, isInactive, isFlipped, isDisabled }) => {
                 {!isFlipped ? (
                     <div className='absolute inset-0 flex items-center justify-center'>
                         <img
-                            src='/images/matching-game-assets/white-tiffin-assets/white-tiffin-logo.png'
+                            src={cardBackImage}
                             alt="cardBack"
                             className='w-15 h-15'
                         />

--- a/src/components/games/matching-game/matching-game-init.js
+++ b/src/components/games/matching-game/matching-game-init.js
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from 'react';
+import MatchingGame from './matching-game';
+import flipCardConfig from '../../../config/flip-card-config';
+
+const MatchingGameInit = () => {
+  const [config, setConfig] = useState(null);
+
+  useEffect(() => {
+    // Simulate fetching configuration from API
+    const timeout = setTimeout(() => {
+      setConfig(flipCardConfig);
+    }, 500);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  if (!config) {
+    return <div className="flex items-center justify-center p-10">Loading...</div>;
+  }
+
+  return <MatchingGame config={config} />;
+};
+
+export default MatchingGameInit;

--- a/src/components/games/matching-game/results-screen.js
+++ b/src/components/games/matching-game/results-screen.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const ResultsScreen = ({ score, voucher }) => {
+  return (
+    <div className="flex flex-col items-center justify-center">
+      <h2 className="text-3xl p-3">Results</h2>
+      <p className="text-xl p-3">Score: {score}</p>
+      <p className="text-xl p-3">Voucher Won: {voucher}</p>
+      <Link to="/" className="p-3 text-blue-500">Back to Home</Link>
+    </div>
+  );
+};
+
+export default ResultsScreen;

--- a/src/config/flip-card-config.js
+++ b/src/config/flip-card-config.js
@@ -1,0 +1,11 @@
+import uniqueCardsArray from '../components/games/matching-game/unique-cards';
+
+const flipCardConfig = {
+  gameId: 'flip-001',
+  gameType: 'flip-card',
+  moveLimit: 5,
+  cards: uniqueCardsArray,
+  cardBackImage: '/images/matching-game-assets/white-tiffin-assets/white-tiffin-logo.png'
+};
+
+export default flipCardConfig;


### PR DESCRIPTION
## Summary
- add sample config for flip card game
- load matching game via init screen using the config
- submit game results to mock API and show voucher with back link

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68c6dcfca858832a867263deb9b86b5d