### PR TITLE
Adapt game configs to new Game document shape

### DIFF
--- a/src/games/flip-card-new/config/base-config.json
+++ b/src/games/flip-card-new/config/base-config.json
@@ -1,74 +1,78 @@
 {
-  "gameId": "flip-new-001",
-  "gameType": "flip-card-new",
-  "title": "Azure Breeze Flip Challenge",
-  "description": "Flip the cards to uncover breezy pairs before your moves run out.",
-  "moveLimit": 8,
-  "initialRevealSeconds": 3,
-  "cardUpflipSeconds": 1.2,
-  "cardBackImage": "/images/matching-game-assets/white-tiffin-assets/white-tiffin-logo.png",
-  "theme": {
-    "backgroundColor": "#fdfaf5",
-    "backgroundImage": "radial-gradient(circle at 10% 0%, rgba(125, 211, 252, 0.45), transparent 55%), radial-gradient(circle at 90% -20%, rgba(253, 224, 171, 0.6), transparent 52%), linear-gradient(160deg, #fdfaf5 0%, #e8f3ff 55%, #fdfaf5 100%)",
-    "backgroundOverlayColor": "rgba(255, 255, 255, 0.82)",
-    "accentColor": "#60a5fa",
-    "titleColor": "#0f172a",
-    "textColor": "#1f2937",
-    "subtleTextColor": "rgba(71, 85, 105, 0.75)",
-    "panelBackgroundColor": "rgba(255, 255, 255, 0.88)",
-    "panelBorderColor": "rgba(148, 163, 184, 0.32)",
-    "panelShadowColor": "rgba(148, 163, 184, 0.26)",
-    "boardBackgroundColor": "rgba(255, 255, 255, 0.92)",
-    "boardBorderColor": "rgba(191, 219, 254, 0.7)",
-    "boardShadowColor": "rgba(100, 116, 139, 0.24)",
-    "cardBackBackgroundColor": "rgba(226, 232, 240, 0.85)",
-    "cardFaceBackgroundColor": "rgba(239, 246, 255, 0.92)",
-    "cardBorderColor": "rgba(191, 219, 254, 0.9)",
-    "cardMatchedBackgroundColor": "rgba(191, 227, 255, 0.65)",
-    "cardMatchedGlowColor": "rgba(96, 165, 250, 0.58)",
-    "cardShadowColor": "rgba(148, 163, 184, 0.4)",
-    "buttonBackgroundColor": "#3b82f6",
-    "buttonHoverBackgroundColor": "#2563eb",
-    "buttonTextColor": "#f8fafc",
-    "cardFlipDurationMs": 520
-  },
-  "submissionEndpoint": "/api/games/flip-card-new/flip-new-001/results",
-  "cards": [
+  "game_id": "flip-new-001",
+  "game_template_name": "flip-card-new",
+  "name": "Azure Breeze Flip Challenge",
+  "merchant_id": "merchant-demo",
+  "game_background_image": "",
+  "game_logo_image": "",
+  "start_date": "2024-01-01T00:00:00.000Z",
+  "end_date": "2024-12-31T23:59:59.000Z",
+  "status": "created",
+  "is_active": true,
+  "hard_play_count_limit": 0,
+  "play_count": 0,
+  "prizes": {},
+  "is_quests_enabled": false,
+  "quests": [],
+  "leaderboard_id": null,
+  "prize_distribution_strategy": "cascade",
+  "createdAt": "2024-01-01T00:00:00.000Z",
+  "updatedAt": "2024-01-01T00:00:00.000Z",
+  "__v": 0,
+  "options": [
     {
-      "id": "mee-siam-with-prawns",
-      "type": "Mee Siam With Prawns",
-      "image": "/images/matching-game-assets/white-tiffin-assets/mee-siam-with-prawns.png",
-      "altText": "Mee Siam With Prawns card artwork"
+      "input_name": "title",
+      "input_type": "string",
+      "value": "Azure Breeze Flip Challenge",
+      "required": true
     },
     {
-      "id": "local-trio",
-      "type": "Local Trio",
-      "image": "/images/matching-game-assets/white-tiffin-assets/local-trio.png",
-      "altText": "Local Trio card artwork"
+      "input_name": "description",
+      "input_type": "string",
+      "value": "Flip the cards to uncover breezy pairs before your moves run out.",
+      "required": true
     },
     {
-      "id": "nasi-lemak-beef",
-      "type": "Nasi Lemak Beef",
-      "image": "/images/matching-game-assets/white-tiffin-assets/nasi-lemak-beef.png",
-      "altText": "Nasi Lemak Beef card artwork"
+      "input_name": "moveLimit",
+      "input_type": "number",
+      "value": "8",
+      "required": true
     },
     {
-      "id": "chicken-curry",
-      "type": "Chicken Curry",
-      "image": "/images/matching-game-assets/white-tiffin-assets/chicken-curry.png",
-      "altText": "Chicken Curry card artwork"
+      "input_name": "initialRevealSeconds",
+      "input_type": "number",
+      "value": "3",
+      "required": true
     },
     {
-      "id": "trio-snack-platter",
-      "type": "Trio Snack Platter",
-      "image": "/images/matching-game-assets/white-tiffin-assets/trio-snack-platter.png",
-      "altText": "Trio Snack Platter card artwork"
+      "input_name": "cardUpflipSeconds",
+      "input_type": "number",
+      "value": "1.2",
+      "required": true
     },
     {
-      "id": "fish-maw-seafood-soup",
-      "type": "Fish Maw Seafood Soup",
-      "image": "/images/matching-game-assets/white-tiffin-assets/fish-maw-seafood-soup.png",
-      "altText": "Fish Maw Seafood Soup card artwork"
+      "input_name": "cardBackImage",
+      "input_type": "image",
+      "value": "/images/matching-game-assets/white-tiffin-assets/white-tiffin-logo.png",
+      "required": true
+    },
+    {
+      "input_name": "theme",
+      "input_type": "string",
+      "value": "{\"backgroundColor\": \"#fdfaf5\", \"backgroundImage\": \"radial-gradient(circle at 10% 0%, rgba(125, 211, 252, 0.45), transparent 55%), radial-gradient(circle at 90% -20%, rgba(253, 224, 171, 0.6), transparent 52%), linear-gradient(160deg, #fdfaf5 0%, #e8f3ff 55%, #fdfaf5 100%)\", \"backgroundOverlayColor\": \"rgba(255, 255, 255, 0.82)\", \"accentColor\": \"#60a5fa\", \"titleColor\": \"#0f172a\", \"textColor\": \"#1f2937\", \"subtleTextColor\": \"rgba(71, 85, 105, 0.75)\", \"panelBackgroundColor\": \"rgba(255, 255, 255, 0.88)\", \"panelBorderColor\": \"rgba(148, 163, 184, 0.32)\", \"panelShadowColor\": \"rgba(148, 163, 184, 0.26)\", \"boardBackgroundColor\": \"rgba(255, 255, 255, 0.92)\", \"boardBorderColor\": \"rgba(191, 219, 254, 0.7)\", \"boardShadowColor\": \"rgba(100, 116, 139, 0.24)\", \"cardBackBackgroundColor\": \"rgba(226, 232, 240, 0.85)\", \"cardFaceBackgroundColor\": \"rgba(239, 246, 255, 0.92)\", \"cardBorderColor\": \"rgba(191, 219, 254, 0.9)\", \"cardMatchedBackgroundColor\": \"rgba(191, 227, 255, 0.65)\", \"cardMatchedGlowColor\": \"rgba(96, 165, 250, 0.58)\", \"cardShadowColor\": \"rgba(148, 163, 184, 0.4)\", \"buttonBackgroundColor\": \"#3b82f6\", \"buttonHoverBackgroundColor\": \"#2563eb\", \"buttonTextColor\": \"#f8fafc\", \"cardFlipDurationMs\": 520}",
+      "required": true
+    },
+    {
+      "input_name": "submissionEndpoint",
+      "input_type": "string",
+      "value": "/api/games/flip-card-new/flip-new-001/results",
+      "required": true
+    },
+    {
+      "input_name": "cards",
+      "input_type": "string",
+      "value": "[{\"id\": \"mee-siam-with-prawns\", \"type\": \"Mee Siam With Prawns\", \"image\": \"/images/matching-game-assets/white-tiffin-assets/mee-siam-with-prawns.png\", \"altText\": \"Mee Siam With Prawns card artwork\"}, {\"id\": \"local-trio\", \"type\": \"Local Trio\", \"image\": \"/images/matching-game-assets/white-tiffin-assets/local-trio.png\", \"altText\": \"Local Trio card artwork\"}, {\"id\": \"nasi-lemak-beef\", \"type\": \"Nasi Lemak Beef\", \"image\": \"/images/matching-game-assets/white-tiffin-assets/nasi-lemak-beef.png\", \"altText\": \"Nasi Lemak Beef card artwork\"}, {\"id\": \"chicken-curry\", \"type\": \"Chicken Curry\", \"image\": \"/images/matching-game-assets/white-tiffin-assets/chicken-curry.png\", \"altText\": \"Chicken Curry card artwork\"}, {\"id\": \"trio-snack-platter\", \"type\": \"Trio Snack Platter\", \"image\": \"/images/matching-game-assets/white-tiffin-assets/trio-snack-platter.png\", \"altText\": \"Trio Snack Platter card artwork\"}, {\"id\": \"fish-maw-seafood-soup\", \"type\": \"Fish Maw Seafood Soup\", \"image\": \"/images/matching-game-assets/white-tiffin-assets/fish-maw-seafood-soup.png\", \"altText\": \"Fish Maw Seafood Soup card artwork\"}]",
+      "required": true
     }
   ]
 }

--- a/src/games/flip-card-new/config/index.js
+++ b/src/games/flip-card-new/config/index.js
@@ -1,4 +1,5 @@
-import baseConfig from './base-config.json';
+import baseGameDocument from './base-config.json';
+import { buildGameConfigBase, cloneConfigValue } from '../../../utils/gameConfig';
 
 export const flipCardNewFieldSchema = {
   admin: {
@@ -143,21 +144,43 @@ export const flipCardNewFieldSchema = {
   }
 };
 
+const baseConfig = buildGameConfigBase(baseGameDocument);
+const { options } = baseConfig;
+
+const normalisedTheme =
+  options.theme && typeof options.theme === 'object' ? cloneConfigValue(options.theme) : {};
+const normalisedCards = Array.isArray(options.cards) ? cloneConfigValue(options.cards) : [];
+
 export const flipCardNewApiContract = {
-  method: 'GET',
+  method: 'POST',
+  path: '/games/list',
+  requestBody: {
+    game_ids: [baseGameDocument.game_id],
+    merchant_id: baseGameDocument.merchant_id
+  },
   responseType: 'application/json',
-  notes: 'The API should respond with the exact shape of baseConfig, optionally overriding the editable fields based on campaign needs.',
-  collection: 'gameConfigs',
-  documentKey: `${baseConfig.gameType}:${baseConfig.gameId}`
+  notes:
+    'POST /games/list returns full Game documents with immutable metadata and the options array mirrored in this configuration.',
+  sampleResponse: baseGameDocument
 };
 
 const flipCardNewConfig = {
-  ...baseConfig,
-  cards: baseConfig.cards.map((card) => ({ ...card })),
+  gameId: baseConfig.gameId,
+  gameType: baseConfig.gameType,
+  title: baseConfig.title,
+  description: options.description ?? options.gameDescription ?? '',
+  moveLimit: options.moveLimit ?? 0,
+  initialRevealSeconds: options.initialRevealSeconds ?? 0,
+  cardUpflipSeconds: options.cardUpflipSeconds ?? 0,
+  cardBackImage: options.cardBackImage ?? '',
+  theme: normalisedTheme,
+  submissionEndpoint: options.submissionEndpoint ?? '',
+  cards: normalisedCards,
   fieldSchema: flipCardNewFieldSchema,
-  apiContract: flipCardNewApiContract
+  apiContract: flipCardNewApiContract,
+  gameDocument: baseGameDocument
 };
 
-export const baseFlipCardNewConfig = baseConfig;
+export const baseFlipCardNewConfig = baseGameDocument;
 
 export default flipCardNewConfig;

--- a/src/games/flip-card-new/unique-cards.js
+++ b/src/games/flip-card-new/unique-cards.js
@@ -1,5 +1,7 @@
-import baseConfig from './config/base-config.json';
+import flipCardNewConfig from './config';
 
-const uniqueCardsArray = baseConfig.cards.map((card) => ({ ...card }));
+const uniqueCardsArray = Array.isArray(flipCardNewConfig.cards)
+  ? flipCardNewConfig.cards.map((card) => ({ ...card }))
+  : [];
 
 export default uniqueCardsArray;

--- a/src/games/matching-game/config/base-config.json
+++ b/src/games/matching-game/config/base-config.json
@@ -1,74 +1,78 @@
 {
-  "gameId": "flip-001",
-  "gameType": "flip-card",
-  "title": "White Tiffin Flip & Match",
-  "description": "Players flip cards to match pairs of dishes before they run out of moves.",
-  "moveLimit": 5,
-  "initialRevealSeconds": 3,
-  "cardUpflipSeconds": 1,
-  "cardBackImage": "/images/matching-game-assets/white-tiffin-assets/white-tiffin-logo.png",
-  "theme": {
-    "backgroundColor": "#0b1220",
-    "backgroundImage": "radial-gradient(circle at 12% -18%, rgba(249, 115, 22, 0.18), transparent 52%), radial-gradient(circle at 82% 0%, rgba(249, 115, 22, 0.14), transparent 48%), linear-gradient(140deg, #0b1220 0%, #111c32 55%, #0b1220 100%)",
-    "backgroundOverlayColor": "rgba(7, 12, 24, 0.86)",
-    "accentColor": "#f97316",
-    "titleColor": "#f8fafc",
-    "textColor": "#e2e8f0",
-    "subtleTextColor": "rgba(226, 232, 240, 0.78)",
-    "panelBackgroundColor": "rgba(11, 17, 32, 0.78)",
-    "panelBorderColor": "rgba(148, 163, 184, 0.3)",
-    "panelShadowColor": "rgba(8, 15, 32, 0.7)",
-    "boardBackgroundColor": "rgba(11, 17, 32, 0.65)",
-    "boardBorderColor": "rgba(148, 163, 184, 0.28)",
-    "boardShadowColor": "rgba(8, 15, 32, 0.72)",
-    "cardBackBackgroundColor": "rgba(30, 41, 59, 0.85)",
-    "cardFaceBackgroundColor": "rgba(13, 19, 32, 0.68)",
-    "cardBorderColor": "rgba(148, 163, 184, 0.32)",
-    "cardMatchedBackgroundColor": "rgba(249, 115, 22, 0.18)",
-    "cardMatchedGlowColor": "rgba(249, 115, 22, 0.52)",
-    "cardShadowColor": "rgba(8, 15, 32, 0.82)",
-    "buttonBackgroundColor": "#f97316",
-    "buttonHoverBackgroundColor": "#fb923c",
-    "buttonTextColor": "#0b1120",
-    "cardFlipDurationMs": 620
-  },
-  "submissionEndpoint": "/api/games/flip-card/flip-001/results",
-  "cards": [
+  "game_id": "flip-001",
+  "game_template_name": "flip-card",
+  "name": "White Tiffin Flip & Match",
+  "merchant_id": "merchant-demo",
+  "game_background_image": "",
+  "game_logo_image": "",
+  "start_date": "2024-01-01T00:00:00.000Z",
+  "end_date": "2024-12-31T23:59:59.000Z",
+  "status": "created",
+  "is_active": true,
+  "hard_play_count_limit": 0,
+  "play_count": 0,
+  "prizes": {},
+  "is_quests_enabled": false,
+  "quests": [],
+  "leaderboard_id": null,
+  "prize_distribution_strategy": "cascade",
+  "createdAt": "2024-01-01T00:00:00.000Z",
+  "updatedAt": "2024-01-01T00:00:00.000Z",
+  "__v": 0,
+  "options": [
     {
-      "id": "mee-siam-with-prawns",
-      "type": "Mee Siam With Prawns",
-      "image": "/images/matching-game-assets/white-tiffin-assets/mee-siam-with-prawns.png",
-      "altText": "White Tiffin Mee Siam With Prawns card artwork"
+      "input_name": "title",
+      "input_type": "string",
+      "value": "White Tiffin Flip & Match",
+      "required": true
     },
     {
-      "id": "local-trio",
-      "type": "Local Trio",
-      "image": "/images/matching-game-assets/white-tiffin-assets/local-trio.png",
-      "altText": "White Tiffin Local Trio card artwork"
+      "input_name": "description",
+      "input_type": "string",
+      "value": "Players flip cards to match pairs of dishes before they run out of moves.",
+      "required": true
     },
     {
-      "id": "nasi-lemak-beef",
-      "type": "Nasi Lemak Beef",
-      "image": "/images/matching-game-assets/white-tiffin-assets/nasi-lemak-beef.png",
-      "altText": "White Tiffin Nasi Lemak Beef card artwork"
+      "input_name": "moveLimit",
+      "input_type": "number",
+      "value": "5",
+      "required": true
     },
     {
-      "id": "chicken-curry",
-      "type": "Chicken Curry",
-      "image": "/images/matching-game-assets/white-tiffin-assets/chicken-curry.png",
-      "altText": "White Tiffin Chicken Curry card artwork"
+      "input_name": "initialRevealSeconds",
+      "input_type": "number",
+      "value": "3",
+      "required": true
     },
     {
-      "id": "trio-snack-platter",
-      "type": "Trio Snack Platter",
-      "image": "/images/matching-game-assets/white-tiffin-assets/trio-snack-platter.png",
-      "altText": "White Tiffin Trio Snack Platter card artwork"
+      "input_name": "cardUpflipSeconds",
+      "input_type": "number",
+      "value": "1",
+      "required": true
     },
     {
-      "id": "fish-maw-seafood-soup",
-      "type": "Fish Maw Seafood Soup",
-      "image": "/images/matching-game-assets/white-tiffin-assets/fish-maw-seafood-soup.png",
-      "altText": "White Tiffin Fish Maw Seafood Soup card artwork"
+      "input_name": "cardBackImage",
+      "input_type": "image",
+      "value": "/images/matching-game-assets/white-tiffin-assets/white-tiffin-logo.png",
+      "required": true
+    },
+    {
+      "input_name": "theme",
+      "input_type": "string",
+      "value": "{\"backgroundColor\": \"#0b1220\", \"backgroundImage\": \"radial-gradient(circle at 12% -18%, rgba(249, 115, 22, 0.18), transparent 52%), radial-gradient(circle at 82% 0%, rgba(249, 115, 22, 0.14), transparent 48%), linear-gradient(140deg, #0b1220 0%, #111c32 55%, #0b1220 100%)\", \"backgroundOverlayColor\": \"rgba(7, 12, 24, 0.86)\", \"accentColor\": \"#f97316\", \"titleColor\": \"#f8fafc\", \"textColor\": \"#e2e8f0\", \"subtleTextColor\": \"rgba(226, 232, 240, 0.78)\", \"panelBackgroundColor\": \"rgba(11, 17, 32, 0.78)\", \"panelBorderColor\": \"rgba(148, 163, 184, 0.3)\", \"panelShadowColor\": \"rgba(8, 15, 32, 0.7)\", \"boardBackgroundColor\": \"rgba(11, 17, 32, 0.65)\", \"boardBorderColor\": \"rgba(148, 163, 184, 0.28)\", \"boardShadowColor\": \"rgba(8, 15, 32, 0.72)\", \"cardBackBackgroundColor\": \"rgba(30, 41, 59, 0.85)\", \"cardFaceBackgroundColor\": \"rgba(13, 19, 32, 0.68)\", \"cardBorderColor\": \"rgba(148, 163, 184, 0.32)\", \"cardMatchedBackgroundColor\": \"rgba(249, 115, 22, 0.18)\", \"cardMatchedGlowColor\": \"rgba(249, 115, 22, 0.52)\", \"cardShadowColor\": \"rgba(8, 15, 32, 0.82)\", \"buttonBackgroundColor\": \"#f97316\", \"buttonHoverBackgroundColor\": \"#fb923c\", \"buttonTextColor\": \"#0b1120\", \"cardFlipDurationMs\": 620}",
+      "required": true
+    },
+    {
+      "input_name": "submissionEndpoint",
+      "input_type": "string",
+      "value": "/api/games/flip-card/flip-001/results",
+      "required": true
+    },
+    {
+      "input_name": "cards",
+      "input_type": "string",
+      "value": "[{\"id\": \"mee-siam-with-prawns\", \"type\": \"Mee Siam With Prawns\", \"image\": \"/images/matching-game-assets/white-tiffin-assets/mee-siam-with-prawns.png\", \"altText\": \"White Tiffin Mee Siam With Prawns card artwork\"}, {\"id\": \"local-trio\", \"type\": \"Local Trio\", \"image\": \"/images/matching-game-assets/white-tiffin-assets/local-trio.png\", \"altText\": \"White Tiffin Local Trio card artwork\"}, {\"id\": \"nasi-lemak-beef\", \"type\": \"Nasi Lemak Beef\", \"image\": \"/images/matching-game-assets/white-tiffin-assets/nasi-lemak-beef.png\", \"altText\": \"White Tiffin Nasi Lemak Beef card artwork\"}, {\"id\": \"chicken-curry\", \"type\": \"Chicken Curry\", \"image\": \"/images/matching-game-assets/white-tiffin-assets/chicken-curry.png\", \"altText\": \"White Tiffin Chicken Curry card artwork\"}, {\"id\": \"trio-snack-platter\", \"type\": \"Trio Snack Platter\", \"image\": \"/images/matching-game-assets/white-tiffin-assets/trio-snack-platter.png\", \"altText\": \"White Tiffin Trio Snack Platter card artwork\"}, {\"id\": \"fish-maw-seafood-soup\", \"type\": \"Fish Maw Seafood Soup\", \"image\": \"/images/matching-game-assets/white-tiffin-assets/fish-maw-seafood-soup.png\", \"altText\": \"White Tiffin Fish Maw Seafood Soup card artwork\"}]",
+      "required": true
     }
   ]
 }

--- a/src/games/matching-game/config/index.js
+++ b/src/games/matching-game/config/index.js
@@ -1,4 +1,5 @@
-import baseConfig from './base-config.json';
+import baseGameDocument from './base-config.json';
+import { buildGameConfigBase, cloneConfigValue } from '../../../utils/gameConfig';
 
 export const matchingGameFieldSchema = {
   admin: {
@@ -143,21 +144,43 @@ export const matchingGameFieldSchema = {
   }
 };
 
+const baseConfig = buildGameConfigBase(baseGameDocument);
+const { options } = baseConfig;
+
+const normalisedTheme =
+  options.theme && typeof options.theme === 'object' ? cloneConfigValue(options.theme) : {};
+const normalisedCards = Array.isArray(options.cards) ? cloneConfigValue(options.cards) : [];
+
 export const matchingGameApiContract = {
-  method: 'GET',
+  method: 'POST',
+  path: '/games/list',
+  requestBody: {
+    game_ids: [baseGameDocument.game_id],
+    merchant_id: baseGameDocument.merchant_id
+  },
   responseType: 'application/json',
-  notes: 'The API should respond with the exact shape of baseConfig, optionally overriding the editable fields based on campaign needs.',
-  collection: 'gameConfigs',
-  documentKey: `${baseConfig.gameType}:${baseConfig.gameId}`
+  notes:
+    'POST /games/list returns full Game documents. Each document includes immutable metadata plus the options array mirrored in this mock payload.',
+  sampleResponse: baseGameDocument
 };
 
 const matchingGameConfig = {
-  ...baseConfig,
-  cards: baseConfig.cards.map((card) => ({ ...card })),
+  gameId: baseConfig.gameId,
+  gameType: baseConfig.gameType,
+  title: baseConfig.title,
+  description: options.description ?? options.gameDescription ?? '',
+  moveLimit: options.moveLimit ?? 0,
+  initialRevealSeconds: options.initialRevealSeconds ?? 0,
+  cardUpflipSeconds: options.cardUpflipSeconds ?? 0,
+  cardBackImage: options.cardBackImage ?? '',
+  theme: normalisedTheme,
+  submissionEndpoint: options.submissionEndpoint ?? '',
+  cards: normalisedCards,
   fieldSchema: matchingGameFieldSchema,
-  apiContract: matchingGameApiContract
+  apiContract: matchingGameApiContract,
+  gameDocument: baseGameDocument
 };
 
-export const baseMatchingGameConfig = baseConfig;
+export const baseMatchingGameConfig = baseGameDocument;
 
 export default matchingGameConfig;

--- a/src/games/matching-game/unique-cards.js
+++ b/src/games/matching-game/unique-cards.js
@@ -1,5 +1,7 @@
-import baseConfig from './config/base-config.json';
+import matchingGameConfig from './config';
 
-const uniqueCardsArray = baseConfig.cards.map((card) => ({ ...card }));
+const uniqueCardsArray = Array.isArray(matchingGameConfig.cards)
+  ? matchingGameConfig.cards.map((card) => ({ ...card }))
+  : [];
 
 export default uniqueCardsArray;

--- a/src/games/mystery-manor-game/config/base-config.json
+++ b/src/games/mystery-manor-game/config/base-config.json
@@ -1,52 +1,84 @@
 {
-  "gameId": "mm-001",
-  "gameType": "mystery-manor",
-  "title": "Mystery Manor",
-  "subtitle": "Find the hidden artefacts before time runs out",
-  "description": "Players explore a static scene and tap hidden objects to solve the manor mystery.",
-  "backgroundImage": "/images/mystery-manor-game/background.svg",
-  "sceneImage": "/images/mystery-manor-game/scene.svg",
-  "hintIcon": "/images/mystery-manor-game/hint.svg",
-  "timerSeconds": 120,
-  "maxHints": 3,
-  "submissionEndpoint": "/api/games/mystery-manor/mm-001/results",
-  "items": [
+  "game_id": "mm-001",
+  "game_template_name": "mystery-manor",
+  "name": "Mystery Manor",
+  "merchant_id": "merchant-demo",
+  "game_background_image": "",
+  "game_logo_image": "",
+  "start_date": "2024-01-01T00:00:00.000Z",
+  "end_date": "2024-12-31T23:59:59.000Z",
+  "status": "created",
+  "is_active": true,
+  "hard_play_count_limit": 0,
+  "play_count": 0,
+  "prizes": {},
+  "is_quests_enabled": false,
+  "quests": [],
+  "leaderboard_id": null,
+  "prize_distribution_strategy": "cascade",
+  "createdAt": "2024-01-01T00:00:00.000Z",
+  "updatedAt": "2024-01-01T00:00:00.000Z",
+  "__v": 0,
+  "options": [
     {
-      "id": "silver-key",
-      "name": "Silver Key",
-      "image": "/images/mystery-manor-game/items/silver-key.svg",
-      "hotspot": {
-        "type": "circle",
-        "x": 0.18,
-        "y": 0.52,
-        "radius": 0.05
-      },
-      "hint": "Look near the ornate chest."
+      "input_name": "title",
+      "input_type": "string",
+      "value": "Mystery Manor",
+      "required": true
     },
     {
-      "id": "ancient-scroll",
-      "name": "Ancient Scroll",
-      "image": "/images/mystery-manor-game/items/ancient-scroll.svg",
-      "hotspot": {
-        "type": "rect",
-        "x": 0.61,
-        "y": 0.38,
-        "width": 0.12,
-        "height": 0.08
-      },
-      "hint": "Check the shelves by the staircase."
+      "input_name": "subtitle",
+      "input_type": "string",
+      "value": "Find the hidden artefacts before time runs out",
+      "required": false
     },
     {
-      "id": "mystic-orb",
-      "name": "Mystic Orb",
-      "image": "/images/mystery-manor-game/items/mystic-orb.svg",
-      "hotspot": {
-        "type": "circle",
-        "x": 0.74,
-        "y": 0.72,
-        "radius": 0.07
-      },
-      "hint": "A faint glow comes from the ballroom floor."
+      "input_name": "description",
+      "input_type": "string",
+      "value": "Players explore a static scene and tap hidden objects to solve the manor mystery.",
+      "required": true
+    },
+    {
+      "input_name": "backgroundImage",
+      "input_type": "image",
+      "value": "/images/mystery-manor-game/background.svg",
+      "required": true
+    },
+    {
+      "input_name": "sceneImage",
+      "input_type": "image",
+      "value": "/images/mystery-manor-game/scene.svg",
+      "required": true
+    },
+    {
+      "input_name": "hintIcon",
+      "input_type": "image",
+      "value": "/images/mystery-manor-game/hint.svg",
+      "required": true
+    },
+    {
+      "input_name": "timerSeconds",
+      "input_type": "number",
+      "value": "120",
+      "required": true
+    },
+    {
+      "input_name": "maxHints",
+      "input_type": "number",
+      "value": "3",
+      "required": true
+    },
+    {
+      "input_name": "submissionEndpoint",
+      "input_type": "string",
+      "value": "/api/games/mystery-manor/mm-001/results",
+      "required": true
+    },
+    {
+      "input_name": "items",
+      "input_type": "string",
+      "value": "[{\"id\": \"silver-key\", \"name\": \"Silver Key\", \"image\": \"/images/mystery-manor-game/items/silver-key.svg\", \"hotspot\": {\"type\": \"circle\", \"x\": 0.18, \"y\": 0.52, \"radius\": 0.05}, \"hint\": \"Look near the ornate chest.\"}, {\"id\": \"ancient-scroll\", \"name\": \"Ancient Scroll\", \"image\": \"/images/mystery-manor-game/items/ancient-scroll.svg\", \"hotspot\": {\"type\": \"rect\", \"x\": 0.61, \"y\": 0.38, \"width\": 0.12, \"height\": 0.08}, \"hint\": \"Check the shelves by the staircase.\"}, {\"id\": \"mystic-orb\", \"name\": \"Mystic Orb\", \"image\": \"/images/mystery-manor-game/items/mystic-orb.svg\", \"hotspot\": {\"type\": \"circle\", \"x\": 0.74, \"y\": 0.72, \"radius\": 0.07}, \"hint\": \"A faint glow comes from the ballroom floor.\"}]",
+      "required": true
     }
   ]
 }

--- a/src/games/mystery-manor-game/config/index.js
+++ b/src/games/mystery-manor-game/config/index.js
@@ -1,4 +1,5 @@
-import baseConfig from './base-config.json';
+import baseGameDocument from './base-config.json';
+import { buildGameConfigBase, cloneConfigValue } from '../../../utils/gameConfig';
 
 export const mysteryManorFieldSchema = {
   admin: {
@@ -55,24 +56,42 @@ export const mysteryManorFieldSchema = {
   }
 };
 
+const baseConfig = buildGameConfigBase(baseGameDocument);
+const { options } = baseConfig;
+
+const normalisedItems = Array.isArray(options.items) ? cloneConfigValue(options.items) : [];
+
 export const mysteryManorApiContract = {
-  method: 'GET',
+  method: 'POST',
+  path: '/games/list',
+  requestBody: {
+    game_ids: [baseGameDocument.game_id],
+    merchant_id: baseGameDocument.merchant_id
+  },
   responseType: 'application/json',
-  collection: 'gameConfigs',
-  documentKey: `${baseConfig.gameType}:${baseConfig.gameId}`,
-  notes: 'The backend should serve the scene configuration and assets with URLs accessible by the client.'
+  notes:
+    'POST /games/list returns full Game documents for the requested IDs. Hidden object definitions are delivered as JSON-stringified values within the options array.',
+  sampleResponse: baseGameDocument
 };
 
 const mysteryManorConfig = {
-  ...baseConfig,
-  items: baseConfig.items.map((item) => ({
-    ...item,
-    hotspot: { ...item.hotspot }
-  })),
+  gameId: baseConfig.gameId,
+  gameType: baseConfig.gameType,
+  title: baseConfig.title,
+  subtitle: options.subtitle ?? '',
+  description: options.description ?? '',
+  backgroundImage: options.backgroundImage ?? '',
+  sceneImage: options.sceneImage ?? '',
+  hintIcon: options.hintIcon ?? '',
+  timerSeconds: options.timerSeconds ?? 0,
+  maxHints: options.maxHints ?? 0,
+  submissionEndpoint: options.submissionEndpoint ?? '',
+  items: normalisedItems,
   fieldSchema: mysteryManorFieldSchema,
-  apiContract: mysteryManorApiContract
+  apiContract: mysteryManorApiContract,
+  gameDocument: baseGameDocument
 };
 
-export const baseMysteryManorConfig = baseConfig;
+export const baseMysteryManorConfig = baseGameDocument;
 
 export default mysteryManorConfig;

--- a/src/games/precision-timer-game/config/base-config.json
+++ b/src/games/precision-timer-game/config/base-config.json
@@ -1,11 +1,66 @@
 {
-  "gameId": "precision-001",
-  "gameType": "precision-timer",
-  "title": "Precision Timer Challenge",
-  "subtitle": "Stop the countdown at the perfect moment",
-  "description": "Players start a five-second countdown and try to stop it as close to zero as possible.",
-  "countdownSeconds": 5,
-  "startButtonLabel": "Start Countdown",
-  "stopButtonLabel": "Stop Timer",
-  "submissionEndpoint": "/api/games/precision-timer/precision-001/results"
+  "game_id": "precision-001",
+  "game_template_name": "precision-timer",
+  "name": "Precision Timer Challenge",
+  "merchant_id": "merchant-demo",
+  "game_background_image": "",
+  "game_logo_image": "",
+  "start_date": "2024-01-01T00:00:00.000Z",
+  "end_date": "2024-12-31T23:59:59.000Z",
+  "status": "created",
+  "is_active": true,
+  "hard_play_count_limit": 0,
+  "play_count": 0,
+  "prizes": {},
+  "is_quests_enabled": false,
+  "quests": [],
+  "leaderboard_id": null,
+  "prize_distribution_strategy": "cascade",
+  "createdAt": "2024-01-01T00:00:00.000Z",
+  "updatedAt": "2024-01-01T00:00:00.000Z",
+  "__v": 0,
+  "options": [
+    {
+      "input_name": "title",
+      "input_type": "string",
+      "value": "Precision Timer Challenge",
+      "required": true
+    },
+    {
+      "input_name": "subtitle",
+      "input_type": "string",
+      "value": "Stop the countdown at the perfect moment",
+      "required": false
+    },
+    {
+      "input_name": "description",
+      "input_type": "string",
+      "value": "Players start a five-second countdown and try to stop it as close to zero as possible.",
+      "required": true
+    },
+    {
+      "input_name": "countdownSeconds",
+      "input_type": "number",
+      "value": "5",
+      "required": true
+    },
+    {
+      "input_name": "startButtonLabel",
+      "input_type": "string",
+      "value": "Start Countdown",
+      "required": true
+    },
+    {
+      "input_name": "stopButtonLabel",
+      "input_type": "string",
+      "value": "Stop Timer",
+      "required": true
+    },
+    {
+      "input_name": "submissionEndpoint",
+      "input_type": "string",
+      "value": "/api/games/precision-timer/precision-001/results",
+      "required": true
+    }
+  ]
 }

--- a/src/games/precision-timer-game/config/index.js
+++ b/src/games/precision-timer-game/config/index.js
@@ -1,4 +1,5 @@
-import baseConfig from './base-config.json';
+import baseGameDocument from './base-config.json';
+import { buildGameConfigBase } from '../../../utils/gameConfig';
 
 export const precisionTimerFieldSchema = {
   admin: {
@@ -35,20 +36,37 @@ export const precisionTimerFieldSchema = {
   }
 };
 
+const baseConfig = buildGameConfigBase(baseGameDocument);
+const { options } = baseConfig;
+
 export const precisionTimerApiContract = {
-  method: 'GET',
+  method: 'POST',
+  path: '/games/list',
+  requestBody: {
+    game_ids: [baseGameDocument.game_id],
+    merchant_id: baseGameDocument.merchant_id
+  },
   responseType: 'application/json',
-  collection: 'gameConfigs',
-  documentKey: `${baseConfig.gameType}:${baseConfig.gameId}`,
-  notes: 'Backend services should merge merchant overrides with the base configuration before returning the payload.'
+  notes:
+    'POST /games/list responds with an array of Game documents. Values in the options array are persisted as strings and should be parsed on the client.',
+  sampleResponse: baseGameDocument
 };
 
 const precisionTimerConfig = {
-  ...baseConfig,
+  gameId: baseConfig.gameId,
+  gameType: baseConfig.gameType,
+  title: baseConfig.title,
+  subtitle: options.subtitle ?? '',
+  description: options.description ?? '',
+  countdownSeconds: options.countdownSeconds ?? 0,
+  startButtonLabel: options.startButtonLabel ?? '',
+  stopButtonLabel: options.stopButtonLabel ?? '',
+  submissionEndpoint: options.submissionEndpoint ?? '',
   fieldSchema: precisionTimerFieldSchema,
-  apiContract: precisionTimerApiContract
+  apiContract: precisionTimerApiContract,
+  gameDocument: baseGameDocument
 };
 
-export const basePrecisionTimerConfig = baseConfig;
+export const basePrecisionTimerConfig = baseGameDocument;
 
 export default precisionTimerConfig;

--- a/src/games/stw-game/config/base-config.json
+++ b/src/games/stw-game/config/base-config.json
@@ -1,43 +1,84 @@
 {
-  "gameId": "stw-001",
-  "gameType": "spin-the-wheel",
-  "title": "Spin the Wheel",
-  "description": "Players spin the wheel once per eligible session to receive a random reward.",
-  "wheelImage": "/images/stw-game-assets/wheel.png",
-  "pointerImage": "/images/stw-game-assets/pointer.png",
-  "backgroundImage": "/images/stw-game-assets/background.png",
-  "spinButtonImage": "/images/stw-game-assets/spin-button.png",
-  "maxSpinsPerUser": 1,
-  "spinCooldownSeconds": 86400,
-  "submissionEndpoint": "/api/games/spin-the-wheel/stw-001/results",
-  "prizeSegments": [
+  "game_id": "stw-001",
+  "game_template_name": "spin-the-wheel",
+  "name": "Spin the Wheel",
+  "merchant_id": "merchant-demo",
+  "game_background_image": "",
+  "game_logo_image": "",
+  "start_date": "2024-01-01T00:00:00.000Z",
+  "end_date": "2024-12-31T23:59:59.000Z",
+  "status": "created",
+  "is_active": true,
+  "hard_play_count_limit": 0,
+  "play_count": 0,
+  "prizes": {},
+  "is_quests_enabled": false,
+  "quests": [],
+  "leaderboard_id": null,
+  "prize_distribution_strategy": "cascade",
+  "createdAt": "2024-01-01T00:00:00.000Z",
+  "updatedAt": "2024-01-01T00:00:00.000Z",
+  "__v": 0,
+  "options": [
     {
-      "id": "voucher-5",
-      "label": "$5 Voucher",
-      "probability": 0.2,
-      "image": "/images/stw-game-assets/segments/voucher-5.png",
-      "description": "Discount on next purchase"
+      "input_name": "title",
+      "input_type": "string",
+      "value": "Spin the Wheel",
+      "required": true
     },
     {
-      "id": "voucher-10",
-      "label": "$10 Voucher",
-      "probability": 0.1,
-      "image": "/images/stw-game-assets/segments/voucher-10.png",
-      "description": "Premium discount reward"
+      "input_name": "description",
+      "input_type": "string",
+      "value": "Players spin the wheel once per eligible session to receive a random reward.",
+      "required": true
     },
     {
-      "id": "free-shipping",
-      "label": "Free Shipping",
-      "probability": 0.3,
-      "image": "/images/stw-game-assets/segments/free-shipping.png",
-      "description": "Waive delivery fees"
+      "input_name": "wheelImage",
+      "input_type": "image",
+      "value": "/images/stw-game-assets/wheel.png",
+      "required": true
     },
     {
-      "id": "try-again",
-      "label": "Try Again",
-      "probability": 0.4,
-      "image": "/images/stw-game-assets/segments/try-again.png",
-      "description": "No reward"
+      "input_name": "pointerImage",
+      "input_type": "image",
+      "value": "/images/stw-game-assets/pointer.png",
+      "required": true
+    },
+    {
+      "input_name": "backgroundImage",
+      "input_type": "image",
+      "value": "/images/stw-game-assets/background.png",
+      "required": true
+    },
+    {
+      "input_name": "spinButtonImage",
+      "input_type": "image",
+      "value": "/images/stw-game-assets/spin-button.png",
+      "required": true
+    },
+    {
+      "input_name": "maxSpinsPerUser",
+      "input_type": "number",
+      "value": "1",
+      "required": true
+    },
+    {
+      "input_name": "spinCooldownSeconds",
+      "input_type": "number",
+      "value": "86400",
+      "required": true
+    },
+    {
+      "input_name": "submissionEndpoint",
+      "input_type": "string",
+      "value": "/api/games/spin-the-wheel/stw-001/results",
+      "required": true
+    },
+    {
+      "input_name": "prizeSegments",
+      "input_type": "string",
+      "value": "[{\"id\": \"voucher-5\", \"label\": \"$5 Voucher\", \"probability\": 0.2, \"image\": \"/images/stw-game-assets/segments/voucher-5.png\", \"description\": \"Discount on next purchase\"}, {\"id\": \"voucher-10\", \"label\": \"$10 Voucher\", \"probability\": 0.1, \"image\": \"/images/stw-game-assets/segments/voucher-10.png\", \"description\": \"Premium discount reward\"}, {\"id\": \"free-shipping\", \"label\": \"Free Shipping\", \"probability\": 0.3, \"image\": \"/images/stw-game-assets/segments/free-shipping.png\", \"description\": \"Waive delivery fees\"}, {\"id\": \"try-again\", \"label\": \"Try Again\", \"probability\": 0.4, \"image\": \"/images/stw-game-assets/segments/try-again.png\", \"description\": \"No reward\"}]",
+      "required": true
     }
   ]
 }

--- a/src/games/stw-game/config/index.js
+++ b/src/games/stw-game/config/index.js
@@ -1,4 +1,5 @@
-import baseConfig from './base-config.json';
+import baseGameDocument from './base-config.json';
+import { buildGameConfigBase, cloneConfigValue } from '../../../utils/gameConfig';
 
 export const spinTheWheelFieldSchema = {
   admin: {
@@ -54,21 +55,43 @@ export const spinTheWheelFieldSchema = {
   }
 };
 
+const baseConfig = buildGameConfigBase(baseGameDocument);
+const { options } = baseConfig;
+
+const normalisedPrizeSegments =
+  Array.isArray(options.prizeSegments) ? cloneConfigValue(options.prizeSegments) : [];
+
 export const spinTheWheelApiContract = {
-  method: 'GET',
+  method: 'POST',
+  path: '/games/list',
+  requestBody: {
+    game_ids: [baseGameDocument.game_id],
+    merchant_id: baseGameDocument.merchant_id
+  },
   responseType: 'application/json',
-  collection: 'gameConfigs',
-  documentKey: `${baseConfig.gameType}:${baseConfig.gameId}`,
-  notes: 'Backend should merge merchant overrides with the baseConfig before returning it to the frontend.'
+  notes:
+    'POST /games/list responds with immutable Game documents. Prize segments and other complex fields are returned as JSON-stringified values in the options array.',
+  sampleResponse: baseGameDocument
 };
 
 const spinTheWheelConfig = {
-  ...baseConfig,
-  prizeSegments: baseConfig.prizeSegments.map((segment) => ({ ...segment })),
+  gameId: baseConfig.gameId,
+  gameType: baseConfig.gameType,
+  title: baseConfig.title,
+  description: options.description ?? '',
+  wheelImage: options.wheelImage ?? '',
+  pointerImage: options.pointerImage ?? '',
+  backgroundImage: options.backgroundImage ?? '',
+  spinButtonImage: options.spinButtonImage ?? '',
+  maxSpinsPerUser: options.maxSpinsPerUser ?? 0,
+  spinCooldownSeconds: options.spinCooldownSeconds ?? 0,
+  submissionEndpoint: options.submissionEndpoint ?? '',
+  prizeSegments: normalisedPrizeSegments,
   fieldSchema: spinTheWheelFieldSchema,
-  apiContract: spinTheWheelApiContract
+  apiContract: spinTheWheelApiContract,
+  gameDocument: baseGameDocument
 };
 
-export const baseSpinTheWheelConfig = baseConfig;
+export const baseSpinTheWheelConfig = baseGameDocument;
 
 export default spinTheWheelConfig;

--- a/src/games/vocal-lift-game/config/base-config.json
+++ b/src/games/vocal-lift-game/config/base-config.json
@@ -1,19 +1,96 @@
 {
-  "gameId": "vocal-lift-001",
-  "gameType": "vocal-lift",
-  "title": "Vocal Lift Challenge",
-  "subtitle": "Keep the relic levitating with your voice",
-  "description": "Project your voice to keep the relic suspended. Hold a steady sound for 30 seconds to win.",
-  "instructions": "Press \"Start Challenge\" and keep a steady stream of sound to levitate the relic. Drop below the threshold and it will fall.",
-  "targetSeconds": 30,
-  "soundThreshold": 0.22,
-  "silenceToleranceMs": 450,
-  "ballAsset": {
-    "url": "/images/vocal-lift-game/levitating-orb.svg",
-    "altText": "Golden orb hovering above a glowing pedestal"
-  },
-  "startButtonLabel": "Start Challenge",
-  "stopButtonLabel": "Stop & Reset",
-  "submissionEndpoint": "/api/games/vocal-lift/vocal-lift-001/results",
-  "notes": "Sound intensity is measured from microphone input. The API should resolve the ballAsset.url to a CDN-hosted image when used in production."
+  "game_id": "vocal-lift-001",
+  "game_template_name": "vocal-lift",
+  "name": "Vocal Lift Challenge",
+  "merchant_id": "merchant-demo",
+  "game_background_image": "",
+  "game_logo_image": "",
+  "start_date": "2024-01-01T00:00:00.000Z",
+  "end_date": "2024-12-31T23:59:59.000Z",
+  "status": "created",
+  "is_active": true,
+  "hard_play_count_limit": 0,
+  "play_count": 0,
+  "prizes": {},
+  "is_quests_enabled": false,
+  "quests": [],
+  "leaderboard_id": null,
+  "prize_distribution_strategy": "cascade",
+  "createdAt": "2024-01-01T00:00:00.000Z",
+  "updatedAt": "2024-01-01T00:00:00.000Z",
+  "__v": 0,
+  "options": [
+    {
+      "input_name": "title",
+      "input_type": "string",
+      "value": "Vocal Lift Challenge",
+      "required": true
+    },
+    {
+      "input_name": "subtitle",
+      "input_type": "string",
+      "value": "Keep the relic levitating with your voice",
+      "required": false
+    },
+    {
+      "input_name": "description",
+      "input_type": "string",
+      "value": "Project your voice to keep the relic suspended. Hold a steady sound for 30 seconds to win.",
+      "required": true
+    },
+    {
+      "input_name": "instructions",
+      "input_type": "string",
+      "value": "Press \"Start Challenge\" and keep a steady stream of sound to levitate the relic. Drop below the threshold and it will fall.",
+      "required": true
+    },
+    {
+      "input_name": "targetSeconds",
+      "input_type": "number",
+      "value": "30",
+      "required": true
+    },
+    {
+      "input_name": "soundThreshold",
+      "input_type": "number",
+      "value": "0.22",
+      "required": true
+    },
+    {
+      "input_name": "silenceToleranceMs",
+      "input_type": "number",
+      "value": "450",
+      "required": true
+    },
+    {
+      "input_name": "ballAsset",
+      "input_type": "string",
+      "value": "{\"url\": \"/images/vocal-lift-game/levitating-orb.svg\", \"altText\": \"Golden orb hovering above a glowing pedestal\"}",
+      "required": true
+    },
+    {
+      "input_name": "startButtonLabel",
+      "input_type": "string",
+      "value": "Start Challenge",
+      "required": true
+    },
+    {
+      "input_name": "stopButtonLabel",
+      "input_type": "string",
+      "value": "Stop & Reset",
+      "required": true
+    },
+    {
+      "input_name": "submissionEndpoint",
+      "input_type": "string",
+      "value": "/api/games/vocal-lift/vocal-lift-001/results",
+      "required": true
+    },
+    {
+      "input_name": "notes",
+      "input_type": "string",
+      "value": "Sound intensity is measured from microphone input. The API should resolve the ballAsset.url to a CDN-hosted image when used in production.",
+      "required": false
+    }
+  ]
 }

--- a/src/games/vocal-lift-game/config/index.js
+++ b/src/games/vocal-lift-game/config/index.js
@@ -1,4 +1,5 @@
-import baseConfig from './base-config.json';
+import baseGameDocument from './base-config.json';
+import { buildGameConfigBase, cloneConfigValue } from '../../../utils/gameConfig';
 
 export const vocalLiftFieldSchema = {
   admin: {
@@ -56,21 +57,45 @@ export const vocalLiftFieldSchema = {
   }
 };
 
+const baseConfig = buildGameConfigBase(baseGameDocument);
+const { options } = baseConfig;
+
+const normalisedBallAsset =
+  options.ballAsset && typeof options.ballAsset === 'object' ? cloneConfigValue(options.ballAsset) : {};
+
 export const vocalLiftApiContract = {
-  method: 'GET',
+  method: 'POST',
+  path: '/games/list',
+  requestBody: {
+    game_ids: [baseGameDocument.game_id],
+    merchant_id: baseGameDocument.merchant_id
+  },
   responseType: 'application/json',
-  notes: 'The API should merge campaign overrides into the base configuration before returning the payload.',
-  collection: 'gameConfigs',
-  documentKey: `${baseConfig.gameType}:${baseConfig.gameId}`
+  notes:
+    'POST /games/list responds with Game documents that include all immutable metadata and the options array shown in this mock configuration.',
+  sampleResponse: baseGameDocument
 };
 
 const vocalLiftConfig = {
-  ...baseConfig,
-  ballAsset: { ...baseConfig.ballAsset },
+  gameId: baseConfig.gameId,
+  gameType: baseConfig.gameType,
+  title: baseConfig.title,
+  subtitle: options.subtitle ?? '',
+  description: options.description ?? '',
+  instructions: options.instructions ?? '',
+  targetSeconds: options.targetSeconds ?? 0,
+  soundThreshold: options.soundThreshold ?? 0,
+  silenceToleranceMs: options.silenceToleranceMs ?? 0,
+  ballAsset: normalisedBallAsset,
+  startButtonLabel: options.startButtonLabel ?? '',
+  stopButtonLabel: options.stopButtonLabel ?? '',
+  submissionEndpoint: options.submissionEndpoint ?? '',
+  notes: options.notes ?? '',
   fieldSchema: vocalLiftFieldSchema,
-  apiContract: vocalLiftApiContract
+  apiContract: vocalLiftApiContract,
+  gameDocument: baseGameDocument
 };
 
-export const baseVocalLiftConfig = baseConfig;
+export const baseVocalLiftConfig = baseGameDocument;
 
 export default vocalLiftConfig;

--- a/src/utils/gameConfig.js
+++ b/src/utils/gameConfig.js
@@ -1,0 +1,183 @@
+const NUMERIC_OPTION_TYPES = new Set(['number', 'integer', 'float', 'double', 'decimal']);
+const JSON_OPTION_TYPES = new Set(['json', 'object', 'array']);
+const MULTI_VALUE_OPTION_TYPES = new Set(['list', 'multi-select', 'multiselect']);
+const BOOLEAN_TRUE_VALUES = new Set(['true', '1', 'yes', 'y', 'on']);
+const BOOLEAN_FALSE_VALUES = new Set(['false', '0', 'no', 'n', 'off']);
+
+const toLowerCase = (value) => (typeof value === 'string' ? value.toLowerCase() : value);
+
+const tryParseJson = (value) => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return value;
+  }
+
+  const firstChar = trimmed[0];
+  const shouldAttemptParse = firstChar === '{' || firstChar === '[';
+
+  if (!shouldAttemptParse) {
+    return value;
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch (error) {
+    return value;
+  }
+};
+
+const parseBoolean = (value) => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+
+    if (BOOLEAN_TRUE_VALUES.has(normalized)) {
+      return true;
+    }
+
+    if (BOOLEAN_FALSE_VALUES.has(normalized)) {
+      return false;
+    }
+  }
+
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+
+  return Boolean(value);
+};
+
+const parseNumeric = (value) => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const parsed = Number(value.trim());
+
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  return parsed;
+};
+
+export const parseGameOptionValue = (option) => {
+  if (!option || typeof option !== 'object') {
+    return undefined;
+  }
+
+  const { input_type: rawInputType, value } = option;
+  const inputType = toLowerCase(rawInputType);
+
+  if (NUMERIC_OPTION_TYPES.has(inputType)) {
+    const numericValue = parseNumeric(value);
+    return numericValue !== null ? numericValue : value;
+  }
+
+  if (inputType === 'boolean') {
+    return parseBoolean(value);
+  }
+
+  if (JSON_OPTION_TYPES.has(inputType) || MULTI_VALUE_OPTION_TYPES.has(inputType)) {
+    return tryParseJson(value);
+  }
+
+  if (typeof value === 'string') {
+    return tryParseJson(value);
+  }
+
+  return value;
+};
+
+export const mapGameOptions = (options = []) => {
+  return options.reduce(
+    (accumulator, option) => {
+      if (!option || typeof option !== 'object') {
+        return accumulator;
+      }
+
+      const { input_name: inputName } = option;
+
+      if (!inputName) {
+        return accumulator;
+      }
+
+      const parsedValue = parseGameOptionValue(option);
+      accumulator.values[inputName] = parsedValue;
+      accumulator.meta[inputName] = { ...option };
+
+      return accumulator;
+    },
+    { values: {}, meta: {} }
+  );
+};
+
+export const normaliseGameDocument = (gameDocument) => {
+  if (!gameDocument || typeof gameDocument !== 'object') {
+    return {
+      gameId: undefined,
+      gameType: undefined,
+      name: undefined,
+      options: {},
+      optionMeta: {},
+      metadata: {}
+    };
+  }
+
+  const { options: optionsArray = [], ...metadata } = gameDocument;
+  const { values: options, meta: optionMeta } = mapGameOptions(optionsArray);
+
+  const gameId = metadata.game_id ?? metadata.gameId;
+  const gameType = metadata.game_template_name ?? metadata.gameType;
+  const resolvedName = metadata.name ?? options.title ?? options.gameTitle;
+
+  return {
+    gameId,
+    gameType,
+    name: resolvedName,
+    options,
+    optionMeta,
+    metadata
+  };
+};
+
+export const buildGameConfigBase = (gameDocument) => {
+  const { gameId, gameType, name, options, optionMeta, metadata } = normaliseGameDocument(gameDocument);
+  const title = options.title ?? options.gameTitle ?? name ?? '';
+
+  return {
+    gameId,
+    gameType,
+    title,
+    name: name ?? title,
+    options,
+    optionMeta,
+    metadata
+  };
+};
+
+export const cloneConfigValue = (value) => {
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneConfigValue(item));
+  }
+
+  if (value && typeof value === 'object') {
+    return { ...value };
+  }
+
+  return value;
+};
+
+export default normaliseGameDocument;


### PR DESCRIPTION
## Summary
- convert each base game config to mirror the Game document payload with metadata and options arrays
- add a shared gameConfig helper and update every game config module to derive component props from parsed option values
- refresh unique card exports to pull from the transformed configs for flip-card experiences

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cfe3311de4832aa04cfd2001200886