### PR TITLE
Fix flip card back visibility

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -15,3 +15,8 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.backface-hidden {
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+}


### PR DESCRIPTION
## Summary
- add global CSS utility to hide card backfaces so the card back image renders correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfee9b94f0832a8bc6758b0ae8687f