### PR TITLE
Add interactive gachapon game experience

### DIFF
--- a/public/images/gachapon-game-thumb.svg
+++ b/public/images/gachapon-game-thumb.svg
@@ -1,0 +1,47 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="256" height="256" rx="32" fill="url(#paint0_radial)"/>
+  <g filter="url(#filter0_d)">
+    <path d="M66 176C66 149.386 87.3858 128 114 128H142C168.614 128 190 149.386 190 176V186C190 196.493 181.493 205 171 205H85C74.5066 205 66 196.493 66 186V176Z" fill="url(#paint1_linear)"/>
+  </g>
+  <g filter="url(#filter1_d)">
+    <path d="M88 126C88 101.699 107.699 82 132 82H124C148.301 82 168 101.699 168 126V134C168 143.389 160.389 151 151 151H105C95.6112 151 88 143.389 88 134V126Z" fill="url(#paint2_linear)"/>
+  </g>
+  <circle cx="128" cy="98" r="46" fill="url(#paint3_radial)" stroke="white" stroke-opacity="0.6" stroke-width="6"/>
+  <circle cx="112" cy="88" r="12" fill="white" fill-opacity="0.75"/>
+  <defs>
+    <filter id="filter0_d" x="50" y="120" width="156" height="101" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="6"/>
+      <feGaussianBlur stdDeviation="8"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.172549 0 0 0 0 0.203922 0 0 0 0 0.372549 0 0 0 0.35 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+    <filter id="filter1_d" x="72" y="74" width="112" height="95" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="6"/>
+      <feGaussianBlur stdDeviation="8"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.203922 0 0 0 0 0.258824 0 0 0 0 0.423529 0 0 0 0.35 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+    <radialGradient id="paint0_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(52 46) rotate(43.7) scale(257)">
+      <stop stop-color="#1E1B4B"/>
+      <stop offset="1" stop-color="#0F172A"/>
+    </radialGradient>
+    <linearGradient id="paint1_linear" x1="66" y1="128" x2="188" y2="204" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#312E81"/>
+      <stop offset="1" stop-color="#1D4ED8"/>
+    </linearGradient>
+    <linearGradient id="paint2_linear" x1="88" y1="82" x2="168" y2="152" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4338CA"/>
+      <stop offset="1" stop-color="#6366F1"/>
+    </linearGradient>
+    <radialGradient id="paint3_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(108 82) rotate(54.6) scale(78)">
+      <stop stop-color="#FDE68A"/>
+      <stop offset="1" stop-color="#F97316"/>
+    </radialGradient>
+  </defs>
+</svg>

--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import HomeNav from './components/home/home-nav';
 import StwGame from './games/stw-game/stw-game';
 import MysteryManorGame from './games/mystery-manor-game/mystery-manor-game';
 import PrecisionTimerGameInit from './games/precision-timer-game/precision-timer-game-init';
+import GachaponGame from './games/gachapon-game/gachapon-game';
 
 function App() {
   return (
@@ -19,6 +20,7 @@ function App() {
               <Route path="/game2" element={<StwGame />} />
               <Route path="/game3" element={<MysteryManorGame />} />
               <Route path="/game4" element={<PrecisionTimerGameInit />} />
+              <Route path="/game5" element={<GachaponGame />} />
             </Routes>
           </div>
         </Router>

--- a/src/components/home/home-nav.js
+++ b/src/components/home/home-nav.js
@@ -46,6 +46,16 @@ const HomeNav = () => {
             <p>Precision Timer</p>
           </div>
         </Link>
+        <Link to="/game5">
+          <div className="flex flex-col items-center justify-center">
+            <img
+              src="/images/gachapon-game-thumb.svg"
+              alt="Gachapon Game Thumbnail"
+              className="h-48 w-48 rounded-md object-contain"
+            />
+            <p>Celestial Capsule Gachapon</p>
+          </div>
+        </Link>
       </div>
     </div>
   );

--- a/src/games/gachapon-game/gachapon-api.js
+++ b/src/games/gachapon-game/gachapon-api.js
@@ -1,0 +1,95 @@
+const MOCK_PRIZES = [
+  {
+    id: 'luminous-orb',
+    name: 'Luminous Orb',
+    rarity: 'common',
+    description: 'A softly glowing orb that keeps your camp lit through the night.',
+    weight: 45,
+  },
+  {
+    id: 'ember-charm',
+    name: 'Ember Charm',
+    rarity: 'uncommon',
+    description: 'A flickering charm that warms nearby allies by a few cozy degrees.',
+    weight: 30,
+  },
+  {
+    id: 'aurora-cape',
+    name: 'Aurora Cape',
+    rarity: 'rare',
+    description: 'Shimmers with the northern lights and lets you glide short distances.',
+    weight: 18,
+  },
+  {
+    id: 'celestial-compass',
+    name: 'Celestial Compass',
+    rarity: 'epic',
+    description: 'Always points toward the nearest secret, no matter where you roam.',
+    weight: 6,
+  },
+  {
+    id: 'dragon-heartfire',
+    name: 'Dragon Heartfire',
+    rarity: 'legendary',
+    description: 'A fragment of dragon flame that grants a surge of courage to its bearer.',
+    weight: 1,
+  },
+];
+
+const rarityColors = {
+  common: '#E5E7EB',
+  uncommon: '#86EFAC',
+  rare: '#93C5FD',
+  epic: '#C4B5FD',
+  legendary: '#FDE68A',
+};
+
+const rarityLabels = {
+  common: 'Common',
+  uncommon: 'Uncommon',
+  rare: 'Rare',
+  epic: 'Epic',
+  legendary: 'Legendary',
+};
+
+const mapPrizeForResponse = (prize) => ({
+  ...prize,
+  rarityLabel: rarityLabels[prize.rarity] ?? prize.rarity,
+  capsuleColor: rarityColors[prize.rarity] ?? '#F3F4F6',
+});
+
+export const fetchAvailablePrizes = () =>
+  new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(MOCK_PRIZES.map(mapPrizeForResponse));
+    }, 700);
+  });
+
+const pickWeightedPrize = () => {
+  const totalWeight = MOCK_PRIZES.reduce((sum, prize) => sum + prize.weight, 0);
+  let threshold = Math.random() * totalWeight;
+
+  for (const prize of MOCK_PRIZES) {
+    threshold -= prize.weight;
+    if (threshold <= 0) {
+      return prize;
+    }
+  }
+
+  return MOCK_PRIZES[MOCK_PRIZES.length - 1];
+};
+
+export const attemptGachapon = () =>
+  new Promise((resolve) => {
+    const selectedPrize = pickWeightedPrize();
+
+    setTimeout(() => {
+      resolve({
+        attemptId: `attempt-${Date.now()}`,
+        prize: mapPrizeForResponse(selectedPrize),
+        flairText: 'The capsule cracks open in a burst of light! 🎉',
+        awardedAt: new Date().toISOString(),
+      });
+    }, 1100);
+  });
+

--- a/src/games/gachapon-game/gachapon-game.css
+++ b/src/games/gachapon-game/gachapon-game.css
@@ -1,0 +1,128 @@
+.gachapon-stage {
+  perspective: 1200px;
+}
+
+.gachapon-box {
+  position: relative;
+  width: 240px;
+  height: 260px;
+  border-radius: 24px;
+  background: linear-gradient(160deg, #312e81, #1f2937);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.45);
+  overflow: hidden;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  transform-style: preserve-3d;
+}
+
+.gachapon-box::before,
+.gachapon-box::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0));
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+.gachapon-box::after {
+  inset: 12px;
+  border-radius: 20px;
+  background: linear-gradient(225deg, rgba(59, 130, 246, 0.15), rgba(14, 116, 144, 0));
+}
+
+.gachapon-box--shake {
+  animation: gachapon-shake 0.12s ease-in-out infinite;
+}
+
+.gachapon-box--hidden {
+  opacity: 0;
+  transform: scale(0.85) rotateX(12deg);
+}
+
+@keyframes gachapon-shake {
+  0% {
+    transform: translate3d(0, 0, 0) rotate(0deg);
+  }
+  25% {
+    transform: translate3d(-5px, 3px, 0) rotate(-1.6deg);
+  }
+  50% {
+    transform: translate3d(4px, -4px, 0) rotate(1.4deg);
+  }
+  75% {
+    transform: translate3d(-4px, -2px, 0) rotate(-1deg);
+  }
+  100% {
+    transform: translate3d(0, 0, 0) rotate(0deg);
+  }
+}
+
+.gachapon-explosion {
+  position: absolute;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(250, 204, 21, 0.9) 0%, rgba(249, 115, 22, 0.6) 55%, rgba(0, 0, 0, 0) 70%);
+  animation: gachapon-explosion-burst 0.6s forwards ease-out;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+@keyframes gachapon-explosion-burst {
+  0% {
+    transform: scale(0.35);
+    opacity: 0.9;
+  }
+  50% {
+    transform: scale(1.9);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(3.8);
+    opacity: 0;
+  }
+}
+
+.gachapon-capsule {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 120px;
+  height: 120px;
+  border-radius: 50% 50% 60% 60%;
+  box-shadow: 0 12px 20px rgba(15, 23, 42, 0.35);
+  transition: transform 0.4s ease, opacity 0.4s ease;
+}
+
+.gachapon-capsule::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0) 55%);
+  mix-blend-mode: screen;
+}
+
+.gachapon-capsule--hidden {
+  transform: translate(-50%, -50%) scale(0.6) rotateX(22deg);
+  opacity: 0;
+}
+
+.gachapon-capsule-display {
+  position: relative;
+  width: 112px;
+  height: 112px;
+  border-radius: 50% 50% 60% 60%;
+  box-shadow: 0 14px 26px rgba(15, 23, 42, 0.35);
+  overflow: hidden;
+}
+
+.gachapon-capsule-display::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0) 55%);
+  mix-blend-mode: screen;
+}

--- a/src/games/gachapon-game/gachapon-game.js
+++ b/src/games/gachapon-game/gachapon-game.js
@@ -1,0 +1,304 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { attemptGachapon, fetchAvailablePrizes } from './gachapon-api';
+import './gachapon-game.css';
+
+const SHAKE_DURATION = 1200;
+const EXPLOSION_DURATION = 650;
+
+const rarityAccentClasses = {
+  common: 'border-gray-300 text-gray-200',
+  uncommon: 'border-emerald-300 text-emerald-200',
+  rare: 'border-sky-300 text-sky-200',
+  epic: 'border-violet-300 text-violet-200',
+  legendary: 'border-amber-200 text-amber-100',
+};
+
+const rarityBackground = {
+  common: 'bg-slate-800/40',
+  uncommon: 'bg-emerald-500/10',
+  rare: 'bg-sky-500/10',
+  epic: 'bg-violet-500/10',
+  legendary: 'bg-amber-500/10',
+};
+
+const formatDropRate = (weight, totalWeight) => {
+  if (!totalWeight) {
+    return '—';
+  }
+
+  const percentage = (weight / totalWeight) * 100;
+  if (percentage < 0.1) {
+    return '<0.1%';
+  }
+
+  return `${percentage.toFixed(1)}%`;
+};
+
+const PrizeCard = ({ prize, dropRate }) => {
+  const accentClass = rarityAccentClasses[prize.rarity] ?? 'border-slate-500 text-slate-200';
+  const backgroundClass = rarityBackground[prize.rarity] ?? 'bg-slate-800/40';
+
+  return (
+    <div
+      className={`flex h-full flex-col justify-between rounded-xl border ${accentClass} ${backgroundClass} p-4 shadow-lg shadow-slate-900/30`}
+    >
+      <div>
+        <p className="text-sm uppercase tracking-wide text-slate-400">{prize.rarityLabel}</p>
+        <h3 className="mt-1 text-xl font-semibold text-white">{prize.name}</h3>
+        <p className="mt-2 text-sm text-slate-300">{prize.description}</p>
+      </div>
+      <div className="mt-4 flex items-center justify-between text-sm text-slate-400">
+        <span>Drop Rate</span>
+        <span className="font-semibold text-slate-100">{dropRate}</span>
+      </div>
+    </div>
+  );
+};
+
+const GachaponGame = () => {
+  const navigate = useNavigate();
+  const [prizes, setPrizes] = useState([]);
+  const [loadingPrizes, setLoadingPrizes] = useState(true);
+  const [prizeError, setPrizeError] = useState(null);
+  const [isAttempting, setIsAttempting] = useState(false);
+  const [animationPhase, setAnimationPhase] = useState('idle');
+  const [result, setResult] = useState(null);
+  const [showResultModal, setShowResultModal] = useState(false);
+  const [attemptError, setAttemptError] = useState(null);
+  const [animationKey, setAnimationKey] = useState(0);
+
+  const timeoutsRef = useRef([]);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+      timeoutsRef.current.forEach(clearTimeout);
+      timeoutsRef.current = [];
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadingPrizes(true);
+    setPrizeError(null);
+
+    fetchAvailablePrizes()
+      .then((availablePrizes) => {
+        if (cancelled || !isMountedRef.current) {
+          return;
+        }
+        setPrizes(availablePrizes);
+      })
+      .catch(() => {
+        if (cancelled || !isMountedRef.current) {
+          return;
+        }
+        setPrizeError('We could not load the prize list. Please refresh to try again.');
+      })
+      .finally(() => {
+        if (cancelled || !isMountedRef.current) {
+          return;
+        }
+        setLoadingPrizes(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const totalWeight = useMemo(() => prizes.reduce((sum, prize) => sum + (prize.weight ?? 0), 0), [prizes]);
+
+  const queueTimeout = (callback, delay) => {
+    const timeoutId = setTimeout(callback, delay);
+    timeoutsRef.current.push(timeoutId);
+    return timeoutId;
+  };
+
+  const handleAttempt = () => {
+    if (isAttempting || loadingPrizes) {
+      return;
+    }
+
+    timeoutsRef.current.forEach(clearTimeout);
+    timeoutsRef.current = [];
+
+    setIsAttempting(true);
+    setAttemptError(null);
+    setResult(null);
+    setShowResultModal(false);
+    setAnimationKey((prev) => prev + 1);
+    setAnimationPhase('shaking');
+
+    const attemptPromise = attemptGachapon();
+    attemptPromise.catch(() => {
+      // prevent unhandled rejection warnings; actual handling occurs below
+    });
+
+    queueTimeout(() => {
+      if (!isMountedRef.current) {
+        return;
+      }
+      setAnimationPhase('explosion');
+
+      queueTimeout(() => {
+        attemptPromise
+          .then((outcome) => {
+            if (!isMountedRef.current) {
+              return;
+            }
+            setResult(outcome);
+            setShowResultModal(true);
+            setAnimationPhase('result');
+          })
+          .catch(() => {
+            if (!isMountedRef.current) {
+              return;
+            }
+            setAttemptError('Something interrupted the gachapon attempt. Please try again.');
+            setAnimationPhase('idle');
+          })
+          .finally(() => {
+            if (!isMountedRef.current) {
+              return;
+            }
+            setIsAttempting(false);
+          });
+      }, EXPLOSION_DURATION);
+    }, SHAKE_DURATION);
+  };
+
+  const closeModal = () => {
+    setShowResultModal(false);
+    setAnimationPhase('idle');
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-950 py-10 text-white">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4">
+        <div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
+          <div>
+            <h1 className="text-3xl font-semibold text-white sm:text-4xl">Celestial Capsule Gachapon</h1>
+            <p className="mt-2 max-w-xl text-sm text-slate-300 sm:text-base">
+              Pull the lever to see what treasure is sealed within the capsule. Every attempt draws from the same
+              prize pool, and your luck determines the rarity of your reward.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <button
+              type="button"
+              className="rounded-full border border-slate-700 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:text-white"
+              onClick={() => navigate('/')}
+            >
+              Back to Store
+            </button>
+            <button
+              type="button"
+              onClick={handleAttempt}
+              disabled={isAttempting || loadingPrizes}
+              className="flex items-center justify-center rounded-full bg-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400 disabled:cursor-not-allowed disabled:bg-slate-600"
+            >
+              {isAttempting ? 'Dispensing…' : 'Start Gachapon'}
+            </button>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-6 lg:flex-row">
+          <div className="flex flex-1 flex-col gap-6 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-2xl shadow-indigo-900/30">
+            <h2 className="text-lg font-semibold text-white">Prize Showcase</h2>
+            {loadingPrizes ? (
+              <p className="text-sm text-slate-400">Loading prize lineup…</p>
+            ) : prizeError ? (
+              <p className="text-sm text-rose-300">{prizeError}</p>
+            ) : (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {prizes.map((prize) => (
+                  <PrizeCard
+                    key={prize.id}
+                    prize={prize}
+                    dropRate={formatDropRate(prize.weight ?? 0, totalWeight)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="gachapon-stage flex flex-1 items-center justify-center rounded-2xl border border-slate-800 bg-slate-900/60 p-6 text-center shadow-2xl shadow-indigo-900/30">
+            <div className="relative flex h-80 w-full flex-col items-center justify-center">
+              <div
+                className={`gachapon-box ${
+                  animationPhase === 'shaking' ? 'gachapon-box--shake' : ''
+                } ${animationPhase === 'explosion' ? 'gachapon-box--hidden' : ''}`}
+              >
+                <div
+                  className={`gachapon-capsule ${
+                    animationPhase === 'explosion' || animationPhase === 'result' ? 'gachapon-capsule--hidden' : ''
+                  }`}
+                  style={{ background: result?.prize?.capsuleColor ?? '#38bdf8' }}
+                />
+                <div className="absolute inset-x-8 bottom-6 rounded-full bg-slate-800/80 py-3 text-xs uppercase tracking-[0.3em] text-slate-400">
+                  {animationPhase === 'shaking'
+                    ? 'Shaking…'
+                    : animationPhase === 'explosion'
+                    ? 'Opening…'
+                    : animationPhase === 'result'
+                    ? 'Capsule opened!'
+                    : 'Ready'}
+                </div>
+              </div>
+              {animationPhase === 'explosion' && (
+                <div key={animationKey} className="gachapon-explosion" />
+              )}
+              {attemptError && (
+                <p className="mt-6 rounded-lg border border-rose-500/40 bg-rose-500/10 px-4 py-2 text-sm text-rose-200">
+                  {attemptError}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {showResultModal && result && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4 py-10 backdrop-blur">
+          <div className="w-full max-w-lg rounded-3xl border border-indigo-400/40 bg-slate-900/90 p-8 shadow-2xl shadow-indigo-900/50">
+            <p className="text-sm uppercase tracking-[0.25em] text-indigo-300">Gachapon Result</p>
+            <h3 className="mt-2 text-3xl font-semibold text-white">{result.prize.name}</h3>
+            <p className="mt-1 text-sm text-slate-400">{result.prize.rarityLabel}</p>
+            <div className="mt-5 flex items-center justify-center">
+              <div
+                className="gachapon-capsule-display"
+                style={{ background: result.prize.capsuleColor }}
+              />
+            </div>
+            <p className="mt-6 text-sm text-slate-300">{result.prize.description}</p>
+            <p className="mt-4 text-sm text-indigo-200">{result.flairText}</p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                className="rounded-full border border-slate-600 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-400 hover:text-white"
+                onClick={closeModal}
+              >
+                Try Again
+              </button>
+              <button
+                type="button"
+                className="rounded-full bg-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400"
+                onClick={() => navigate('/')}
+              >
+                Back to Store
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default GachaponGame;
+


### PR DESCRIPTION
## Summary
- add Celestial Capsule Gachapon game with mock API-driven animation flow and results modal
- create supporting styles and assets for gachapon stage and navigation
- expose new game via home navigation and routing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd7877c3f4832a8e823966a3ce5971