### PR TITLE
Add initial reveal and end-game modal flow to matching game

### DIFF
--- a/src/components/games/matching-game/matching-game.js
+++ b/src/components/games/matching-game/matching-game.js
@@ -3,68 +3,226 @@ import Card from './match-card';
 import uniqueCardsArray from './unique-cards';
 import ResultsScreen from './results-screen';
 
+const GameStatusModal = ({ status, movesLeft, timeElapsed, onSubmit, isSubmitting }) => {
+  const isWin = status === 'won';
+  const title = isWin ? 'Great job!' : 'Game over';
+  const description = isWin
+    ? 'You matched all of the cards before running out of moves.'
+    : 'You ran out of moves before matching all of the cards.';
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-10">
+      <div className="bg-white rounded-lg shadow-xl p-6 max-w-sm w-full text-center space-y-4">
+        <div>
+          <h3 className="text-2xl font-semibold mb-1">{title}</h3>
+          <p className="text-gray-600">{description}</p>
+        </div>
+        <div className="space-y-1 text-sm text-gray-700">
+          <p><span className="font-medium">Outcome:</span> {isWin ? 'Won' : 'Lost'}</p>
+          <p><span className="font-medium">Moves left:</span> {movesLeft}</p>
+          <p><span className="font-medium">Time elapsed:</span> {timeElapsed}s</p>
+        </div>
+        <button
+          type="button"
+          onClick={onSubmit}
+          disabled={isSubmitting}
+          className="w-full py-2 px-4 rounded-md bg-blue-600 text-white font-semibold hover:bg-blue-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+        >
+          {isSubmitting ? 'Submitting...' : 'Submit Results'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
 const MatchingGame = ({ config }) => {
   const cardsFromConfig = config?.cards || uniqueCardsArray;
   const [cards] = useState(() => shuffleCards(cardsFromConfig.concat(cardsFromConfig)));
+  const totalPairs = cards.length / 2;
+  const moveLimit = config?.moveLimit || 5;
+  const initialRevealDuration = config?.initialRevealSeconds ?? 0;
+  const mismatchRevealSeconds = config?.cardUpflipSeconds ?? 0.5;
+  const mismatchRevealDurationMs = Math.max(0, mismatchRevealSeconds * 1000);
+
   const [openCards, setOpenCards] = useState([]);
   const [clearedCards, setClearedCards] = useState({});
   const [moves, setMoves] = useState(0);
   const [result, setResult] = useState(null);
-  const [shouldDisableAllCards, setShouldDisableAllCards] = useState(false);
-  const timeout = useRef(null);
-  const moveLimit = config?.moveLimit || 5;
+  const [gameStatus, setGameStatus] = useState('playing');
+  const [showModal, setShowModal] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isInitialRevealActive, setIsInitialRevealActive] = useState(initialRevealDuration > 0);
+  const [shouldDisableAllCards, setShouldDisableAllCards] = useState(initialRevealDuration > 0);
+  const [elapsedTime, setElapsedTime] = useState(0);
 
-  // Check if both the cards have same type. If they do, mark them inactive
-  const evaluate = () => {
-    const [first, second] = openCards;
-    if (cards[first].type === cards[second].type) {
-      setClearedCards((prev) => ({ ...prev, [cards[first].type]: true }));
-      setOpenCards([]);
-      return;
+  const gameStartTimeRef = useRef(Date.now());
+  const gameStatusRef = useRef('playing');
+  const evaluationTimeoutRef = useRef(null);
+  const initialRevealTimeoutRef = useRef(null);
+
+  const movesLeft = Math.max(moveLimit - moves, 0);
+
+  const stopAllTimeouts = () => {
+    if (initialRevealTimeoutRef.current) {
+      clearTimeout(initialRevealTimeoutRef.current);
+      initialRevealTimeoutRef.current = null;
     }
-    // Flip cards after a 500ms duration
-    timeout.current = setTimeout(() => {
-      setOpenCards([]);
-    }, 500);
+    if (evaluationTimeoutRef.current) {
+      clearTimeout(evaluationTimeoutRef.current);
+      evaluationTimeoutRef.current = null;
+    }
   };
 
-  const handleCardClick = (index) => {
-    // Have a maximum of 2 items in array at once.
-    if (openCards.length === 1) {
-      setOpenCards((prev) => [...prev, index]);
-      // increase the moves once we opened a pair
-      setMoves((moves) => moves + 1);
-    } else {
-      // If two cards are already open, we cancel timeout set for flipping cards back
-      clearTimeout(timeout.current);
-      setOpenCards([index]);
+  useEffect(() => () => stopAllTimeouts(), []);
+
+  useEffect(() => {
+    gameStatusRef.current = gameStatus;
+  }, [gameStatus]);
+
+  useEffect(() => {
+    if (initialRevealTimeoutRef.current) {
+      clearTimeout(initialRevealTimeoutRef.current);
+      initialRevealTimeoutRef.current = null;
     }
+
+    if (initialRevealDuration > 0) {
+      setIsInitialRevealActive(true);
+      setShouldDisableAllCards(true);
+      initialRevealTimeoutRef.current = setTimeout(() => {
+        setIsInitialRevealActive(false);
+        gameStartTimeRef.current = Date.now();
+        if (gameStatusRef.current === 'playing') {
+          setShouldDisableAllCards(false);
+        }
+        initialRevealTimeoutRef.current = null;
+      }, initialRevealDuration * 1000);
+    } else {
+      setIsInitialRevealActive(false);
+      gameStartTimeRef.current = Date.now();
+      if (gameStatusRef.current === 'playing') {
+        setShouldDisableAllCards(false);
+      }
+    }
+
+    return () => {
+      if (initialRevealTimeoutRef.current) {
+        clearTimeout(initialRevealTimeoutRef.current);
+        initialRevealTimeoutRef.current = null;
+      }
+    };
+  }, [initialRevealDuration]);
+
+  const finalizeGame = (status) => {
+    if (gameStatusRef.current !== 'playing') {
+      return;
+    }
+    stopAllTimeouts();
+    setOpenCards([]);
+    setElapsedTime(Math.floor((Date.now() - gameStartTimeRef.current) / 1000));
+    setShowModal(true);
+    setShouldDisableAllCards(true);
+    setGameStatus(status);
+  };
+
+  useEffect(() => {
+    if (moves >= moveLimit && gameStatusRef.current === 'playing') {
+      finalizeGame('lost');
+    }
+  }, [moves, moveLimit]);
+
+  const evaluate = () => {
+    const [first, second] = openCards;
+    if (first === undefined || second === undefined) {
+      return;
+    }
+
+    if (cards[first].type === cards[second].type) {
+      setClearedCards((prev) => {
+        const updated = { ...prev, [cards[first].type]: true };
+        if (Object.keys(updated).length === totalPairs) {
+          finalizeGame('won');
+        } else if (gameStatusRef.current === 'playing') {
+          setShouldDisableAllCards(false);
+        }
+        return updated;
+      });
+    } else {
+      if (gameStatusRef.current === 'playing') {
+        setShouldDisableAllCards(false);
+      }
+    }
+    setOpenCards([]);
   };
 
   useEffect(() => {
     if (openCards.length === 2) {
-      setTimeout(evaluate, 500);
+      evaluationTimeoutRef.current = setTimeout(() => {
+        evaluate();
+        evaluationTimeoutRef.current = null;
+      }, mismatchRevealDurationMs);
     }
-  }, [openCards]);
 
-  useEffect(() => {
-    if (moves === moveLimit) {
-      const score = Object.keys(clearedCards).length;
-      const url = `/api/${config.gameType}/${config.gameId}`;
-      mockSubmitResults(url, { score }).then((res) => setResult(res));
+    return () => {
+      if (evaluationTimeoutRef.current) {
+        clearTimeout(evaluationTimeoutRef.current);
+        evaluationTimeoutRef.current = null;
+      }
+    };
+  }, [openCards, mismatchRevealDurationMs]);
+
+  const handleCardClick = (index) => {
+    if (shouldDisableAllCards || gameStatusRef.current !== 'playing' || isInitialRevealActive) {
+      return;
     }
-  }, [moves]);
+
+    if (openCards.includes(index)) {
+      return;
+    }
+
+    if (openCards.length === 1) {
+      setOpenCards((prev) => [...prev, index]);
+      setMoves((prevMoves) => prevMoves + 1);
+      setShouldDisableAllCards(true);
+    } else {
+      setOpenCards([index]);
+    }
+  };
 
   const checkIsFlipped = (index) => {
-    return openCards.includes(index);
+    return isInitialRevealActive || openCards.includes(index);
   };
 
   const checkIsInactive = (card) => {
     return Boolean(clearedCards[card.type]);
   };
 
+  const handleSubmitResults = () => {
+    if (isSubmitting || gameStatusRef.current === 'playing') {
+      return;
+    }
+
+    setIsSubmitting(true);
+    const finalElapsedTime = elapsedTime || Math.floor((Date.now() - gameStartTimeRef.current) / 1000);
+    const payload = {
+      gameId: config?.gameId,
+      gameType: config?.gameType,
+      outcome: gameStatus === 'won' ? 'Won' : 'Lost',
+      movesLeft,
+      timeElapsed: finalElapsedTime,
+    };
+    const url = `/api/${config?.gameType}/${config?.gameId}`;
+
+    mockSubmitResults(url, payload)
+      .then((response) => {
+        setResult(response);
+      })
+      .finally(() => {
+        setIsSubmitting(false);
+      });
+  };
+
   if (result) {
-    return <ResultsScreen score={result.score} voucher={result.voucher} />;
+    return <ResultsScreen {...result} />;
   }
 
   return (
@@ -72,7 +230,7 @@ const MatchingGame = ({ config }) => {
       <header className='flex flex-col items-center justify-center'>
         <h2 className='text-3xl p-3'>Matching Game</h2>
         <p className='text-xl p-3'>Match the cards!</p>
-        <p className='text-xl p-3'>You have {moveLimit - moves} moves left!</p>
+        <p className='text-xl p-3'>You have {movesLeft} moves left!</p>
       </header>
       <div className="grid grid-cols-3 gap-4">
         {cards.map((card, index) => {
@@ -90,6 +248,15 @@ const MatchingGame = ({ config }) => {
           );
         })}
       </div>
+      {showModal && (
+        <GameStatusModal
+          status={gameStatus}
+          movesLeft={movesLeft}
+          timeElapsed={elapsedTime}
+          onSubmit={handleSubmitResults}
+          isSubmitting={isSubmitting}
+        />
+      )}
     </div>
   );
 };
@@ -99,22 +266,22 @@ const swap = (array, i, j) => {
   const temp = array[i];
   array[i] = array[j];
   array[j] = temp;
-}
+};
 
 const shuffleCards = (array) => {
   const length = array.length;
   for (let i = length; i > 0; i--) {
     const randomIndex = Math.floor(Math.random() * i);
     const currIndex = i - 1;
-    swap(array, currIndex, randomIndex)
+    swap(array, currIndex, randomIndex);
   }
   return array;
-}
+};
 
 const mockSubmitResults = (url, payload) => {
   return new Promise((resolve) => {
     setTimeout(() => {
-      resolve({ voucher: 'Free Dessert', score: payload.score });
+      resolve(payload);
     }, 1000);
   });
 };

--- a/src/components/games/matching-game/results-screen.js
+++ b/src/components/games/matching-game/results-screen.js
@@ -1,12 +1,15 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-const ResultsScreen = ({ score, voucher }) => {
+const ResultsScreen = ({ outcome, movesLeft, timeElapsed, gameId, gameType }) => {
   return (
     <div className="flex flex-col items-center justify-center">
       <h2 className="text-3xl p-3">Results</h2>
-      <p className="text-xl p-3">Score: {score}</p>
-      <p className="text-xl p-3">Voucher Won: {voucher}</p>
+      {gameType && <p className="text-lg text-gray-600">Game Type: {gameType}</p>}
+      <p className="text-xl p-3">Game ID: {gameId}</p>
+      <p className="text-xl p-3">Outcome: {outcome}</p>
+      <p className="text-xl p-3">Moves Left: {movesLeft}</p>
+      <p className="text-xl p-3">Time Elapsed: {timeElapsed}s</p>
       <Link to="/" className="p-3 text-blue-500">Back to Home</Link>
     </div>
   );

--- a/src/config/flip-card-config.js
+++ b/src/config/flip-card-config.js
@@ -4,6 +4,8 @@ const flipCardConfig = {
   gameId: 'flip-001',
   gameType: 'flip-card',
   moveLimit: 5,
+  initialRevealSeconds: 3,
+  cardUpflipSeconds: 0.75,
   cards: uniqueCardsArray,
   cardBackImage: '/images/matching-game-assets/white-tiffin-assets/white-tiffin-logo.png'
 };


### PR DESCRIPTION
## Summary
- add a configurable initial reveal period for matching cards and disable interaction until it ends
- detect win and loss states, surface a modal to submit results, and send outcome statistics to the results screen
- update the results screen to display the submitted outcome details and surface the new reveal duration option in config
- make the mismatch flip-back delay configurable through the matching game config and start the round timer after the reveal completes

## Testing
- npm test -- --watchAll=false *(fails: Jest cannot resolve react-router-dom in the current setup)*

------
https://chatgpt.com/codex/tasks/task_e_68cc141ce0fc832ab6204d1bcc4b6e65