### PR TITLE
Add precision timer countdown challenge game

### DIFF
--- a/public/images/precision-timer-game-thumb.svg
+++ b/public/images/precision-timer-game-thumb.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <defs>
+    <linearGradient id="gradient" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#10b981" />
+    </linearGradient>
+  </defs>
+  <rect width="200" height="200" rx="24" fill="url(#gradient)" />
+  <g transform="translate(100 90)">
+    <circle r="56" fill="rgba(255,255,255,0.15)" />
+    <circle r="52" fill="rgba(255,255,255,0.25)" />
+    <circle r="48" fill="rgba(255,255,255,0.35)" />
+    <text
+      x="0"
+      y="14"
+      text-anchor="middle"
+      font-family="'Fira Mono', 'Menlo', 'Courier New', monospace"
+      font-size="28"
+      fill="#ffffff"
+    >
+      0.000
+    </text>
+  </g>
+  <text
+    x="100"
+    y="160"
+    text-anchor="middle"
+    font-family="'Inter', 'Helvetica Neue', Arial, sans-serif"
+    font-size="20"
+    font-weight="600"
+    fill="#ffffff"
+  >
+    Precision Timer
+  </text>
+</svg>

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import MatchingGameInit from './games/matching-game/matching-game-init';
 import HomeNav from './components/home/home-nav';
 import StwGame from './games/stw-game/stw-game';
 import MysteryManorGame from './games/mystery-manor-game/mystery-manor-game';
+import PrecisionTimerGameInit from './games/precision-timer-game/precision-timer-game-init';
 
 function App() {
   return (
@@ -17,6 +18,7 @@ function App() {
               <Route path="/game1" element={<MatchingGameInit />} />
               <Route path="/game2" element={<StwGame />} />
               <Route path="/game3" element={<MysteryManorGame />} />
+              <Route path="/game4" element={<PrecisionTimerGameInit />} />
             </Routes>
           </div>
         </Router>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,20 @@
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+jest.mock(
+  'react-router-dom',
+  () => ({
+    BrowserRouter: ({ children }) => <div>{children}</div>,
+    Route: ({ element }) => element,
+    Routes: ({ children }) => <>{children}</>,
+    Link: ({ children, to }) => <a href={to}>{children}</a>
+  }),
+  { virtual: true }
+);
+
+test("renders the game library navigation", () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getByText(/NthLabs' Game Library/i)).toBeInTheDocument();
+  expect(screen.getByText(/Precision Timer/i)).toBeInTheDocument();
 });

--- a/src/components/home/home-nav.js
+++ b/src/components/home/home-nav.js
@@ -1,44 +1,54 @@
-import React from 'react'
+import React from 'react';
 import { Link } from 'react-router-dom';
 
 const HomeNav = () => {
-    return (
-        <div className='flex flex-col items-center justify-center'>
-            <h2 className='p-10 text-3xl'>NthLabs' Game Library</h2>
-            <div className='grid grid-cols-2 gap-4'>
-                <Link to="/game1">
-                    <div className='flex flex-col items-center justify-center'>
-                        <img
-                            src="/images/matching-game-assets/matching-game-thumb.png"
-                            alt="Matching Game Thumbnail"
-                            className="w-48 h-48 object-contain rounded-md"
-                        />
-                        <p>Matching Game</p>
-                    </div>
-                </Link>
-                <Link to="/game2">
-                    <div className='flex flex-col items-center justify-center'>
-                        <img
-                            src="/images/stw-game-thumb.png"
-                            alt="STW Game Thumbnail"
-                            className="w-48 h-48 object-cover rounded-md"
-                        />
-                        <p>Spin The Wheel</p>
-                    </div>
-                </Link>
-                <Link to="/game3">
-                    <div className='flex flex-col items-center justify-center'>
-                        <img
-                            src="/images/mystery-manor-game-thumb.png"
-                            alt="Mystery Manor Game Thumbnail"
-                            className="w-48 h-48 object-cover rounded-md"
-                        />
-                        <p>Mystery Manor</p>
-                    </div>
-                </Link>
-            </div>
-        </div>
-    )
-}
+  return (
+    <div className="flex flex-col items-center justify-center">
+      <h2 className="p-10 text-3xl">NthLabs' Game Library</h2>
+      <div className="grid grid-cols-2 gap-4">
+        <Link to="/game1">
+          <div className="flex flex-col items-center justify-center">
+            <img
+              src="/images/matching-game-assets/matching-game-thumb.png"
+              alt="Matching Game Thumbnail"
+              className="h-48 w-48 rounded-md object-contain"
+            />
+            <p>Matching Game</p>
+          </div>
+        </Link>
+        <Link to="/game2">
+          <div className="flex flex-col items-center justify-center">
+            <img
+              src="/images/stw-game-thumb.png"
+              alt="STW Game Thumbnail"
+              className="h-48 w-48 rounded-md object-cover"
+            />
+            <p>Spin The Wheel</p>
+          </div>
+        </Link>
+        <Link to="/game3">
+          <div className="flex flex-col items-center justify-center">
+            <img
+              src="/images/mystery-manor-game-thumb.png"
+              alt="Mystery Manor Game Thumbnail"
+              className="h-48 w-48 rounded-md object-cover"
+            />
+            <p>Mystery Manor</p>
+          </div>
+        </Link>
+        <Link to="/game4">
+          <div className="flex flex-col items-center justify-center">
+            <img
+              src="/images/precision-timer-game-thumb.svg"
+              alt="Precision Timer Game Thumbnail"
+              className="h-48 w-48 rounded-md object-contain"
+            />
+            <p>Precision Timer</p>
+          </div>
+        </Link>
+      </div>
+    </div>
+  );
+};
 
-export default HomeNav
+export default HomeNav;

--- a/src/games/precision-timer-game/README.md
+++ b/src/games/precision-timer-game/README.md
@@ -1,0 +1,54 @@
+# Precision Timer Module
+
+This directory houses the configuration and React implementation for the
+Precision Timer challenge. Players start a five-second countdown and try to stop
+it as close to zero as possible. The folder mirrors the structure of the other
+modules so it can be copied into another project without additional wiring.
+
+## Folder contents
+
+- `precision-timer-game-init.js` – Lightweight wrapper that fetches the config
+  and mounts the gameplay component.
+- `precision-timer-game.js` – Countdown gameplay logic, submission mock, and UI.
+- `results-screen.js` – Post-game summary and return-to-home link.
+- `config/base-config.json` – Canonical configuration document for storage.
+- `config/index.js` – Exports the runtime config plus schema metadata.
+
+## API contract
+
+The frontend expects a JSON payload that matches the shape of
+`config/base-config.json`. A representative response looks like this:
+
+```json
+{
+  "gameId": "precision-001",
+  "gameType": "precision-timer",
+  "title": "Precision Timer Challenge",
+  "subtitle": "Stop the countdown at the perfect moment",
+  "description": "Players start a five-second countdown and try to stop it as close to zero as possible.",
+  "countdownSeconds": 5,
+  "startButtonLabel": "Start Countdown",
+  "stopButtonLabel": "Stop Timer",
+  "submissionEndpoint": "/api/games/precision-timer/precision-001/results"
+}
+```
+
+When the player ends the countdown, the frontend posts the final score to the
+`submissionEndpoint`. The mock implementation in this repository resolves the
+promise locally but the production service should persist the results.
+
+## Editable fields
+
+`config/index.js` surfaces a `fieldSchema` that downstream dashboards can use to
+control access:
+
+- **Admin dashboard**: `countdownSeconds`, `submissionEndpoint`.
+- **Merchant dashboard**: marketing copy (`title`, `subtitle`, `description`) and
+  button labels (`startButtonLabel`, `stopButtonLabel`).
+
+## MongoDB storage
+
+Store the base configuration document in a `gameConfigs` collection using the
+key `precision-timer:precision-001`. Clone this record for new campaigns and
+apply overrides according to the `fieldSchema`. The runtime payload should be a
+single merged document that mirrors `base-config.json`.

--- a/src/games/precision-timer-game/config/base-config.json
+++ b/src/games/precision-timer-game/config/base-config.json
@@ -1,0 +1,11 @@
+{
+  "gameId": "precision-001",
+  "gameType": "precision-timer",
+  "title": "Precision Timer Challenge",
+  "subtitle": "Stop the countdown at the perfect moment",
+  "description": "Players start a five-second countdown and try to stop it as close to zero as possible.",
+  "countdownSeconds": 5,
+  "startButtonLabel": "Start Countdown",
+  "stopButtonLabel": "Stop Timer",
+  "submissionEndpoint": "/api/games/precision-timer/precision-001/results"
+}

--- a/src/games/precision-timer-game/config/index.js
+++ b/src/games/precision-timer-game/config/index.js
@@ -1,0 +1,54 @@
+import baseConfig from './base-config.json';
+
+export const precisionTimerFieldSchema = {
+  admin: {
+    countdownSeconds: {
+      type: 'number',
+      description: 'Number of seconds the countdown should run before players try to stop it.'
+    },
+    submissionEndpoint: {
+      type: 'string',
+      description: 'API endpoint that records the player\'s timing attempt once the game ends.'
+    }
+  },
+  merchant: {
+    title: {
+      type: 'string',
+      description: 'Headline displayed at the top of the countdown screen.'
+    },
+    subtitle: {
+      type: 'string',
+      description: 'Optional subheading reinforcing the campaign message.'
+    },
+    description: {
+      type: 'string',
+      description: 'Supporting copy that explains how the challenge works.'
+    },
+    startButtonLabel: {
+      type: 'string',
+      description: 'Text displayed on the button that begins the countdown.'
+    },
+    stopButtonLabel: {
+      type: 'string',
+      description: 'Text displayed on the button that submits the player\'s attempt.'
+    }
+  }
+};
+
+export const precisionTimerApiContract = {
+  method: 'GET',
+  responseType: 'application/json',
+  collection: 'gameConfigs',
+  documentKey: `${baseConfig.gameType}:${baseConfig.gameId}`,
+  notes: 'Backend services should merge merchant overrides with the base configuration before returning the payload.'
+};
+
+const precisionTimerConfig = {
+  ...baseConfig,
+  fieldSchema: precisionTimerFieldSchema,
+  apiContract: precisionTimerApiContract
+};
+
+export const basePrecisionTimerConfig = baseConfig;
+
+export default precisionTimerConfig;

--- a/src/games/precision-timer-game/precision-timer-game-init.js
+++ b/src/games/precision-timer-game/precision-timer-game-init.js
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react';
+import PrecisionTimerGame from './precision-timer-game';
+import precisionTimerConfig from './config';
+
+const PrecisionTimerGameInit = () => {
+  const [config, setConfig] = useState(null);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setConfig(precisionTimerConfig);
+    }, 400);
+
+    return () => clearTimeout(timeout);
+  }, []);
+
+  if (!config) {
+    return (
+      <div className="flex min-h-[50vh] w-full items-center justify-center" role="status" aria-live="polite">
+        <span className="text-lg font-medium text-gray-700">Loading countdown challenge...</span>
+      </div>
+    );
+  }
+
+  return <PrecisionTimerGame config={config} />;
+};
+
+export default PrecisionTimerGameInit;

--- a/src/games/precision-timer-game/precision-timer-game.js
+++ b/src/games/precision-timer-game/precision-timer-game.js
@@ -1,0 +1,214 @@
+import React, { useEffect, useRef, useState } from 'react';
+import precisionTimerConfig from './config';
+import ResultsScreen from './results-screen';
+
+const formatSeconds = (value) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return '0.000';
+  }
+  return numeric.toFixed(3);
+};
+
+const parseCountdownSeconds = (value) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return 5;
+  }
+  return numeric;
+};
+
+const PrecisionTimerGame = ({ config = precisionTimerConfig }) => {
+  const countdownSeconds = parseCountdownSeconds(config?.countdownSeconds);
+  const [displaySeconds, setDisplaySeconds] = useState(() => formatSeconds(countdownSeconds));
+  const [status, setStatus] = useState('idle');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [result, setResult] = useState(null);
+
+  const startTimeRef = useRef(null);
+  const targetTimeRef = useRef(null);
+  const intervalRef = useRef(null);
+  const hasFinalisedRef = useRef(false);
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (status === 'idle') {
+      setDisplaySeconds(formatSeconds(countdownSeconds));
+    }
+  }, [countdownSeconds, status]);
+
+  const startCountdown = () => {
+    if (status !== 'idle') {
+      return;
+    }
+
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    const now = Date.now();
+    startTimeRef.current = now;
+    targetTimeRef.current = now + countdownSeconds * 1000;
+    hasFinalisedRef.current = false;
+
+    setDisplaySeconds(formatSeconds(countdownSeconds));
+    setStatus('counting');
+
+    intervalRef.current = setInterval(() => {
+      const remainingMs = targetTimeRef.current - Date.now();
+
+      if (remainingMs <= 0) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+        setDisplaySeconds('0.000');
+        finaliseResult({ reason: 'timeout', stopTime: targetTimeRef.current });
+        return;
+      }
+
+      setDisplaySeconds(formatSeconds(remainingMs / 1000));
+    }, 50);
+  };
+
+  const stopCountdown = () => {
+    if (status !== 'counting' || hasFinalisedRef.current) {
+      return;
+    }
+
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    const stopTime = Date.now();
+    const remainingMs = targetTimeRef.current - stopTime;
+    setDisplaySeconds(formatSeconds(remainingMs / 1000));
+    finaliseResult({ reason: 'player', stopTime });
+  };
+
+  const finaliseResult = ({ reason, stopTime }) => {
+    if (hasFinalisedRef.current) {
+      return;
+    }
+
+    hasFinalisedRef.current = true;
+    setStatus('submitting');
+    setIsSubmitting(true);
+
+    const startedAt = startTimeRef.current || stopTime;
+    const resolvedStopTime = stopTime || Date.now();
+
+    let pressedAtSeconds = null;
+    let timeRemainingSeconds = null;
+    let score = null;
+
+    if (reason === 'timeout') {
+      timeRemainingSeconds = 0;
+      score = Number(countdownSeconds.toFixed(3));
+    } else {
+      const deltaMs = targetTimeRef.current - resolvedStopTime;
+      timeRemainingSeconds = Number((deltaMs / 1000).toFixed(3));
+      pressedAtSeconds = Number(((resolvedStopTime - startedAt) / 1000).toFixed(3));
+      score = Number(Math.abs(deltaMs / 1000).toFixed(3));
+    }
+
+    const payload = {
+      gameId: config?.gameId,
+      gameType: config?.gameType,
+      gameTitle: config?.title,
+      outcome: reason === 'timeout' ? 'Missed' : 'Completed',
+      countdownSeconds,
+      pressedAtSeconds,
+      timeRemainingSeconds,
+      score
+    };
+
+    const endpoint = config?.submissionEndpoint || `/api/${config?.gameType}/${config?.gameId}`;
+
+    mockSubmitResults(endpoint, payload)
+      .then((response) => {
+        setResult(response);
+        setStatus('submitted');
+      })
+      .finally(() => {
+        setIsSubmitting(false);
+      });
+  };
+
+  if (result) {
+    return <ResultsScreen {...result} />;
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-6 p-10 text-center">
+      <header className="space-y-2">
+        <h2 className="text-3xl font-semibold">{config?.title}</h2>
+        {config?.subtitle && <p className="text-lg text-gray-600">{config.subtitle}</p>}
+        {config?.description && (
+          <p className="max-w-2xl text-gray-500">{config.description}</p>
+        )}
+      </header>
+
+      <div className="flex flex-col items-center gap-4">
+        <div className="rounded-lg border border-gray-200 bg-white px-8 py-6 shadow-sm">
+          <span className="text-6xl font-mono tabular-nums text-gray-800">{displaySeconds}</span>
+        </div>
+        <p className="text-sm text-gray-500">
+          Stop the timer as close to zero as possible. The smaller the difference, the better your score.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <button
+            type="button"
+            onClick={startCountdown}
+            disabled={status !== 'idle'}
+            className="rounded-md bg-blue-600 px-5 py-2 text-white shadow disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {config?.startButtonLabel || 'Start'}
+          </button>
+          <button
+            type="button"
+            onClick={stopCountdown}
+            disabled={status !== 'counting'}
+            className="rounded-md bg-emerald-600 px-5 py-2 text-white shadow disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {config?.stopButtonLabel || 'Stop'}
+          </button>
+        </div>
+      </div>
+
+      {status === 'counting' && (
+        <p className="text-sm text-gray-500">
+          Countdown started from {formatSeconds(countdownSeconds)} seconds. Press stop to lock in your attempt.
+        </p>
+      )}
+
+      {isSubmitting && !result && (
+        <p className="text-sm font-medium text-gray-600" role="status" aria-live="polite">
+          Submitting results...
+        </p>
+      )}
+    </div>
+  );
+};
+
+const mockSubmitResults = (url, payload) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        ...payload,
+        submittedAt: new Date().toISOString(),
+        submissionEndpoint: url
+      });
+    }, 900);
+  });
+};
+
+export default PrecisionTimerGame;

--- a/src/games/precision-timer-game/results-screen.js
+++ b/src/games/precision-timer-game/results-screen.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const formatSeconds = (value) => {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) {
+    return '—';
+  }
+  return Number(value).toFixed(3);
+};
+
+const ResultsScreen = ({
+  gameId,
+  gameType,
+  gameTitle,
+  outcome,
+  countdownSeconds,
+  pressedAtSeconds,
+  timeRemainingSeconds,
+  score,
+  submittedAt
+}) => {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 p-10 text-center">
+      <h2 className="text-3xl font-semibold">Countdown Results</h2>
+      {gameTitle && <p className="text-lg text-gray-600">{gameTitle}</p>}
+      <div className="w-full max-w-md rounded-lg border border-gray-200 bg-white p-6 text-left shadow-sm">
+        <dl className="space-y-2 text-sm text-gray-700">
+          {gameType && (
+            <div className="flex justify-between">
+              <dt className="font-medium text-gray-500">Game Type</dt>
+              <dd className="text-gray-800">{gameType}</dd>
+            </div>
+          )}
+          {gameId && (
+            <div className="flex justify-between">
+              <dt className="font-medium text-gray-500">Game ID</dt>
+              <dd className="text-gray-800">{gameId}</dd>
+            </div>
+          )}
+          {typeof countdownSeconds !== 'undefined' && (
+            <div className="flex justify-between">
+              <dt className="font-medium text-gray-500">Countdown Duration</dt>
+              <dd className="text-gray-800">{formatSeconds(countdownSeconds)}s</dd>
+            </div>
+          )}
+          <div className="flex justify-between">
+            <dt className="font-medium text-gray-500">Outcome</dt>
+            <dd className="text-gray-800">{outcome || 'Completed'}</dd>
+          </div>
+          <div className="flex justify-between">
+            <dt className="font-medium text-gray-500">Pressed At</dt>
+            <dd className="text-gray-800">{formatSeconds(pressedAtSeconds)}s</dd>
+          </div>
+          <div className="flex justify-between">
+            <dt className="font-medium text-gray-500">Time Remaining</dt>
+            <dd className="text-gray-800">{formatSeconds(timeRemainingSeconds)}s</dd>
+          </div>
+          <div className="flex justify-between">
+            <dt className="font-medium text-gray-500">Accuracy Score</dt>
+            <dd className="text-gray-800">{formatSeconds(score)}s</dd>
+          </div>
+          {submittedAt && (
+            <div className="flex justify-between">
+              <dt className="font-medium text-gray-500">Submitted At</dt>
+              <dd className="text-gray-800">{new Date(submittedAt).toLocaleString()}</dd>
+            </div>
+          )}
+        </dl>
+        <p className="mt-4 text-xs text-gray-500">
+          A lower accuracy score means you stopped the timer closer to zero.
+        </p>
+      </div>
+      <Link to="/" className="text-blue-600 hover:underline">
+        Back to Home
+      </Link>
+    </div>
+  );
+};
+
+export default ResultsScreen;


### PR DESCRIPTION
## Summary
- add a precision timer countdown challenge module complete with config, init wrapper, and results screen
- hook the new game into the router, home navigation, and provide a thumbnail asset
- adjust the app test to mock the router package and assert the updated navigation copy

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cd6d883d78832a99702d56fade0e65