### PR TITLE
Make scratch card interactive and refresh styling

### DIFF
--- a/src/games/scratch-card-game/scratch-card-game.css
+++ b/src/games/scratch-card-game/scratch-card-game.css
@@ -1,24 +1,26 @@
+
 .scratch-card-stage {
-  perspective: 1100px;
+  perspective: 1200px;
+  position: relative;
 }
 
 .scratch-card-container {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 18px;
+  gap: 28px;
 }
 
 .scratch-card {
   position: relative;
-  width: 280px;
-  height: 200px;
+  width: 320px;
+  height: 220px;
   border-radius: 28px;
-  padding: 14px;
-  background: linear-gradient(140deg, rgba(30, 64, 175, 0.35), rgba(59, 7, 100, 0.5));
-  box-shadow: 0 22px 46px rgba(15, 23, 42, 0.55);
+  padding: 16px;
+  background: linear-gradient(150deg, rgba(79, 70, 229, 0.32), rgba(236, 72, 153, 0.28));
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.6);
   transform-style: preserve-3d;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
 }
 
 .scratch-card::before {
@@ -26,18 +28,18 @@
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: linear-gradient(135deg, rgba(226, 232, 240, 0.12), rgba(14, 165, 233, 0));
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.18), rgba(125, 211, 252, 0));
   mix-blend-mode: screen;
   pointer-events: none;
 }
 
 .scratch-card--scratching {
-  animation: scratch-card-wiggle 0.12s ease-in-out infinite;
+  animation: scratch-card-wiggle 0.18s ease-in-out infinite;
 }
 
 .scratch-card--revealed {
-  box-shadow: 0 28px 60px rgba(165, 180, 252, 0.45);
-  transform: translateY(-4px) scale(1.015);
+  transform: translateY(-4px) scale(1.03);
+  box-shadow: 0 36px 80px rgba(129, 140, 248, 0.5);
 }
 
 @keyframes scratch-card-wiggle {
@@ -45,13 +47,13 @@
     transform: rotate(0deg) translate3d(0, 0, 0);
   }
   25% {
-    transform: rotate(-1.5deg) translate3d(-5px, 2px, 0);
+    transform: rotate(-1.6deg) translate3d(-5px, 2px, 0);
   }
   50% {
-    transform: rotate(1.4deg) translate3d(4px, -3px, 0);
+    transform: rotate(1.6deg) translate3d(4px, -3px, 0);
   }
   75% {
-    transform: rotate(-1deg) translate3d(-3px, -2px, 0);
+    transform: rotate(-1.2deg) translate3d(-3px, -2px, 0);
   }
   100% {
     transform: rotate(0deg) translate3d(0, 0, 0);
@@ -64,13 +66,13 @@
   height: 100%;
   border-radius: 22px;
   overflow: hidden;
-  background: linear-gradient(160deg, rgba(30, 41, 59, 0.8), rgba(15, 23, 42, 0.95));
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.85));
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
 }
 
 .scratch-card__reward {
   position: absolute;
-  inset: 10px;
+  inset: 12px;
   border-radius: 18px;
   display: flex;
   flex-direction: column;
@@ -79,9 +81,9 @@
   text-align: center;
   color: #e2e8f0;
   padding: 24px;
-  background: linear-gradient(135deg, rgba(148, 163, 184, 0.4), rgba(51, 65, 85, 0.95));
-  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.45);
-  opacity: 0.35;
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.35), rgba(51, 65, 85, 0.92));
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.5);
+  opacity: 0.4;
   transform: scale(0.96);
   transition: opacity 0.45s ease, transform 0.45s ease, box-shadow 0.45s ease;
 }
@@ -93,10 +95,10 @@
 
 .scratch-card__reward-glow {
   position: absolute;
-  inset: -30%;
+  inset: -35%;
   border-radius: inherit;
-  background: radial-gradient(circle, rgba(56, 189, 248, 0.35) 0%, rgba(15, 23, 42, 0) 75%);
-  filter: blur(20px);
+  background: radial-gradient(circle, rgba(129, 140, 248, 0.45) 0%, rgba(15, 23, 42, 0) 75%);
+  filter: blur(26px);
   opacity: 0;
   transition: opacity 0.45s ease;
 }
@@ -110,223 +112,230 @@
   z-index: 1;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 
 .scratch-card__reward-rarity {
-  font-size: 0.75rem;
-  letter-spacing: 0.28em;
+  font-size: 0.74rem;
+  letter-spacing: 0.32em;
   text-transform: uppercase;
   color: rgba(226, 232, 240, 0.7);
 }
 
 .scratch-card__reward-name {
-  font-size: 1.35rem;
+  font-size: 1.25rem;
   font-weight: 600;
+  letter-spacing: 0.06em;
   color: #f8fafc;
 }
 
-.scratch-card__cover {
+.scratch-card__reward-helper {
+  font-size: 0.75rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.55);
+}
+
+.scratch-card__foil {
   position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  pointer-events: none;
+  inset: 12px;
+  border-radius: 18px;
   overflow: hidden;
-  background: linear-gradient(140deg, rgba(100, 116, 139, 0.85), rgba(71, 85, 105, 0.95));
-  box-shadow: inset 0 0 0 1px rgba(226, 232, 240, 0.08);
-  transition: opacity 0.5s ease, transform 0.5s ease;
-  z-index: 3;
+  transition: opacity 0.45s ease, transform 0.45s ease;
 }
 
-.scratch-card__cover-texture {
+.scratch-card__foil--interactive {
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.scratch-card__foil--cleared {
+  opacity: 0;
+  transform: scale(1.03);
+  pointer-events: none;
+}
+
+.scratch-card__foil-canvas {
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0) 60%),
-    radial-gradient(circle at 70% 70%, rgba(148, 163, 184, 0.15), rgba(15, 23, 42, 0) 65%);
-  mix-blend-mode: soft-light;
-  opacity: 0.7;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  cursor: crosshair;
+  touch-action: none;
+  transition: opacity 0.4s ease;
 }
 
-.scratch-card__cover::before {
-  content: '';
+.scratch-card__foil-canvas--inactive {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.scratch-card__foil-canvas--cleared {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.scratch-card__foil-noise {
   position: absolute;
-  inset: -60% -40% -30% -40%;
-  background-image: linear-gradient(130deg, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0));
+  inset: -25%;
+  background: conic-gradient(
+    from 0deg,
+    rgba(255, 255, 255, 0.22),
+    rgba(79, 70, 229, 0.25),
+    rgba(236, 72, 153, 0.22),
+    rgba(255, 255, 255, 0.22)
+  );
   mix-blend-mode: screen;
   opacity: 0.55;
+  animation: scratch-card-foil-spin 7s linear infinite;
+  pointer-events: none;
 }
 
-.scratch-card__cover::after {
-  content: '';
+.scratch-card__foil-shine {
+  position: absolute;
+  inset: -35%;
+  background: radial-gradient(circle at 20% -10%, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0));
+  opacity: 0.7;
+  animation: scratch-card-foil-shimmer 4.5s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.scratch-card__foil-message {
   position: absolute;
   inset: 0;
-  background-image: repeating-linear-gradient(
-      0deg,
-      rgba(15, 23, 42, 0.4) 0px,
-      rgba(15, 23, 42, 0.4) 6px,
-      rgba(30, 41, 59, 0.45) 6px,
-      rgba(30, 41, 59, 0.45) 12px
-    );
-  mix-blend-mode: overlay;
-  opacity: 0.45;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 0 24px;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-size: 0.7rem;
+  color: rgba(226, 232, 240, 0.85);
+  backdrop-filter: blur(0px);
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  pointer-events: none;
 }
 
-.scratch-card__cover--scratching {
-  animation: scratch-card-cover-shimmer 0.7s ease-in-out infinite;
+.scratch-card__foil-message--visible {
+  opacity: 1;
+  transform: translateY(0);
 }
 
-@keyframes scratch-card-cover-shimmer {
-  0% {
-    filter: brightness(1);
+.scratch-card__foil-detail {
+  font-size: 0.66rem;
+  letter-spacing: 0.25em;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+@keyframes scratch-card-foil-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes scratch-card-foil-shimmer {
+  0%,
+  100% {
+    opacity: 0.65;
+    transform: translateX(-10%);
   }
   50% {
-    filter: brightness(1.25);
-  }
-  100% {
-    filter: brightness(1);
-  }
-}
-
-.scratch-card__cover--cleared {
-  animation: scratch-card-peel 0.7s forwards ease-out;
-}
-
-@keyframes scratch-card-peel {
-  0% {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-  50% {
-    opacity: 0.55;
-    transform: translateY(10px) scale(0.98);
-  }
-  100% {
-    opacity: 0;
-    transform: translateY(24px) scale(0.94);
-  }
-}
-
-.scratch-card__strokes {
-  position: absolute;
-  inset: 0;
-  mix-blend-mode: screen;
-  opacity: 0.75;
-}
-
-.scratch-card__stroke {
-  position: absolute;
-  width: 140%;
-  height: 28px;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.75) 45%, rgba(255, 255, 255, 0) 100%);
-  filter: blur(3px);
-  animation-duration: 0.9s;
-  animation-timing-function: ease-in-out;
-  animation-iteration-count: infinite;
-}
-
-.scratch-card__stroke--one {
-  top: 25%;
-  left: -20%;
-  transform: rotate(-12deg);
-  animation-name: scratch-card-stroke-one;
-}
-
-.scratch-card__stroke--two {
-  top: 50%;
-  left: -25%;
-  transform: rotate(8deg);
-  animation-name: scratch-card-stroke-two;
-}
-
-.scratch-card__stroke--three {
-  top: 72%;
-  left: -15%;
-  transform: rotate(-6deg);
-  animation-name: scratch-card-stroke-three;
-}
-
-@keyframes scratch-card-stroke-one {
-  0% {
-    transform: translateX(0) rotate(-12deg);
-    opacity: 0;
-  }
-  20% {
-    opacity: 1;
-  }
-  70% {
-    transform: translateX(65%) rotate(-12deg);
     opacity: 0.85;
-  }
-  100% {
-    transform: translateX(120%) rotate(-12deg);
-    opacity: 0;
+    transform: translateX(10%);
   }
 }
 
-@keyframes scratch-card-stroke-two {
-  0% {
-    transform: translateX(0) rotate(8deg);
-    opacity: 0;
-  }
-  20% {
-    opacity: 1;
-  }
-  70% {
-    transform: translateX(70%) rotate(8deg);
-    opacity: 0.85;
-  }
-  100% {
-    transform: translateX(120%) rotate(8deg);
-    opacity: 0;
-  }
-}
-
-@keyframes scratch-card-stroke-three {
-  0% {
-    transform: translateX(0) rotate(-6deg);
-    opacity: 0;
-  }
-  20% {
-    opacity: 1;
-  }
-  70% {
-    transform: translateX(70%) rotate(-6deg);
-    opacity: 0.85;
-  }
-  100% {
-    transform: translateX(120%) rotate(-6deg);
-    opacity: 0;
-  }
+.scratch-card__status-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
 }
 
 .scratch-card__status-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 8px 18px;
+  padding: 10px 22px;
   border-radius: 999px;
-  border: 1px solid rgba(129, 140, 248, 0.35);
-  background: rgba(30, 41, 59, 0.85);
+  border: 1px solid rgba(129, 140, 248, 0.45);
+  background: linear-gradient(120deg, rgba(30, 41, 59, 0.9), rgba(99, 102, 241, 0.2));
   font-size: 0.7rem;
   letter-spacing: 0.28em;
   text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.75);
-  backdrop-filter: blur(8px);
+  color: rgba(226, 232, 240, 0.78);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.35);
+}
+
+.scratch-card__progress {
+  width: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+}
+
+.scratch-card__progress-track {
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(30, 41, 59, 0.9);
+  border: 1px solid rgba(129, 140, 248, 0.3);
+  overflow: hidden;
+}
+
+.scratch-card__progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #ec4899, #6366f1, #38bdf8);
+  border-radius: inherit;
+  transition: width 0.3s ease;
+}
+
+.scratch-card__progress-label {
+  font-size: 0.65rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.scratch-card__status-detail {
+  font-size: 0.85rem;
+  color: rgba(244, 211, 255, 0.8);
+  letter-spacing: 0.05em;
+}
+
+.scratch-card__status-detail span {
+  color: #f472b6;
+  font-weight: 600;
 }
 
 .scratch-card-error {
-  margin-top: 24px;
   padding: 10px 16px;
   border-radius: 14px;
-  border: 1px solid rgba(248, 113, 113, 0.45);
-  background: rgba(248, 113, 113, 0.1);
+  border: 1px solid rgba(248, 113, 113, 0.5);
+  background: rgba(248, 113, 113, 0.12);
   color: #fecdd3;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
+  line-height: 1.4;
 }
 
 @media (max-width: 640px) {
   .scratch-card {
     width: 100%;
     max-width: 320px;
+  }
+
+  .scratch-card__progress {
+    width: 100%;
   }
 }

--- a/src/games/scratch-card-game/scratch-card-game.js
+++ b/src/games/scratch-card-game/scratch-card-game.js
@@ -1,25 +1,27 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { attemptScratchCard, fetchScratchPrizes } from './scratch-card-api';
 import './scratch-card-game.css';
 
-const SCRATCH_DURATION = 1300;
-const REVEAL_DURATION = 700;
+const SCRATCH_CELL_SIZE = 32;
+const SCRATCH_RADIUS = 28;
+const REVEAL_THRESHOLD = 0.6;
 
 const rarityAccentClasses = {
-  common: 'border-gray-300 text-gray-200',
-  uncommon: 'border-emerald-300 text-emerald-200',
-  rare: 'border-sky-300 text-sky-200',
-  epic: 'border-violet-300 text-violet-200',
-  legendary: 'border-amber-200 text-amber-100',
+  common: 'border-slate-500/70 text-slate-100',
+  uncommon: 'border-emerald-400/70 text-emerald-100',
+  rare: 'border-sky-400/70 text-sky-100',
+  epic: 'border-violet-400/70 text-violet-100',
+  legendary: 'border-amber-300/80 text-amber-100',
 };
 
 const rarityBackground = {
-  common: 'bg-slate-800/40',
-  uncommon: 'bg-emerald-500/10',
-  rare: 'bg-sky-500/10',
-  epic: 'bg-violet-500/10',
-  legendary: 'bg-amber-500/10',
+  common: 'bg-slate-900/60',
+  uncommon: 'bg-emerald-500/15',
+  rare: 'bg-sky-500/15',
+  epic: 'bg-violet-500/15',
+  legendary: 'bg-amber-500/20',
 };
 
 const formatDropRate = (weight, totalWeight) => {
@@ -36,21 +38,21 @@ const formatDropRate = (weight, totalWeight) => {
 };
 
 const PrizeCard = ({ prize, dropRate }) => {
-  const accentClass = rarityAccentClasses[prize.rarity] ?? 'border-slate-500 text-slate-200';
-  const backgroundClass = rarityBackground[prize.rarity] ?? 'bg-slate-800/40';
+  const accentClass = rarityAccentClasses[prize.rarity] ?? 'border-slate-500/60 text-slate-200';
+  const backgroundClass = rarityBackground[prize.rarity] ?? 'bg-slate-900/60';
 
   return (
     <div
-      className={`flex h-full flex-col justify-between rounded-xl border ${accentClass} ${backgroundClass} p-4 shadow-lg shadow-slate-900/30`}
+      className={`flex h-full flex-col justify-between rounded-2xl border ${accentClass} ${backgroundClass} p-5 shadow-lg shadow-slate-950/40 backdrop-blur`}
     >
       <div>
-        <p className="text-sm uppercase tracking-wide text-slate-400">{prize.rarityLabel}</p>
-        <h3 className="mt-1 text-xl font-semibold text-white">{prize.name}</h3>
-        <p className="mt-2 text-sm text-slate-300">{prize.description}</p>
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">{prize.rarityLabel}</p>
+        <h3 className="mt-2 text-lg font-semibold text-white">{prize.name}</h3>
+        <p className="mt-3 text-sm text-slate-300">{prize.description}</p>
       </div>
-      <div className="mt-4 flex items-center justify-between text-sm text-slate-400">
+      <div className="mt-5 flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-400">
         <span>Drop Rate</span>
-        <span className="font-semibold text-slate-100">{dropRate}</span>
+        <span className="text-sm font-semibold text-slate-100 normal-case tracking-normal">{dropRate}</span>
       </div>
     </div>
   );
@@ -62,14 +64,22 @@ const ScratchCardGame = () => {
   const [loadingPrizes, setLoadingPrizes] = useState(true);
   const [prizeError, setPrizeError] = useState(null);
   const [isAttempting, setIsAttempting] = useState(false);
-  const [animationPhase, setAnimationPhase] = useState('idle');
+  const [cardState, setCardState] = useState('idle');
+  const [scratchProgress, setScratchProgress] = useState(0);
+  const [isScratching, setIsScratching] = useState(false);
+  const [coverCleared, setCoverCleared] = useState(false);
   const [result, setResult] = useState(null);
   const [showResultModal, setShowResultModal] = useState(false);
   const [attemptError, setAttemptError] = useState(null);
-  const [animationKey, setAnimationKey] = useState(0);
 
   const timeoutsRef = useRef([]);
   const isMountedRef = useRef(true);
+  const canvasRef = useRef(null);
+  const surfaceRef = useRef(null);
+  const pointerActiveRef = useRef(false);
+  const scratchedCellsRef = useRef(new Set());
+  const totalCellsRef = useRef(0);
+  const scratchCompletedRef = useRef(false);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -111,7 +121,10 @@ const ScratchCardGame = () => {
     };
   }, []);
 
-  const totalWeight = useMemo(() => prizes.reduce((sum, prize) => sum + (prize.weight ?? 0), 0), [prizes]);
+  const totalWeight = useMemo(
+    () => prizes.reduce((sum, prize) => sum + (prize.weight ?? 0), 0),
+    [prizes]
+  );
 
   const queueTimeout = (callback, delay) => {
     const timeoutId = setTimeout(callback, delay);
@@ -120,7 +133,7 @@ const ScratchCardGame = () => {
   };
 
   const handleAttempt = () => {
-    if (isAttempting || loadingPrizes) {
+    if (isAttempting || loadingPrizes || cardState === 'preparing' || cardState === 'ready') {
       return;
     }
 
@@ -129,185 +142,492 @@ const ScratchCardGame = () => {
 
     setIsAttempting(true);
     setAttemptError(null);
+    setIsScratching(false);
+    pointerActiveRef.current = false;
     setResult(null);
     setShowResultModal(false);
-    setAnimationKey((prev) => prev + 1);
-    setAnimationPhase('scratching');
+    setCardState('preparing');
+    setScratchProgress(0);
+    setCoverCleared(false);
+    scratchedCellsRef.current = new Set();
+    totalCellsRef.current = 0;
+    scratchCompletedRef.current = false;
 
-    const attemptPromise = attemptScratchCard();
-    attemptPromise.catch(() => {
-      // prevent unhandled rejection warnings; actual handling occurs below
-    });
+    attemptScratchCard()
+      .then((outcome) => {
+        if (!isMountedRef.current) {
+          return;
+        }
+        setResult(outcome);
+        setCardState('ready');
+      })
+      .catch(() => {
+        if (!isMountedRef.current) {
+          return;
+        }
+        setAttemptError('Something interrupted the scratch card attempt. Please try again.');
+        setCardState('idle');
+      })
+      .finally(() => {
+        if (!isMountedRef.current) {
+          return;
+        }
+        setIsAttempting(false);
+      });
+  };
+
+  const closeModal = () => {
+    setShowResultModal(false);
+  };
+
+  const initializeFoil = useCallback(() => {
+    if (cardState !== 'ready') {
+      return;
+    }
+
+    const canvas = canvasRef.current;
+    const surface = surfaceRef.current;
+    if (!canvas || !surface) {
+      return;
+    }
+
+    const rect = surface.getBoundingClientRect();
+    if (!rect.width || !rect.height) {
+      return;
+    }
+
+    const dpr = window.devicePixelRatio || 1;
+
+    canvas.width = rect.width * dpr;
+    canvas.height = rect.height * dpr;
+    canvas.style.width = `${rect.width}px`;
+    canvas.style.height = `${rect.height}px`;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      return;
+    }
+
+    ctx.globalCompositeOperation = 'source-over';
+    const gradient = ctx.createLinearGradient(0, 0, canvas.width, canvas.height);
+    gradient.addColorStop(0, '#4f46e5');
+    gradient.addColorStop(0.45, '#7c3aed');
+    gradient.addColorStop(1, '#ec4899');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.globalAlpha = 0.22;
+    ctx.fillStyle = '#ffffff';
+    const stripeStep = 28 * dpr;
+    for (let offset = -canvas.height; offset < canvas.width * 2; offset += stripeStep) {
+      ctx.save();
+      ctx.translate(0, offset);
+      ctx.rotate((18 * Math.PI) / 180);
+      ctx.fillRect(-canvas.width, 0, canvas.width * 3, 8 * dpr);
+      ctx.restore();
+    }
+    ctx.globalAlpha = 1;
+
+    scratchedCellsRef.current = new Set();
+    const widthCells = Math.ceil(rect.width / SCRATCH_CELL_SIZE);
+    const heightCells = Math.ceil(rect.height / SCRATCH_CELL_SIZE);
+    totalCellsRef.current = widthCells * heightCells;
+    setScratchProgress(0);
+    setCoverCleared(false);
+    scratchCompletedRef.current = false;
+  }, [cardState]);
+
+  useEffect(() => {
+    if (cardState !== 'ready') {
+      return;
+    }
+
+    initializeFoil();
+
+    const handleResize = () => {
+      initializeFoil();
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [cardState, initializeFoil]);
+
+  const handleScratchComplete = useCallback(() => {
+    if (cardState !== 'ready' || !result || scratchCompletedRef.current) {
+      return;
+    }
+
+    scratchCompletedRef.current = true;
+    setCardState('revealed');
+    setCoverCleared(true);
+    setScratchProgress(1);
 
     queueTimeout(() => {
       if (!isMountedRef.current) {
         return;
       }
-      setAnimationPhase('reveal');
+      setShowResultModal(true);
+    }, 650);
+  }, [cardState, result]);
 
-      queueTimeout(() => {
-        attemptPromise
-          .then((outcome) => {
-            if (!isMountedRef.current) {
-              return;
-            }
-            setResult(outcome);
-            setShowResultModal(true);
-            setAnimationPhase('result');
-          })
-          .catch(() => {
-            if (!isMountedRef.current) {
-              return;
-            }
-            setAttemptError('Something interrupted the scratch card attempt. Please try again.');
-            setAnimationPhase('idle');
-          })
-          .finally(() => {
-            if (!isMountedRef.current) {
-              return;
-            }
-            setIsAttempting(false);
-          });
-      }, REVEAL_DURATION);
-    }, SCRATCH_DURATION);
-  };
+  const scratchAt = useCallback(
+    (clientX, clientY) => {
+      if (cardState !== 'ready') {
+        return;
+      }
 
-  const closeModal = () => {
-    setShowResultModal(false);
-    setAnimationPhase('idle');
-  };
+      const canvas = canvasRef.current;
+      if (!canvas) {
+        return;
+      }
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        return;
+      }
 
-  const hasRevealed =
-    animationPhase === 'reveal' || animationPhase === 'result' || (!!result && animationPhase === 'idle');
+      const rect = canvas.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+      const x = (clientX - rect.left) * dpr;
+      const y = (clientY - rect.top) * dpr;
+
+      if (Number.isNaN(x) || Number.isNaN(y)) {
+        return;
+      }
+
+      const radius = SCRATCH_RADIUS * dpr;
+      const gradient = ctx.createRadialGradient(x, y, radius * 0.3, x, y, radius);
+      gradient.addColorStop(0, 'rgba(0, 0, 0, 0.9)');
+      gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
+      ctx.globalCompositeOperation = 'destination-out';
+      ctx.fillStyle = gradient;
+      ctx.beginPath();
+      ctx.arc(x, y, radius, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.closePath();
+      ctx.globalCompositeOperation = 'source-over';
+
+      const normalizedX = clientX - rect.left;
+      const normalizedY = clientY - rect.top;
+      const cellX = Math.floor(normalizedX / SCRATCH_CELL_SIZE);
+      const cellY = Math.floor(normalizedY / SCRATCH_CELL_SIZE);
+      const cellKey = `${cellX},${cellY}`;
+
+      if (!scratchedCellsRef.current.has(cellKey)) {
+        scratchedCellsRef.current.add(cellKey);
+        if (totalCellsRef.current > 0) {
+          const ratio = scratchedCellsRef.current.size / totalCellsRef.current;
+          setScratchProgress((prev) => (ratio > prev ? ratio : prev));
+          if (ratio >= REVEAL_THRESHOLD) {
+            handleScratchComplete();
+          }
+        }
+      }
+    },
+    [cardState, handleScratchComplete]
+  );
+
+  const endScratch = useCallback(() => {
+    if (!pointerActiveRef.current) {
+      return;
+    }
+    pointerActiveRef.current = false;
+    setIsScratching(false);
+  }, []);
+
+  const handlePointerDown = useCallback(
+    (event) => {
+      if (cardState !== 'ready') {
+        return;
+      }
+      event.preventDefault();
+      pointerActiveRef.current = true;
+      setIsScratching(true);
+      if (event.target?.setPointerCapture) {
+        event.target.setPointerCapture(event.pointerId);
+      }
+      const points = event.getCoalescedEvents ? event.getCoalescedEvents() : [event];
+      points.forEach((point) => {
+        scratchAt(point.clientX, point.clientY);
+      });
+    },
+    [cardState, scratchAt]
+  );
+
+  const handlePointerMove = useCallback(
+    (event) => {
+      if (!pointerActiveRef.current || cardState !== 'ready') {
+        return;
+      }
+      event.preventDefault();
+      const points = event.getCoalescedEvents ? event.getCoalescedEvents() : [event];
+      points.forEach((point) => {
+        scratchAt(point.clientX, point.clientY);
+      });
+    },
+    [cardState, scratchAt]
+  );
+
+  const handlePointerUp = useCallback(
+    (event) => {
+      if (event?.target?.releasePointerCapture) {
+        event.target.releasePointerCapture(event.pointerId);
+      }
+      endScratch();
+    },
+    [endScratch]
+  );
+
+  const handlePointerLeave = useCallback(() => {
+    endScratch();
+  }, [endScratch]);
+
+  useEffect(() => {
+    const handleGlobalPointerUp = () => {
+      endScratch();
+    };
+
+    window.addEventListener('pointerup', handleGlobalPointerUp);
+    window.addEventListener('pointercancel', handleGlobalPointerUp);
+
+    return () => {
+      window.removeEventListener('pointerup', handleGlobalPointerUp);
+      window.removeEventListener('pointercancel', handleGlobalPointerUp);
+    };
+  }, [endScratch]);
+
+  const hasRevealed = cardState === 'revealed';
+  const progressPercent = Math.min(100, Math.round(scratchProgress * 100));
+  const showProgress = cardState === 'ready' || cardState === 'revealed';
 
   const cardClassName = [
     'scratch-card',
-    animationPhase === 'scratching' ? 'scratch-card--scratching' : '',
+    cardState === 'ready' && isScratching ? 'scratch-card--scratching' : '',
     hasRevealed ? 'scratch-card--revealed' : '',
   ]
     .filter(Boolean)
     .join(' ');
 
-  const coverClassName = [
-    'scratch-card__cover',
-    animationPhase === 'scratching' ? 'scratch-card__cover--scratching' : '',
-    hasRevealed ? 'scratch-card__cover--cleared' : '',
+  const foilClassName = [
+    'scratch-card__foil',
+    cardState === 'ready' ? 'scratch-card__foil--interactive' : '',
+    coverCleared ? 'scratch-card__foil--cleared' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const canvasClassName = [
+    'scratch-card__foil-canvas',
+    cardState !== 'ready' ? 'scratch-card__foil-canvas--inactive' : '',
+    coverCleared ? 'scratch-card__foil-canvas--cleared' : '',
   ]
     .filter(Boolean)
     .join(' ');
 
   const rewardStyle = {
-    background: hasRevealed && result
-      ? `linear-gradient(135deg, ${result.prize.foilColor}, rgba(15, 23, 42, 0.92))`
-      : 'linear-gradient(135deg, rgba(148, 163, 184, 0.4), rgba(51, 65, 85, 0.95))',
-    boxShadow: hasRevealed && result
-      ? `0 18px 45px ${result.prize.glowColor}`
-      : '0 14px 30px rgba(15, 23, 42, 0.45)',
+    background:
+      hasRevealed && result
+        ? `linear-gradient(135deg, ${result.prize.foilColor}, rgba(15, 23, 42, 0.92))`
+        : 'linear-gradient(135deg, rgba(148, 163, 184, 0.35), rgba(51, 65, 85, 0.95))',
+    boxShadow:
+      hasRevealed && result ? `0 20px 48px ${result.prize.glowColor}` : '0 16px 36px rgba(15, 23, 42, 0.45)',
   };
 
   const glowStyle = {
-    background: hasRevealed && result
-      ? `radial-gradient(circle, ${result.prize.glowColor} 0%, rgba(15, 23, 42, 0) 75%)`
-      : 'radial-gradient(circle, rgba(56, 189, 248, 0.35) 0%, rgba(15, 23, 42, 0) 75%)',
+    background:
+      hasRevealed && result
+        ? `radial-gradient(circle, ${result.prize.glowColor} 0%, rgba(15, 23, 42, 0) 75%)`
+        : 'radial-gradient(circle, rgba(129, 140, 248, 0.45) 0%, rgba(15, 23, 42, 0) 75%)',
   };
 
   const statusText = (() => {
-    if (animationPhase === 'scratching') {
-      return 'Scratching…';
+    if (cardState === 'preparing') {
+      return 'Preparing your aurora foil…';
     }
-    if (animationPhase === 'reveal') {
-      return 'Foil clearing…';
+    if (cardState === 'ready') {
+      if (scratchProgress >= REVEAL_THRESHOLD) {
+        return 'Almost there… keep scratching!';
+      }
+      if (isScratching) {
+        return 'Scratching in progress…';
+      }
+      return 'Foil ready! Start scratching.';
     }
-    if (animationPhase === 'result') {
-      return 'Prize revealed!';
+    if (cardState === 'revealed' && result) {
+      return `Prize revealed: ${result.prize.name}`;
     }
-    if (result) {
-      return 'Prize ready';
-    }
-    return 'Ready to scratch';
+    return 'Tap “Get a new card” to begin.';
   })();
 
+  const foilMessage = (() => {
+    if (cardState === 'preparing') {
+      return 'Charging the foil layers…';
+    }
+    if (cardState === 'ready') {
+      return scratchProgress === 0 ? 'Scratch to reveal your prize' : 'Keep scratching to unveil it!';
+    }
+    if (cardState === 'revealed') {
+      return 'Shimmering reward unlocked!';
+    }
+    return 'Press the button to draw a card.';
+  })();
+
+  const foilMessageDetail = (() => {
+    if (cardState === 'ready') {
+      return `${progressPercent}% revealed`;
+    }
+    if (cardState === 'preparing') {
+      return 'Infusing with cosmic pigment…';
+    }
+    if (cardState === 'idle') {
+      return 'You have one free scratch awaiting.';
+    }
+    if (cardState === 'revealed' && result) {
+      return result.prize.rarityLabel;
+    }
+    return '';
+  })();
+
+  const buttonLabel = (() => {
+    if (cardState === 'preparing' || isAttempting) {
+      return 'Preparing card…';
+    }
+    if (cardState === 'ready') {
+      return 'Scratch the foil';
+    }
+    if (cardState === 'revealed') {
+      return 'Get another card';
+    }
+    return 'Get a new card';
+  })();
+
+  const buttonDisabled =
+    isAttempting || loadingPrizes || cardState === 'preparing' || cardState === 'ready';
+
   return (
-    <div className="min-h-screen bg-slate-950 py-10 text-white">
-      <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4">
-        <div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
-          <div>
-            <h1 className="text-3xl font-semibold text-white sm:text-4xl">Radiant Foil Scratch Card</h1>
-            <p className="mt-2 max-w-xl text-sm text-slate-300 sm:text-base">
-              Reveal shimmering loot by peeling back the foil. The same prize pool fuels every scratch, so luck and
-              persistence shape the gleam you uncover.
+    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-indigo-950 to-fuchsia-950 py-12 text-white">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-10 px-4">
+        <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-indigo-300/80">Glitterforge Games</p>
+            <h1 className="text-3xl font-bold leading-tight text-white sm:text-4xl">Aurora Scratch Card</h1>
+            <p className="max-w-2xl text-sm text-slate-300/90 sm:text-base">
+              Claim a radiant foil, then do the scratching yourself to reveal the treasure hidden beneath. Every swipe
+              clears the nebula shimmer until your prize erupts in full color.
             </p>
           </div>
-          <div className="flex flex-col gap-2 sm:flex-row">
-            <button
-              type="button"
-              className="rounded-full border border-slate-700 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:text-white"
-              onClick={() => navigate('/')}
-            >
-              Back to Store
-            </button>
-            <button
-              type="button"
-              onClick={handleAttempt}
-              disabled={isAttempting || loadingPrizes}
-              className="flex items-center justify-center rounded-full bg-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400 disabled:cursor-not-allowed disabled:bg-slate-600"
-            >
-              {isAttempting ? 'Scratching…' : 'Scratch Now'}
-            </button>
+          <div className="flex flex-col items-start gap-3 sm:items-end">
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="rounded-full border border-indigo-400/40 px-5 py-2 text-sm font-medium text-indigo-100 transition hover:border-indigo-300 hover:text-white"
+                onClick={() => navigate('/')}
+              >
+                Back to Store
+              </button>
+              <button
+                type="button"
+                onClick={handleAttempt}
+                disabled={buttonDisabled}
+                className="flex items-center justify-center rounded-full bg-gradient-to-r from-fuchsia-500 via-indigo-500 to-sky-500 px-6 py-2 text-sm font-semibold text-white shadow-lg shadow-indigo-900/40 transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {buttonLabel}
+              </button>
+            </div>
+            {cardState === 'ready' && (
+              <span className="text-xs uppercase tracking-[0.3em] text-indigo-200/70">Foil armed &amp; ready</span>
+            )}
           </div>
         </div>
 
-        <div className="flex flex-col gap-6 lg:flex-row">
-          <div className="flex flex-1 flex-col gap-6 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-2xl shadow-indigo-900/30">
-            <h2 className="text-lg font-semibold text-white">Prize Ledger</h2>
-            {loadingPrizes ? (
-              <p className="text-sm text-slate-400">Loading scratch card lineup…</p>
-            ) : prizeError ? (
-              <p className="text-sm text-rose-300">{prizeError}</p>
-            ) : (
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                {prizes.map((prize) => (
-                  <PrizeCard
-                    key={prize.id}
-                    prize={prize}
-                    dropRate={formatDropRate(prize.weight ?? 0, totalWeight)}
-                  />
-                ))}
-              </div>
-            )}
-          </div>
-
-          <div className="scratch-card-stage flex flex-1 items-center justify-center rounded-2xl border border-slate-800 bg-slate-900/60 p-6 text-center shadow-2xl shadow-indigo-900/30">
-            <div className="scratch-card-container">
-              <div className={cardClassName}>
-                <div className="scratch-card__inner">
-                  <div className="scratch-card__reward" style={rewardStyle}>
-                    <div className="scratch-card__reward-glow" style={glowStyle} />
-                    <div className="scratch-card__reward-content">
-                      <p className="scratch-card__reward-rarity">
-                        {result ? result.prize.rarityLabel : 'Mystery Reward'}
-                      </p>
-                      <h3 className="scratch-card__reward-name">
-                        {result ? result.prize.name : 'Scratch to reveal'}
-                      </h3>
-                    </div>
+        <div className="scratch-card-stage rounded-3xl border border-indigo-500/30 bg-gradient-to-br from-indigo-950/70 via-slate-950/60 to-fuchsia-900/40 p-8 shadow-[0_35px_80px_rgba(59,7,100,0.45)]">
+          <div className="scratch-card-container">
+            <div className={cardClassName}>
+              <div className="scratch-card__inner" ref={surfaceRef}>
+                <div className="scratch-card__reward" style={rewardStyle}>
+                  <div className="scratch-card__reward-glow" style={glowStyle} />
+                  <div className="scratch-card__reward-content">
+                    <p className="scratch-card__reward-rarity">
+                      {hasRevealed && result ? result.prize.rarityLabel : 'Mystery Reward'}
+                    </p>
+                    <h3 className="scratch-card__reward-name">
+                      {hasRevealed && result
+                        ? result.prize.name
+                        : cardState === 'ready'
+                        ? 'Scratch to reveal'
+                        : 'Awaiting scratch'}
+                    </h3>
+                    <p className="scratch-card__reward-helper">
+                      {hasRevealed && result ? result.flairText : 'Drag across the foil to lift the shimmer.'}
+                    </p>
                   </div>
-                  <div key={animationKey} className={coverClassName}>
-                    <div className="scratch-card__cover-texture" />
-                    {animationPhase === 'scratching' && (
-                      <div className="scratch-card__strokes">
-                        <span className="scratch-card__stroke scratch-card__stroke--one" />
-                        <span className="scratch-card__stroke scratch-card__stroke--two" />
-                        <span className="scratch-card__stroke scratch-card__stroke--three" />
-                      </div>
-                    )}
+                </div>
+                <div className={foilClassName}>
+                  <canvas
+                    ref={canvasRef}
+                    className={canvasClassName}
+                    onPointerDown={handlePointerDown}
+                    onPointerMove={handlePointerMove}
+                    onPointerUp={handlePointerUp}
+                    onPointerCancel={handlePointerLeave}
+                    onPointerLeave={handlePointerLeave}
+                  />
+                  <div className="scratch-card__foil-noise" />
+                  <div className="scratch-card__foil-shine" />
+                  <div
+                    className={`scratch-card__foil-message ${
+                      cardState !== 'revealed' ? 'scratch-card__foil-message--visible' : ''
+                    }`}
+                  >
+                    <span>{foilMessage}</span>
+                    {foilMessageDetail && <span className="scratch-card__foil-detail">{foilMessageDetail}</span>}
                   </div>
                 </div>
               </div>
+            </div>
+            <div className="scratch-card__status-panel">
               <div className="scratch-card__status-badge">{statusText}</div>
+              {showProgress && (
+                <div className="scratch-card__progress">
+                  <div className="scratch-card__progress-track">
+                    <div className="scratch-card__progress-fill" style={{ width: `${progressPercent}%` }} />
+                  </div>
+                  <span className="scratch-card__progress-label">{progressPercent}% revealed</span>
+                </div>
+              )}
+              {cardState === 'revealed' && result && (
+                <p className="scratch-card__status-detail">
+                  You uncovered the <span>{result.prize.name}</span>!
+                </p>
+              )}
               {attemptError && <div className="scratch-card-error">{attemptError}</div>}
             </div>
           </div>
+        </div>
+
+        <div className="rounded-3xl border border-slate-800/60 bg-slate-950/60 p-7 shadow-[0_30px_70px_rgba(15,23,42,0.45)] backdrop-blur">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-lg font-semibold text-white">Prize Ledger</h2>
+            <span className="rounded-full border border-indigo-400/30 px-3 py-1 text-xs uppercase tracking-[0.3em] text-indigo-200/70">
+              Drop Rates
+            </span>
+          </div>
+          {loadingPrizes ? (
+            <p className="mt-4 text-sm text-slate-400">Loading scratch card lineup…</p>
+          ) : prizeError ? (
+            <p className="mt-4 text-sm text-rose-300">{prizeError}</p>
+          ) : (
+            <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+              {prizes.map((prize) => (
+                <PrizeCard
+                  key={prize.id}
+                  prize={prize}
+                  dropRate={formatDropRate(prize.weight ?? 0, totalWeight)}
+                />
+              ))}
+            </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- rebuild the scratch card component with manual scratching logic, progress tracking, and updated layout
- place the foil stage above the ledger with richer status messaging and modal handling
- refresh the scratch card styles with vibrant gradients, foil textures, and progress visuals

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cd8403f718832a8980ec1bd722d27b