### PR TITLE
Beautify precision timer and redesign gachapon layout

### DIFF
--- a/src/games/gachapon-game/gachapon-game.css
+++ b/src/games/gachapon-game/gachapon-game.css
@@ -126,3 +126,82 @@
   background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0) 55%);
   mix-blend-mode: screen;
 }
+
+.gachapon-start-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.1rem 3.5rem;
+  border: none;
+  border-radius: 9999px;
+  background: transparent;
+  color: #fff7ed;
+  font-size: 1.25rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 18px 0 #9a3412, 0 28px 45px rgba(249, 115, 22, 0.55);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.gachapon-start-button::before {
+  content: '';
+  position: absolute;
+  inset: -18px -28px -40px;
+  border-radius: inherit;
+  background: radial-gradient(circle, rgba(249, 115, 22, 0.35), rgba(249, 115, 22, 0));
+  z-index: 0;
+}
+
+.gachapon-start-button::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at 50% 20%, #fde68a 0%, #fb923c 45%, #f97316 70%, #ea580c 100%);
+  box-shadow: inset 0 -10px 0 rgba(124, 45, 18, 0.6), inset 0 8px 18px rgba(255, 255, 255, 0.25);
+  z-index: 1;
+  transition: inherit;
+}
+
+.gachapon-start-button span {
+  position: relative;
+  z-index: 2;
+  text-shadow: 0 4px 12px rgba(120, 53, 15, 0.6);
+}
+
+.gachapon-start-button:hover:not(:disabled) {
+  transform: translateY(-3px);
+  box-shadow: 0 20px 0 #b45309, 0 34px 55px rgba(249, 115, 22, 0.6);
+}
+
+.gachapon-start-button:hover:not(:disabled)::after {
+  filter: brightness(1.05);
+}
+
+.gachapon-start-button:active:not(:disabled) {
+  transform: translateY(6px);
+  box-shadow: 0 10px 0 #9a3412, 0 18px 32px rgba(153, 27, 27, 0.45);
+}
+
+.gachapon-start-button:active:not(:disabled)::after {
+  box-shadow: inset 0 -4px 0 rgba(124, 45, 18, 0.6), inset 0 4px 12px rgba(255, 255, 255, 0.25);
+}
+
+.gachapon-start-button:disabled {
+  cursor: not-allowed;
+  filter: grayscale(0.3) brightness(0.92);
+  box-shadow: 0 14px 0 #9a3412, 0 20px 32px rgba(15, 23, 42, 0.45);
+}
+
+.gachapon-start-button:disabled::after {
+  background: radial-gradient(circle at 50% 30%, #fcd34d 0%, #fb923c 55%, #f97316 90%);
+}
+
+.gachapon-start-button:focus-visible {
+  outline: 4px solid rgba(253, 224, 71, 0.7);
+  outline-offset: 6px;
+}

--- a/src/games/gachapon-game/gachapon-game.js
+++ b/src/games/gachapon-game/gachapon-game.js
@@ -178,38 +178,95 @@ const GachaponGame = () => {
   };
 
   return (
-    <div className="min-h-screen bg-slate-950 py-10 text-white">
-      <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4">
-        <div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
-          <div>
-            <h1 className="text-3xl font-semibold text-white sm:text-4xl">Celestial Capsule Gachapon</h1>
-            <p className="mt-2 max-w-xl text-sm text-slate-300 sm:text-base">
-              Pull the lever to see what treasure is sealed within the capsule. Every attempt draws from the same
-              prize pool, and your luck determines the rarity of your reward.
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 py-12 text-white">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-16 left-16 h-60 w-60 rounded-full bg-indigo-500/25 blur-3xl" />
+        <div className="absolute top-1/3 right-12 h-72 w-72 rounded-full bg-violet-500/20 blur-3xl" />
+        <div className="absolute bottom-0 left-1/4 h-72 w-72 rounded-full bg-fuchsia-500/15 blur-3xl" />
+      </div>
+
+      <div className="relative mx-auto flex w-full max-w-5xl flex-col items-center px-4">
+        <div className="text-center">
+          <p className="text-sm uppercase tracking-[0.35em] text-indigo-300">Arcade Feature</p>
+          <h1 className="mt-2 text-4xl font-semibold text-white sm:text-5xl">Celestial Capsule Gachapon</h1>
+          <p className="mt-4 max-w-2xl text-sm text-slate-300 sm:text-base">
+            Pull the lever to see what treasure is sealed within the capsule. Every attempt draws from the same prize
+            pool, and your luck determines the rarity of your reward.
+          </p>
+        </div>
+
+        <div className="mt-10 w-full max-w-3xl overflow-hidden rounded-[2.5rem] border border-indigo-400/30 bg-slate-900/80 p-10 text-center shadow-2xl shadow-indigo-900/40 backdrop-blur">
+          <div className="flex flex-col items-center gap-8">
+            <p className="text-xs uppercase tracking-[0.35em] text-indigo-300">Capsule Machine</p>
+            <div className="gachapon-stage relative flex h-80 w-full max-w-md items-center justify-center rounded-[2rem] border border-indigo-400/30 bg-slate-950/70 p-8 shadow-[0_24px_45px_rgba(15,23,42,0.55)]">
+              <div className="relative flex h-full w-full flex-col items-center justify-center">
+                <div
+                  className={`gachapon-box ${
+                    animationPhase === 'shaking' ? 'gachapon-box--shake' : ''
+                  } ${animationPhase === 'explosion' ? 'gachapon-box--hidden' : ''}`}
+                >
+                  <div
+                    className={`gachapon-capsule ${
+                      animationPhase === 'explosion' || animationPhase === 'result' ? 'gachapon-capsule--hidden' : ''
+                    }`}
+                    style={{ background: result?.prize?.capsuleColor ?? '#38bdf8' }}
+                  />
+                  <div className="absolute inset-x-8 bottom-6 rounded-full bg-slate-800/80 py-3 text-xs uppercase tracking-[0.3em] text-slate-400">
+                    {animationPhase === 'shaking'
+                      ? 'Shaking…'
+                      : animationPhase === 'explosion'
+                      ? 'Opening…'
+                      : animationPhase === 'result'
+                      ? 'Capsule opened!'
+                      : 'Ready'}
+                  </div>
+                </div>
+                {animationPhase === 'explosion' && (
+                  <div key={animationKey} className="gachapon-explosion" />
+                )}
+              </div>
+            </div>
+            <p className="max-w-lg text-sm text-indigo-100/80">
+              Every shake builds anticipation before the capsule bursts open to reveal your prize. Hold tight and watch
+              the glow change as the machine prepares your reward.
             </p>
-          </div>
-          <div className="flex flex-col gap-2 sm:flex-row">
-            <button
-              type="button"
-              className="rounded-full border border-slate-700 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:text-white"
-              onClick={() => navigate('/')}
-            >
-              Back to Store
-            </button>
-            <button
-              type="button"
-              onClick={handleAttempt}
-              disabled={isAttempting || loadingPrizes}
-              className="flex items-center justify-center rounded-full bg-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400 disabled:cursor-not-allowed disabled:bg-slate-600"
-            >
-              {isAttempting ? 'Dispensing…' : 'Start Gachapon'}
-            </button>
+            {attemptError && (
+              <p className="w-full rounded-2xl border border-rose-500/40 bg-rose-500/10 px-5 py-3 text-sm text-rose-200" role="status">
+                {attemptError}
+              </p>
+            )}
           </div>
         </div>
 
-        <div className="flex flex-col gap-6 lg:flex-row">
-          <div className="flex flex-1 flex-col gap-6 rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-2xl shadow-indigo-900/30">
-            <h2 className="text-lg font-semibold text-white">Prize Showcase</h2>
+        <div className="mt-10 flex flex-col items-center gap-4">
+          <button
+            type="button"
+            onClick={handleAttempt}
+            disabled={isAttempting || loadingPrizes}
+            className="gachapon-start-button"
+          >
+            <span>{isAttempting ? 'Dispensing…' : 'Start Gachapon'}</span>
+          </button>
+          <button
+            type="button"
+            className="rounded-full border border-slate-700/70 px-6 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:text-white"
+            onClick={() => navigate('/')}
+          >
+            Back to Store
+          </button>
+        </div>
+
+        <div className="mt-12 w-full overflow-hidden rounded-[2.5rem] border border-slate-800/70 bg-slate-900/80 p-8 shadow-2xl shadow-indigo-900/30 backdrop-blur">
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-col items-center justify-between gap-3 text-center sm:flex-row sm:text-left">
+              <div>
+                <h2 className="text-lg font-semibold text-white sm:text-xl">Prize Showcase</h2>
+                <p className="mt-1 text-sm text-slate-400">Browse every prize currently loaded into the capsule.</p>
+              </div>
+              <span className="rounded-full border border-slate-700/60 bg-slate-950/60 px-4 py-1 text-xs uppercase tracking-[0.3em] text-slate-300">
+                {prizes.length} Rewards
+              </span>
+            </div>
             {loadingPrizes ? (
               <p className="text-sm text-slate-400">Loading prize lineup…</p>
             ) : prizeError ? (
@@ -225,40 +282,6 @@ const GachaponGame = () => {
                 ))}
               </div>
             )}
-          </div>
-
-          <div className="gachapon-stage flex flex-1 items-center justify-center rounded-2xl border border-slate-800 bg-slate-900/60 p-6 text-center shadow-2xl shadow-indigo-900/30">
-            <div className="relative flex h-80 w-full flex-col items-center justify-center">
-              <div
-                className={`gachapon-box ${
-                  animationPhase === 'shaking' ? 'gachapon-box--shake' : ''
-                } ${animationPhase === 'explosion' ? 'gachapon-box--hidden' : ''}`}
-              >
-                <div
-                  className={`gachapon-capsule ${
-                    animationPhase === 'explosion' || animationPhase === 'result' ? 'gachapon-capsule--hidden' : ''
-                  }`}
-                  style={{ background: result?.prize?.capsuleColor ?? '#38bdf8' }}
-                />
-                <div className="absolute inset-x-8 bottom-6 rounded-full bg-slate-800/80 py-3 text-xs uppercase tracking-[0.3em] text-slate-400">
-                  {animationPhase === 'shaking'
-                    ? 'Shaking…'
-                    : animationPhase === 'explosion'
-                    ? 'Opening…'
-                    : animationPhase === 'result'
-                    ? 'Capsule opened!'
-                    : 'Ready'}
-                </div>
-              </div>
-              {animationPhase === 'explosion' && (
-                <div key={animationKey} className="gachapon-explosion" />
-              )}
-              {attemptError && (
-                <p className="mt-6 rounded-lg border border-rose-500/40 bg-rose-500/10 px-4 py-2 text-sm text-rose-200">
-                  {attemptError}
-                </p>
-              )}
-            </div>
           </div>
         </div>
       </div>

--- a/src/games/precision-timer-game/precision-timer-game.js
+++ b/src/games/precision-timer-game/precision-timer-game.js
@@ -143,58 +143,123 @@ const PrecisionTimerGame = ({ config = precisionTimerConfig }) => {
       });
   };
 
+  const statusLabels = {
+    idle: 'Ready',
+    counting: 'Counting Down',
+    submitting: 'Submitting',
+    submitted: 'Complete'
+  };
+
+  const statusMessage = (() => {
+    switch (status) {
+      case 'counting':
+        return 'Trust your timing and tap stop the moment you sense the countdown reaching zero.';
+      case 'submitting':
+        return 'Calculating how close you landed—hold tight while we lock in your precision.';
+      case 'submitted':
+        return 'Great timing! Preparing your results.';
+      default:
+        return 'When you are ready, start the countdown and see how precise your instincts can be.';
+    }
+  })();
+
+  const formattedCountdown = formatSeconds(countdownSeconds);
+
   if (result) {
     return <ResultsScreen {...result} />;
   }
 
   return (
-    <div className="flex flex-col items-center justify-center gap-6 p-10 text-center">
-      <header className="space-y-2">
-        <h2 className="text-3xl font-semibold">{config?.title}</h2>
-        {config?.subtitle && <p className="text-lg text-gray-600">{config.subtitle}</p>}
-        {config?.description && (
-          <p className="max-w-2xl text-gray-500">{config.description}</p>
-        )}
-      </header>
-
-      <div className="flex flex-col items-center gap-4">
-        <div className="rounded-lg border border-gray-200 bg-white px-8 py-6 shadow-sm">
-          <span className="text-6xl font-mono tabular-nums text-gray-800">{displaySeconds}</span>
-        </div>
-        <p className="text-sm text-gray-500">
-          Stop the timer as close to zero as possible. The smaller the difference, the better your score.
-        </p>
-        <div className="flex flex-wrap items-center justify-center gap-3">
-          <button
-            type="button"
-            onClick={startCountdown}
-            disabled={status !== 'idle'}
-            className="rounded-md bg-blue-600 px-5 py-2 text-white shadow disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {config?.startButtonLabel || 'Start'}
-          </button>
-          <button
-            type="button"
-            onClick={stopCountdown}
-            disabled={status !== 'counting'}
-            className="rounded-md bg-emerald-600 px-5 py-2 text-white shadow disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {config?.stopButtonLabel || 'Stop'}
-          </button>
-        </div>
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 py-16 px-4 text-white">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-24 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-sky-500/25 blur-3xl" />
+        <div className="absolute bottom-0 right-12 h-72 w-72 rounded-full bg-violet-500/20 blur-3xl" />
+        <div className="absolute -bottom-20 left-8 h-64 w-64 rounded-full bg-emerald-500/20 blur-3xl" />
       </div>
 
-      {status === 'counting' && (
-        <p className="text-sm text-gray-500">
-          Countdown started from {formatSeconds(countdownSeconds)} seconds. Press stop to lock in your attempt.
-        </p>
-      )}
+      <div className="relative mx-auto flex w-full max-w-4xl flex-col items-center gap-10">
+        <header className="space-y-3 text-center">
+          <p className="text-sm uppercase tracking-[0.35em] text-sky-300">Precision Timer</p>
+          <h2 className="text-4xl font-semibold text-white drop-shadow">{config?.title}</h2>
+          {config?.subtitle && <p className="text-lg text-slate-300">{config.subtitle}</p>}
+          {config?.description && (
+            <p className="mx-auto max-w-2xl text-base text-slate-400">{config.description}</p>
+          )}
+        </header>
 
-      {isSubmitting && !result && (
-        <p className="text-sm font-medium text-gray-600" role="status" aria-live="polite">
-          Submitting results...
-        </p>
-      )}
+        <div className="relative w-full overflow-hidden rounded-[2rem] border border-slate-800/60 bg-slate-900/70 p-10 text-center shadow-2xl shadow-sky-900/30 backdrop-blur">
+          <div className="absolute inset-x-16 top-0 h-px bg-gradient-to-r from-transparent via-sky-400/60 to-transparent" />
+          <div className="flex flex-col items-center gap-10">
+            <div className="flex flex-col items-center gap-4">
+              <span className="rounded-full border border-sky-400/60 bg-slate-900/80 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-sky-200">
+                {statusLabels[status] || statusLabels.idle}
+              </span>
+              <div className="relative">
+                <div className="absolute inset-0 -translate-y-6 scale-125 rounded-full bg-sky-500/25 blur-3xl" />
+                <div className="relative flex h-56 w-56 items-center justify-center rounded-full border border-sky-400/40 bg-slate-950/80 shadow-[0_22px_45px_rgba(15,23,42,0.55)]">
+                  <div className="absolute inset-4 rounded-full border border-sky-500/20 bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900 shadow-inner shadow-[inset_0_-8px_18px_rgba(15,23,42,0.55)]" />
+                  <span className="relative text-6xl font-mono font-semibold tabular-nums text-sky-100">{displaySeconds}</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="grid w-full gap-4 text-left text-sm text-slate-300 sm:grid-cols-2">
+              <div className="rounded-2xl border border-slate-800 bg-slate-950/60 p-5">
+                <h3 className="text-xs uppercase tracking-[0.25em] text-slate-400">Challenge Brief</h3>
+                <p className="mt-2 text-slate-200">
+                  Stop the timer as close to zero as possible. Every millisecond counts towards your final score.
+                </p>
+              </div>
+              <div className="flex items-center justify-between rounded-2xl border border-slate-800 bg-slate-950/60 p-5">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.25em] text-slate-400">Countdown Duration</p>
+                  <p className="mt-2 text-2xl font-semibold text-white">{formattedCountdown}s</p>
+                </div>
+                <div className="text-right text-xs text-slate-500">
+                  <p>Press stop when you sense the final second vanish.</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center justify-center gap-4">
+              <button
+                type="button"
+                onClick={startCountdown}
+                disabled={status !== 'idle'}
+                className="group relative inline-flex items-center justify-center overflow-hidden rounded-full bg-gradient-to-r from-emerald-400 via-sky-500 to-indigo-500 px-8 py-3 text-lg font-semibold text-white shadow-[0_18px_35px_rgba(14,116,144,0.45)] transition-transform disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                <span className="relative drop-shadow-[0_2px_6px_rgba(6,182,212,0.5)]">
+                  {config?.startButtonLabel || 'Start'}
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={stopCountdown}
+                disabled={status !== 'counting'}
+                className="group relative inline-flex items-center justify-center overflow-hidden rounded-full bg-gradient-to-r from-rose-500 via-orange-500 to-amber-500 px-8 py-3 text-lg font-semibold text-white shadow-[0_18px_35px_rgba(190,24,93,0.45)] transition-transform disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                <span className="relative drop-shadow-[0_2px_6px_rgba(249,115,22,0.5)]">
+                  {config?.stopButtonLabel || 'Stop'}
+                </span>
+              </button>
+            </div>
+
+            <div className="w-full rounded-2xl border border-slate-800 bg-slate-950/60 p-5 text-sm text-slate-200">
+              <p>{statusMessage}</p>
+              {status === 'counting' && (
+                <p className="mt-2 text-xs uppercase tracking-[0.25em] text-slate-500">
+                  Countdown began at {formattedCountdown} seconds
+                </p>
+              )}
+              {isSubmitting && !result && (
+                <p className="mt-2 text-xs font-semibold uppercase tracking-[0.3em] text-sky-300" role="status" aria-live="polite">
+                  Submitting results…
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/games/precision-timer-game/results-screen.js
+++ b/src/games/precision-timer-game/results-screen.js
@@ -19,60 +19,77 @@ const ResultsScreen = ({
   score,
   submittedAt
 }) => {
+  const metrics = [
+    typeof countdownSeconds !== 'undefined'
+      ? { label: 'Countdown Duration', value: `${formatSeconds(countdownSeconds)}s` }
+      : null,
+    { label: 'Pressed At', value: `${formatSeconds(pressedAtSeconds)}s` },
+    { label: 'Time Remaining', value: `${formatSeconds(timeRemainingSeconds)}s` },
+    { label: 'Accuracy Score', value: `${formatSeconds(score)}s` }
+  ].filter(Boolean);
+
+  const metaItems = [
+    gameType ? { label: 'Game Type', value: gameType } : null,
+    gameId ? { label: 'Game ID', value: gameId } : null,
+    submittedAt
+      ? { label: 'Submitted At', value: new Date(submittedAt).toLocaleString() }
+      : null
+  ].filter(Boolean);
+
+  const resolvedOutcome = outcome || 'Completed';
+
   return (
-    <div className="flex flex-col items-center justify-center gap-4 p-10 text-center">
-      <h2 className="text-3xl font-semibold">Countdown Results</h2>
-      {gameTitle && <p className="text-lg text-gray-600">{gameTitle}</p>}
-      <div className="w-full max-w-md rounded-lg border border-gray-200 bg-white p-6 text-left shadow-sm">
-        <dl className="space-y-2 text-sm text-gray-700">
-          {gameType && (
-            <div className="flex justify-between">
-              <dt className="font-medium text-gray-500">Game Type</dt>
-              <dd className="text-gray-800">{gameType}</dd>
-            </div>
-          )}
-          {gameId && (
-            <div className="flex justify-between">
-              <dt className="font-medium text-gray-500">Game ID</dt>
-              <dd className="text-gray-800">{gameId}</dd>
-            </div>
-          )}
-          {typeof countdownSeconds !== 'undefined' && (
-            <div className="flex justify-between">
-              <dt className="font-medium text-gray-500">Countdown Duration</dt>
-              <dd className="text-gray-800">{formatSeconds(countdownSeconds)}s</dd>
-            </div>
-          )}
-          <div className="flex justify-between">
-            <dt className="font-medium text-gray-500">Outcome</dt>
-            <dd className="text-gray-800">{outcome || 'Completed'}</dd>
-          </div>
-          <div className="flex justify-between">
-            <dt className="font-medium text-gray-500">Pressed At</dt>
-            <dd className="text-gray-800">{formatSeconds(pressedAtSeconds)}s</dd>
-          </div>
-          <div className="flex justify-between">
-            <dt className="font-medium text-gray-500">Time Remaining</dt>
-            <dd className="text-gray-800">{formatSeconds(timeRemainingSeconds)}s</dd>
-          </div>
-          <div className="flex justify-between">
-            <dt className="font-medium text-gray-500">Accuracy Score</dt>
-            <dd className="text-gray-800">{formatSeconds(score)}s</dd>
-          </div>
-          {submittedAt && (
-            <div className="flex justify-between">
-              <dt className="font-medium text-gray-500">Submitted At</dt>
-              <dd className="text-gray-800">{new Date(submittedAt).toLocaleString()}</dd>
-            </div>
-          )}
-        </dl>
-        <p className="mt-4 text-xs text-gray-500">
-          A lower accuracy score means you stopped the timer closer to zero.
-        </p>
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 py-16 px-4 text-white">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-16 left-1/3 h-72 w-72 -translate-x-1/2 rounded-full bg-sky-500/25 blur-3xl" />
+        <div className="absolute bottom-0 right-10 h-72 w-72 rounded-full bg-violet-500/20 blur-3xl" />
+        <div className="absolute bottom-16 left-12 h-56 w-56 rounded-full bg-emerald-500/20 blur-3xl" />
       </div>
-      <Link to="/" className="text-blue-600 hover:underline">
-        Back to Home
-      </Link>
+
+      <div className="relative mx-auto flex w-full max-w-4xl flex-col items-center gap-10 text-center">
+        <header className="space-y-4">
+          <p className="text-sm uppercase tracking-[0.35em] text-sky-300">Precision Timer</p>
+          <h2 className="text-4xl font-semibold text-white drop-shadow">Countdown Results</h2>
+          {gameTitle && <p className="text-lg text-slate-200">{gameTitle}</p>}
+        </header>
+
+        <span className="rounded-full border border-sky-400/40 bg-slate-900/70 px-6 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-sky-200">
+          {resolvedOutcome}
+        </span>
+
+        <div className="w-full overflow-hidden rounded-[2rem] border border-slate-800/70 bg-slate-900/80 p-10 text-left shadow-2xl shadow-sky-900/30 backdrop-blur">
+          <dl className="grid gap-5 sm:grid-cols-2">
+            {metrics.map((metric) => (
+              <div key={metric.label} className="rounded-2xl border border-slate-800 bg-slate-950/60 p-6">
+                <dt className="text-xs uppercase tracking-[0.25em] text-slate-400">{metric.label}</dt>
+                <dd className="mt-3 text-3xl font-semibold text-white">{metric.value}</dd>
+              </div>
+            ))}
+          </dl>
+
+          {metaItems.length > 0 && (
+            <dl className="mt-8 grid gap-4 rounded-2xl border border-slate-800 bg-slate-950/60 p-6 text-sm text-slate-300 sm:grid-cols-2">
+              {metaItems.map((item) => (
+                <div key={item.label} className="flex flex-col gap-1">
+                  <dt className="text-xs uppercase tracking-[0.25em] text-slate-500">{item.label}</dt>
+                  <dd className="text-base text-slate-200">{item.value}</dd>
+                </div>
+              ))}
+            </dl>
+          )}
+
+          <p className="mt-8 rounded-2xl border border-sky-500/20 bg-sky-500/10 px-6 py-4 text-sm text-sky-100">
+            A lower accuracy score means you stopped the timer closer to zero. Keep practicing to hone your instinctive timing.
+          </p>
+        </div>
+
+        <Link
+          to="/"
+          className="rounded-full border border-sky-400/40 px-6 py-2 text-sm font-medium text-sky-100 transition hover:border-sky-300 hover:text-white"
+        >
+          Back to Store
+        </Link>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- restyled the precision timer experience with a cinematic backdrop, gradient timer display, contextual messaging, and upgraded action buttons
- refreshed the precision timer results view to match the new aesthetic with stat cards, meta details, and guidance copy
- elevated the gachapon layout by spotlighting the machine, centering a carnival-style start control, and moving the prize showcase into its own panel with a rewards badge
- added bespoke styling for the new push-button interaction to deliver a 3D arcade feel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d006e54d9c832a8f32d9d6e6a1b216