### PR TITLE
Add scratch card game

### DIFF
--- a/public/images/scratch-card-game-thumb.svg
+++ b/public/images/scratch-card-game-thumb.svg
@@ -1,0 +1,112 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" rx="64" fill="url(#paint0_radial)" />
+  <g filter="url(#filter0_d)">
+    <rect x="116" y="132" width="280" height="248" rx="36" fill="url(#paint1_linear)" />
+    <rect x="132" y="148" width="248" height="216" rx="28" fill="url(#paint2_linear)" />
+    <rect x="148" y="164" width="216" height="184" rx="22" fill="url(#paint3_linear)" />
+    <rect x="148" y="164" width="216" height="184" rx="22" fill="url(#paint4_radial)" opacity="0.35" />
+    <rect x="148" y="164" width="216" height="184" rx="22" stroke="url(#paint5_linear)" stroke-width="4" />
+    <path
+      d="M170 188H342"
+      stroke="url(#paint6_linear)"
+      stroke-width="18"
+      stroke-linecap="round"
+      opacity="0.9"
+    />
+    <path
+      d="M170 228H342"
+      stroke="url(#paint7_linear)"
+      stroke-width="18"
+      stroke-linecap="round"
+      opacity="0.72"
+    />
+    <path
+      d="M170 268H342"
+      stroke="url(#paint8_linear)"
+      stroke-width="18"
+      stroke-linecap="round"
+      opacity="0.6"
+    />
+    <rect x="184" y="308" width="144" height="28" rx="14" fill="url(#paint9_linear)" />
+    <path
+      d="M148 212C148 196.536 160.536 184 176 184H220"
+      stroke="url(#paint10_linear)"
+      stroke-width="24"
+      stroke-linecap="round"
+    />
+    <path
+      d="M364 348C364 363.464 351.464 376 336 376H292"
+      stroke="url(#paint11_linear)"
+      stroke-width="24"
+      stroke-linecap="round"
+    />
+  </g>
+  <defs>
+    <filter
+      id="filter0_d"
+      x="88"
+      y="112"
+      width="336"
+      height="304"
+      filterUnits="userSpaceOnUse"
+      color-interpolation-filters="sRGB"
+    >
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feOffset dy="18" />
+      <feGaussianBlur stdDeviation="18" />
+      <feComposite in2="SourceAlpha" operator="out" />
+      <feColorMatrix type="matrix" values="0 0 0 0 0.34 0 0 0 0 0.45 0 0 0 0 0.94 0 0 0 0.45 0" />
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow" />
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape" />
+    </filter>
+    <radialGradient id="paint0_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(110 96) rotate(43.5) scale(520)">
+      <stop stop-color="#1e3a8a" />
+      <stop offset="0.52" stop-color="#0f172a" />
+      <stop offset="1" stop-color="#020617" />
+    </radialGradient>
+    <linearGradient id="paint1_linear" x1="122" y1="140" x2="396" y2="372" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#312e81" />
+      <stop offset="1" stop-color="#1f2937" />
+    </linearGradient>
+    <linearGradient id="paint2_linear" x1="360" y1="148" x2="148" y2="364" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#6366f1" stop-opacity="0.65" />
+      <stop offset="1" stop-color="#1e3a8a" stop-opacity="0.9" />
+    </linearGradient>
+    <linearGradient id="paint3_linear" x1="148" y1="168" x2="364" y2="348" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#a5b4fc" stop-opacity="0.82" />
+      <stop offset="1" stop-color="#0f172a" stop-opacity="0.95" />
+    </linearGradient>
+    <radialGradient id="paint4_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(196 200) rotate(40) scale(220 160)">
+      <stop stop-color="#e0f2fe" />
+      <stop offset="1" stop-color="#22d3ee" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="paint5_linear" x1="148" y1="176" x2="364" y2="348" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#c7d2fe" stop-opacity="0.8" />
+      <stop offset="1" stop-color="#6366f1" stop-opacity="0.6" />
+    </linearGradient>
+    <linearGradient id="paint6_linear" x1="170" y1="188" x2="342" y2="188" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#f9fafb" stop-opacity="0.9" />
+      <stop offset="1" stop-color="#e0f2fe" stop-opacity="0.35" />
+    </linearGradient>
+    <linearGradient id="paint7_linear" x1="170" y1="228" x2="342" y2="228" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#e0e7ff" stop-opacity="0.85" />
+      <stop offset="1" stop-color="#a5b4fc" stop-opacity="0.55" />
+    </linearGradient>
+    <linearGradient id="paint8_linear" x1="170" y1="268" x2="342" y2="268" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#c7d2fe" stop-opacity="0.8" />
+      <stop offset="1" stop-color="#818cf8" stop-opacity="0.4" />
+    </linearGradient>
+    <linearGradient id="paint9_linear" x1="184" y1="322" x2="328" y2="322" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#6366f1" />
+      <stop offset="1" stop-color="#4338ca" />
+    </linearGradient>
+    <linearGradient id="paint10_linear" x1="148" y1="196" x2="220" y2="196" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#fef3c7" />
+      <stop offset="1" stop-color="#fde68a" stop-opacity="0" />
+    </linearGradient>
+    <linearGradient id="paint11_linear" x1="364" y1="360" x2="292" y2="360" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#e879f9" />
+      <stop offset="1" stop-color="#6366f1" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import StwGame from './games/stw-game/stw-game';
 import MysteryManorGame from './games/mystery-manor-game/mystery-manor-game';
 import PrecisionTimerGameInit from './games/precision-timer-game/precision-timer-game-init';
 import GachaponGame from './games/gachapon-game/gachapon-game';
+import ScratchCardGame from './games/scratch-card-game/scratch-card-game';
 
 function App() {
   return (
@@ -21,6 +22,7 @@ function App() {
               <Route path="/game3" element={<MysteryManorGame />} />
               <Route path="/game4" element={<PrecisionTimerGameInit />} />
               <Route path="/game5" element={<GachaponGame />} />
+              <Route path="/game6" element={<ScratchCardGame />} />
             </Routes>
           </div>
         </Router>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -8,7 +8,8 @@ jest.mock(
     BrowserRouter: ({ children }) => <div>{children}</div>,
     Route: ({ element }) => element,
     Routes: ({ children }) => <>{children}</>,
-    Link: ({ children, to }) => <a href={to}>{children}</a>
+    Link: ({ children, to }) => <a href={to}>{children}</a>,
+    useNavigate: () => jest.fn(),
   }),
   { virtual: true }
 );

--- a/src/components/home/home-nav.js
+++ b/src/components/home/home-nav.js
@@ -56,6 +56,16 @@ const HomeNav = () => {
             <p>Celestial Capsule Gachapon</p>
           </div>
         </Link>
+        <Link to="/game6">
+          <div className="flex flex-col items-center justify-center">
+            <img
+              src="/images/scratch-card-game-thumb.svg"
+              alt="Scratch Card Game Thumbnail"
+              className="h-48 w-48 rounded-md object-contain"
+            />
+            <p>Radiant Scratch Card</p>
+          </div>
+        </Link>
       </div>
     </div>
   );

--- a/src/games/scratch-card-game/scratch-card-api.js
+++ b/src/games/scratch-card-game/scratch-card-api.js
@@ -1,0 +1,103 @@
+const MOCK_SCRATCH_PRIZES = [
+  {
+    id: 'starlit-token',
+    name: 'Starlit Token',
+    rarity: 'common',
+    description: 'A token etched with constellations, good for a single campfire wish.',
+    weight: 45,
+  },
+  {
+    id: 'glimmer-thread',
+    name: 'Glimmer Thread',
+    rarity: 'uncommon',
+    description: 'Woven from comet tails, it reinforces any gear you stitch it into.',
+    weight: 30,
+  },
+  {
+    id: 'dawn-charm',
+    name: 'Charm of Dawn',
+    rarity: 'rare',
+    description: 'A radiant charm that greets every sunrise with a burst of optimism.',
+    weight: 18,
+  },
+  {
+    id: 'eclipse-crest',
+    name: 'Eclipse Crest',
+    rarity: 'epic',
+    description: 'A crest forged from shadow and light, empowering the bearer at dusk.',
+    weight: 6,
+  },
+  {
+    id: 'aurora-heart',
+    name: 'Aurora Heart',
+    rarity: 'legendary',
+    description: 'A prismatic core that pulses with the aurora\'s rhythm and courage.',
+    weight: 1,
+  },
+];
+
+const rarityFoilColors = {
+  common: '#CBD5F5',
+  uncommon: '#8DE6C9',
+  rare: '#95C6FF',
+  epic: '#D4B3FF',
+  legendary: '#FDE48A',
+};
+
+const rarityGlowColors = {
+  common: 'rgba(96, 165, 250, 0.4)',
+  uncommon: 'rgba(52, 211, 153, 0.45)',
+  rare: 'rgba(59, 130, 246, 0.55)',
+  epic: 'rgba(167, 139, 250, 0.55)',
+  legendary: 'rgba(251, 191, 36, 0.6)',
+};
+
+const rarityLabels = {
+  common: 'Common',
+  uncommon: 'Uncommon',
+  rare: 'Rare',
+  epic: 'Epic',
+  legendary: 'Legendary',
+};
+
+const mapPrizeForResponse = (prize) => ({
+  ...prize,
+  rarityLabel: rarityLabels[prize.rarity] ?? prize.rarity,
+  foilColor: rarityFoilColors[prize.rarity] ?? '#E0E7FF',
+  glowColor: rarityGlowColors[prize.rarity] ?? 'rgba(96, 165, 250, 0.35)',
+});
+
+export const fetchScratchPrizes = () =>
+  new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(MOCK_SCRATCH_PRIZES.map(mapPrizeForResponse));
+    }, 650);
+  });
+
+const pickWeightedPrize = () => {
+  const totalWeight = MOCK_SCRATCH_PRIZES.reduce((sum, prize) => sum + prize.weight, 0);
+  let threshold = Math.random() * totalWeight;
+
+  for (const prize of MOCK_SCRATCH_PRIZES) {
+    threshold -= prize.weight;
+    if (threshold <= 0) {
+      return prize;
+    }
+  }
+
+  return MOCK_SCRATCH_PRIZES[MOCK_SCRATCH_PRIZES.length - 1];
+};
+
+export const attemptScratchCard = () =>
+  new Promise((resolve) => {
+    const selectedPrize = pickWeightedPrize();
+
+    setTimeout(() => {
+      resolve({
+        attemptId: `scratch-${Date.now()}`,
+        prize: mapPrizeForResponse(selectedPrize),
+        flairText: 'The foil peels away and the prize gleams brilliantly! ✨',
+        awardedAt: new Date().toISOString(),
+      });
+    }, 1150);
+  });

--- a/src/games/scratch-card-game/scratch-card-game.css
+++ b/src/games/scratch-card-game/scratch-card-game.css
@@ -1,0 +1,332 @@
+.scratch-card-stage {
+  perspective: 1100px;
+}
+
+.scratch-card-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+}
+
+.scratch-card {
+  position: relative;
+  width: 280px;
+  height: 200px;
+  border-radius: 28px;
+  padding: 14px;
+  background: linear-gradient(140deg, rgba(30, 64, 175, 0.35), rgba(59, 7, 100, 0.5));
+  box-shadow: 0 22px 46px rgba(15, 23, 42, 0.55);
+  transform-style: preserve-3d;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.scratch-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(226, 232, 240, 0.12), rgba(14, 165, 233, 0));
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+.scratch-card--scratching {
+  animation: scratch-card-wiggle 0.12s ease-in-out infinite;
+}
+
+.scratch-card--revealed {
+  box-shadow: 0 28px 60px rgba(165, 180, 252, 0.45);
+  transform: translateY(-4px) scale(1.015);
+}
+
+@keyframes scratch-card-wiggle {
+  0% {
+    transform: rotate(0deg) translate3d(0, 0, 0);
+  }
+  25% {
+    transform: rotate(-1.5deg) translate3d(-5px, 2px, 0);
+  }
+  50% {
+    transform: rotate(1.4deg) translate3d(4px, -3px, 0);
+  }
+  75% {
+    transform: rotate(-1deg) translate3d(-3px, -2px, 0);
+  }
+  100% {
+    transform: rotate(0deg) translate3d(0, 0, 0);
+  }
+}
+
+.scratch-card__inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 22px;
+  overflow: hidden;
+  background: linear-gradient(160deg, rgba(30, 41, 59, 0.8), rgba(15, 23, 42, 0.95));
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+}
+
+.scratch-card__reward {
+  position: absolute;
+  inset: 10px;
+  border-radius: 18px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: #e2e8f0;
+  padding: 24px;
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.4), rgba(51, 65, 85, 0.95));
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.45);
+  opacity: 0.35;
+  transform: scale(0.96);
+  transition: opacity 0.45s ease, transform 0.45s ease, box-shadow 0.45s ease;
+}
+
+.scratch-card--revealed .scratch-card__reward {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.scratch-card__reward-glow {
+  position: absolute;
+  inset: -30%;
+  border-radius: inherit;
+  background: radial-gradient(circle, rgba(56, 189, 248, 0.35) 0%, rgba(15, 23, 42, 0) 75%);
+  filter: blur(20px);
+  opacity: 0;
+  transition: opacity 0.45s ease;
+}
+
+.scratch-card--revealed .scratch-card__reward-glow {
+  opacity: 1;
+}
+
+.scratch-card__reward-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.scratch-card__reward-rarity {
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.scratch-card__reward-name {
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.scratch-card__cover {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  overflow: hidden;
+  background: linear-gradient(140deg, rgba(100, 116, 139, 0.85), rgba(71, 85, 105, 0.95));
+  box-shadow: inset 0 0 0 1px rgba(226, 232, 240, 0.08);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+  z-index: 3;
+}
+
+.scratch-card__cover-texture {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0) 60%),
+    radial-gradient(circle at 70% 70%, rgba(148, 163, 184, 0.15), rgba(15, 23, 42, 0) 65%);
+  mix-blend-mode: soft-light;
+  opacity: 0.7;
+}
+
+.scratch-card__cover::before {
+  content: '';
+  position: absolute;
+  inset: -60% -40% -30% -40%;
+  background-image: linear-gradient(130deg, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0));
+  mix-blend-mode: screen;
+  opacity: 0.55;
+}
+
+.scratch-card__cover::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: repeating-linear-gradient(
+      0deg,
+      rgba(15, 23, 42, 0.4) 0px,
+      rgba(15, 23, 42, 0.4) 6px,
+      rgba(30, 41, 59, 0.45) 6px,
+      rgba(30, 41, 59, 0.45) 12px
+    );
+  mix-blend-mode: overlay;
+  opacity: 0.45;
+}
+
+.scratch-card__cover--scratching {
+  animation: scratch-card-cover-shimmer 0.7s ease-in-out infinite;
+}
+
+@keyframes scratch-card-cover-shimmer {
+  0% {
+    filter: brightness(1);
+  }
+  50% {
+    filter: brightness(1.25);
+  }
+  100% {
+    filter: brightness(1);
+  }
+}
+
+.scratch-card__cover--cleared {
+  animation: scratch-card-peel 0.7s forwards ease-out;
+}
+
+@keyframes scratch-card-peel {
+  0% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  50% {
+    opacity: 0.55;
+    transform: translateY(10px) scale(0.98);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(24px) scale(0.94);
+  }
+}
+
+.scratch-card__strokes {
+  position: absolute;
+  inset: 0;
+  mix-blend-mode: screen;
+  opacity: 0.75;
+}
+
+.scratch-card__stroke {
+  position: absolute;
+  width: 140%;
+  height: 28px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.75) 45%, rgba(255, 255, 255, 0) 100%);
+  filter: blur(3px);
+  animation-duration: 0.9s;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+}
+
+.scratch-card__stroke--one {
+  top: 25%;
+  left: -20%;
+  transform: rotate(-12deg);
+  animation-name: scratch-card-stroke-one;
+}
+
+.scratch-card__stroke--two {
+  top: 50%;
+  left: -25%;
+  transform: rotate(8deg);
+  animation-name: scratch-card-stroke-two;
+}
+
+.scratch-card__stroke--three {
+  top: 72%;
+  left: -15%;
+  transform: rotate(-6deg);
+  animation-name: scratch-card-stroke-three;
+}
+
+@keyframes scratch-card-stroke-one {
+  0% {
+    transform: translateX(0) rotate(-12deg);
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  70% {
+    transform: translateX(65%) rotate(-12deg);
+    opacity: 0.85;
+  }
+  100% {
+    transform: translateX(120%) rotate(-12deg);
+    opacity: 0;
+  }
+}
+
+@keyframes scratch-card-stroke-two {
+  0% {
+    transform: translateX(0) rotate(8deg);
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  70% {
+    transform: translateX(70%) rotate(8deg);
+    opacity: 0.85;
+  }
+  100% {
+    transform: translateX(120%) rotate(8deg);
+    opacity: 0;
+  }
+}
+
+@keyframes scratch-card-stroke-three {
+  0% {
+    transform: translateX(0) rotate(-6deg);
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  70% {
+    transform: translateX(70%) rotate(-6deg);
+    opacity: 0.85;
+  }
+  100% {
+    transform: translateX(120%) rotate(-6deg);
+    opacity: 0;
+  }
+}
+
+.scratch-card__status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(129, 140, 248, 0.35);
+  background: rgba(30, 41, 59, 0.85);
+  font-size: 0.7rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.75);
+  backdrop-filter: blur(8px);
+}
+
+.scratch-card-error {
+  margin-top: 24px;
+  padding: 10px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  background: rgba(248, 113, 113, 0.1);
+  color: #fecdd3;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 640px) {
+  .scratch-card {
+    width: 100%;
+    max-width: 320px;
+  }
+}

--- a/src/games/scratch-card-game/scratch-card-game.js
+++ b/src/games/scratch-card-game/scratch-card-game.js
@@ -1,0 +1,358 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { attemptScratchCard, fetchScratchPrizes } from './scratch-card-api';
+import './scratch-card-game.css';
+
+const SCRATCH_DURATION = 1300;
+const REVEAL_DURATION = 700;
+
+const rarityAccentClasses = {
+  common: 'border-gray-300 text-gray-200',
+  uncommon: 'border-emerald-300 text-emerald-200',
+  rare: 'border-sky-300 text-sky-200',
+  epic: 'border-violet-300 text-violet-200',
+  legendary: 'border-amber-200 text-amber-100',
+};
+
+const rarityBackground = {
+  common: 'bg-slate-800/40',
+  uncommon: 'bg-emerald-500/10',
+  rare: 'bg-sky-500/10',
+  epic: 'bg-violet-500/10',
+  legendary: 'bg-amber-500/10',
+};
+
+const formatDropRate = (weight, totalWeight) => {
+  if (!totalWeight) {
+    return '—';
+  }
+
+  const percentage = (weight / totalWeight) * 100;
+  if (percentage < 0.1) {
+    return '<0.1%';
+  }
+
+  return `${percentage.toFixed(1)}%`;
+};
+
+const PrizeCard = ({ prize, dropRate }) => {
+  const accentClass = rarityAccentClasses[prize.rarity] ?? 'border-slate-500 text-slate-200';
+  const backgroundClass = rarityBackground[prize.rarity] ?? 'bg-slate-800/40';
+
+  return (
+    <div
+      className={`flex h-full flex-col justify-between rounded-xl border ${accentClass} ${backgroundClass} p-4 shadow-lg shadow-slate-900/30`}
+    >
+      <div>
+        <p className="text-sm uppercase tracking-wide text-slate-400">{prize.rarityLabel}</p>
+        <h3 className="mt-1 text-xl font-semibold text-white">{prize.name}</h3>
+        <p className="mt-2 text-sm text-slate-300">{prize.description}</p>
+      </div>
+      <div className="mt-4 flex items-center justify-between text-sm text-slate-400">
+        <span>Drop Rate</span>
+        <span className="font-semibold text-slate-100">{dropRate}</span>
+      </div>
+    </div>
+  );
+};
+
+const ScratchCardGame = () => {
+  const navigate = useNavigate();
+  const [prizes, setPrizes] = useState([]);
+  const [loadingPrizes, setLoadingPrizes] = useState(true);
+  const [prizeError, setPrizeError] = useState(null);
+  const [isAttempting, setIsAttempting] = useState(false);
+  const [animationPhase, setAnimationPhase] = useState('idle');
+  const [result, setResult] = useState(null);
+  const [showResultModal, setShowResultModal] = useState(false);
+  const [attemptError, setAttemptError] = useState(null);
+  const [animationKey, setAnimationKey] = useState(0);
+
+  const timeoutsRef = useRef([]);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+      timeoutsRef.current.forEach(clearTimeout);
+      timeoutsRef.current = [];
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadingPrizes(true);
+    setPrizeError(null);
+
+    fetchScratchPrizes()
+      .then((availablePrizes) => {
+        if (cancelled || !isMountedRef.current) {
+          return;
+        }
+        setPrizes(availablePrizes);
+      })
+      .catch(() => {
+        if (cancelled || !isMountedRef.current) {
+          return;
+        }
+        setPrizeError('We could not load the prize ledger. Please refresh to try again.');
+      })
+      .finally(() => {
+        if (cancelled || !isMountedRef.current) {
+          return;
+        }
+        setLoadingPrizes(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const totalWeight = useMemo(() => prizes.reduce((sum, prize) => sum + (prize.weight ?? 0), 0), [prizes]);
+
+  const queueTimeout = (callback, delay) => {
+    const timeoutId = setTimeout(callback, delay);
+    timeoutsRef.current.push(timeoutId);
+    return timeoutId;
+  };
+
+  const handleAttempt = () => {
+    if (isAttempting || loadingPrizes) {
+      return;
+    }
+
+    timeoutsRef.current.forEach(clearTimeout);
+    timeoutsRef.current = [];
+
+    setIsAttempting(true);
+    setAttemptError(null);
+    setResult(null);
+    setShowResultModal(false);
+    setAnimationKey((prev) => prev + 1);
+    setAnimationPhase('scratching');
+
+    const attemptPromise = attemptScratchCard();
+    attemptPromise.catch(() => {
+      // prevent unhandled rejection warnings; actual handling occurs below
+    });
+
+    queueTimeout(() => {
+      if (!isMountedRef.current) {
+        return;
+      }
+      setAnimationPhase('reveal');
+
+      queueTimeout(() => {
+        attemptPromise
+          .then((outcome) => {
+            if (!isMountedRef.current) {
+              return;
+            }
+            setResult(outcome);
+            setShowResultModal(true);
+            setAnimationPhase('result');
+          })
+          .catch(() => {
+            if (!isMountedRef.current) {
+              return;
+            }
+            setAttemptError('Something interrupted the scratch card attempt. Please try again.');
+            setAnimationPhase('idle');
+          })
+          .finally(() => {
+            if (!isMountedRef.current) {
+              return;
+            }
+            setIsAttempting(false);
+          });
+      }, REVEAL_DURATION);
+    }, SCRATCH_DURATION);
+  };
+
+  const closeModal = () => {
+    setShowResultModal(false);
+    setAnimationPhase('idle');
+  };
+
+  const hasRevealed =
+    animationPhase === 'reveal' || animationPhase === 'result' || (!!result && animationPhase === 'idle');
+
+  const cardClassName = [
+    'scratch-card',
+    animationPhase === 'scratching' ? 'scratch-card--scratching' : '',
+    hasRevealed ? 'scratch-card--revealed' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const coverClassName = [
+    'scratch-card__cover',
+    animationPhase === 'scratching' ? 'scratch-card__cover--scratching' : '',
+    hasRevealed ? 'scratch-card__cover--cleared' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const rewardStyle = {
+    background: hasRevealed && result
+      ? `linear-gradient(135deg, ${result.prize.foilColor}, rgba(15, 23, 42, 0.92))`
+      : 'linear-gradient(135deg, rgba(148, 163, 184, 0.4), rgba(51, 65, 85, 0.95))',
+    boxShadow: hasRevealed && result
+      ? `0 18px 45px ${result.prize.glowColor}`
+      : '0 14px 30px rgba(15, 23, 42, 0.45)',
+  };
+
+  const glowStyle = {
+    background: hasRevealed && result
+      ? `radial-gradient(circle, ${result.prize.glowColor} 0%, rgba(15, 23, 42, 0) 75%)`
+      : 'radial-gradient(circle, rgba(56, 189, 248, 0.35) 0%, rgba(15, 23, 42, 0) 75%)',
+  };
+
+  const statusText = (() => {
+    if (animationPhase === 'scratching') {
+      return 'Scratching…';
+    }
+    if (animationPhase === 'reveal') {
+      return 'Foil clearing…';
+    }
+    if (animationPhase === 'result') {
+      return 'Prize revealed!';
+    }
+    if (result) {
+      return 'Prize ready';
+    }
+    return 'Ready to scratch';
+  })();
+
+  return (
+    <div className="min-h-screen bg-slate-950 py-10 text-white">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4">
+        <div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
+          <div>
+            <h1 className="text-3xl font-semibold text-white sm:text-4xl">Radiant Foil Scratch Card</h1>
+            <p className="mt-2 max-w-xl text-sm text-slate-300 sm:text-base">
+              Reveal shimmering loot by peeling back the foil. The same prize pool fuels every scratch, so luck and
+              persistence shape the gleam you uncover.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <button
+              type="button"
+              className="rounded-full border border-slate-700 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:text-white"
+              onClick={() => navigate('/')}
+            >
+              Back to Store
+            </button>
+            <button
+              type="button"
+              onClick={handleAttempt}
+              disabled={isAttempting || loadingPrizes}
+              className="flex items-center justify-center rounded-full bg-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400 disabled:cursor-not-allowed disabled:bg-slate-600"
+            >
+              {isAttempting ? 'Scratching…' : 'Scratch Now'}
+            </button>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-6 lg:flex-row">
+          <div className="flex flex-1 flex-col gap-6 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-2xl shadow-indigo-900/30">
+            <h2 className="text-lg font-semibold text-white">Prize Ledger</h2>
+            {loadingPrizes ? (
+              <p className="text-sm text-slate-400">Loading scratch card lineup…</p>
+            ) : prizeError ? (
+              <p className="text-sm text-rose-300">{prizeError}</p>
+            ) : (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {prizes.map((prize) => (
+                  <PrizeCard
+                    key={prize.id}
+                    prize={prize}
+                    dropRate={formatDropRate(prize.weight ?? 0, totalWeight)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="scratch-card-stage flex flex-1 items-center justify-center rounded-2xl border border-slate-800 bg-slate-900/60 p-6 text-center shadow-2xl shadow-indigo-900/30">
+            <div className="scratch-card-container">
+              <div className={cardClassName}>
+                <div className="scratch-card__inner">
+                  <div className="scratch-card__reward" style={rewardStyle}>
+                    <div className="scratch-card__reward-glow" style={glowStyle} />
+                    <div className="scratch-card__reward-content">
+                      <p className="scratch-card__reward-rarity">
+                        {result ? result.prize.rarityLabel : 'Mystery Reward'}
+                      </p>
+                      <h3 className="scratch-card__reward-name">
+                        {result ? result.prize.name : 'Scratch to reveal'}
+                      </h3>
+                    </div>
+                  </div>
+                  <div key={animationKey} className={coverClassName}>
+                    <div className="scratch-card__cover-texture" />
+                    {animationPhase === 'scratching' && (
+                      <div className="scratch-card__strokes">
+                        <span className="scratch-card__stroke scratch-card__stroke--one" />
+                        <span className="scratch-card__stroke scratch-card__stroke--two" />
+                        <span className="scratch-card__stroke scratch-card__stroke--three" />
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+              <div className="scratch-card__status-badge">{statusText}</div>
+              {attemptError && <div className="scratch-card-error">{attemptError}</div>}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {showResultModal && result && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4 py-10 backdrop-blur">
+          <div className="w-full max-w-lg rounded-3xl border border-indigo-400/40 bg-slate-900/90 p-8 shadow-2xl shadow-indigo-900/50">
+            <p className="text-sm uppercase tracking-[0.25em] text-indigo-300">Scratch Card Result</p>
+            <h3 className="mt-2 text-3xl font-semibold text-white">{result.prize.name}</h3>
+            <p className="mt-1 text-sm text-slate-400">{result.prize.rarityLabel}</p>
+            <div className="mt-5 flex items-center justify-center">
+              <div
+                className="h-28 w-44 rounded-2xl border border-indigo-400/30 bg-gradient-to-br from-slate-700 via-indigo-500/60 to-slate-900 shadow-[0_18px_40px_rgba(79,70,229,0.35)]"
+                style={{ boxShadow: `0 18px 40px ${result.prize.glowColor}` }}
+              >
+                <div
+                  className="h-full w-full rounded-2xl"
+                  style={{
+                    background: `linear-gradient(135deg, ${result.prize.foilColor}, rgba(15, 23, 42, 0.92))`,
+                  }}
+                />
+              </div>
+            </div>
+            <p className="mt-6 text-sm text-slate-300">{result.prize.description}</p>
+            <p className="mt-4 text-sm text-indigo-200">{result.flairText}</p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                className="rounded-full border border-slate-600 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-400 hover:text-white"
+                onClick={closeModal}
+              >
+                Scratch Again
+              </button>
+              <button
+                type="button"
+                className="rounded-full bg-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400"
+                onClick={() => navigate('/')}
+              >
+                Back to Store
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ScratchCardGame;


### PR DESCRIPTION
## Summary
- add a radiant scratch card experience that mirrors the gachapon flow with weighted prizes and animated reveal
- expose the new game in the navigation with supporting styling assets and thumbnail art
- update the router mock in tests to handle navigation hooks used by gachapon-style games

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cd7b1ca3cc832aa836236b2428f49a