### PR TITLE
Refactor scratch card and gachapon games around template configs

### DIFF
--- a/src/games/gachapon-game/config/index.js
+++ b/src/games/gachapon-game/config/index.js
@@ -1,0 +1,130 @@
+import template from './template.json';
+
+const previewMetadata = {
+  gameId: 'gacha-001',
+  merchantId: 'merchant-demo'
+};
+
+const previewOptions = {
+  ...template.defaults
+};
+
+const templateFields = Array.isArray(template.fields) ? template.fields : [];
+
+const serialiseOptionValue = (field, value) => {
+  if (value === null) {
+    return null;
+  }
+
+  if (typeof value === 'undefined') {
+    return '';
+  }
+
+  const fieldType = field?.type;
+
+  if (fieldType === 'number' && typeof value === 'number') {
+    return value.toString();
+  }
+
+  if (fieldType === 'boolean' && typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+
+  if (fieldType === 'array' || fieldType === 'object' || fieldType === 'json') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value) || typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+
+  return String(value);
+};
+
+const buildOptionEntry = (field) => {
+  const optionName = field?.name;
+
+  if (!optionName) {
+    return null;
+  }
+
+  const hasCustomValue = Object.prototype.hasOwnProperty.call(previewOptions, optionName);
+  const optionValue = hasCustomValue ? previewOptions[optionName] : field?.default;
+
+  if (typeof optionValue === 'undefined') {
+    return null;
+  }
+
+  return {
+    input_name: optionName,
+    input_type: field?.type ?? 'string',
+    required: Boolean(field?.required),
+    value: serialiseOptionValue(field, optionValue)
+  };
+};
+
+const previewGameDocument = {
+  game_id: previewMetadata.gameId,
+  game_template_name: template.gameType,
+  merchant_id: previewMetadata.merchantId,
+  name: previewOptions.title ?? template.metadata?.name ?? '',
+  status: 'draft',
+  is_active: true,
+  hard_play_count_limit: 0,
+  play_count: 0,
+  prize_distribution_strategy: 'cascade',
+  options: templateFields.map((field) => buildOptionEntry(field)).filter(Boolean)
+};
+
+const gachaponConfig = {
+  gameId: previewMetadata.gameId,
+  gameType: template.gameType,
+  title: previewOptions.title,
+  tagline: previewOptions.tagline,
+  description: previewOptions.description,
+  ctaLabel: previewOptions.ctaLabel,
+  preparingLabel: previewOptions.preparingLabel,
+  resultModalTitle: previewOptions.resultModalTitle,
+  capsuleMachineLabel: previewOptions.capsuleMachineLabel,
+  capsuleStatusIdleLabel: previewOptions.capsuleStatusIdleLabel,
+  capsuleStatusPreparingLabel: previewOptions.capsuleStatusPreparingLabel,
+  capsuleStatusShakingLabel: previewOptions.capsuleStatusShakingLabel,
+  capsuleStatusOpeningLabel: previewOptions.capsuleStatusOpeningLabel,
+  capsuleStatusResultLabel: previewOptions.capsuleStatusResultLabel,
+  capsuleDescription: previewOptions.capsuleDescription,
+  prizeShowcaseTitle: previewOptions.prizeShowcaseTitle,
+  prizeShowcaseDescription: previewOptions.prizeShowcaseDescription,
+  prizeListLoadingText: previewOptions.prizeListLoadingText,
+  prizeListErrorText: previewOptions.prizeListErrorText,
+  attemptErrorText: previewOptions.attemptErrorText,
+  defaultFlairText: previewOptions.defaultFlairText,
+  defaultCapsuleColor: previewOptions.defaultCapsuleColor,
+  submissionEndpoint: previewOptions.submissionEndpoint,
+  shakeDurationMs: previewOptions.shakeDurationMs,
+  explosionDurationMs: previewOptions.explosionDurationMs,
+  prizes: previewOptions.prizes,
+  template,
+  templateVersion: template.version,
+  previewOptions,
+  previewMetadata,
+  fields: templateFields,
+  apiContract: {
+    method: 'POST',
+    path: '/games/list',
+    requestBody: {
+      game_ids: [previewMetadata.gameId],
+      merchant_id: previewMetadata.merchantId
+    },
+    responseType: 'application/json',
+    notes:
+      'POST /games/list returns Game documents with option values serialised as strings. Structured defaults are stringified during publishing.',
+    sampleResponse: previewGameDocument
+  },
+  gameDocument: previewGameDocument
+};
+
+export const gachaponTemplate = template;
+export const gachaponPreviewOptions = previewOptions;
+export const gachaponPreviewGameDocument = previewGameDocument;
+
+export default gachaponConfig;

--- a/src/games/gachapon-game/config/template.json
+++ b/src/games/gachapon-game/config/template.json
@@ -1,0 +1,300 @@
+{
+  "templateId": "gachapon",
+  "gameType": "gachapon",
+  "version": 1,
+  "metadata": {
+    "name": "Celestial Capsule Gachapon",
+    "description": "Dispense a capsule and reveal a randomised reward with dramatic flair.",
+    "thumbnailUrl": "/images/gachapon-game-thumb.png"
+  },
+  "defaults": {
+    "title": "Celestial Capsule Gachapon",
+    "tagline": "Arcade Feature",
+    "description": "Pull the lever to see what treasure is sealed within the capsule. Every attempt draws from the same prize pool, and your luck determines the rarity of your reward.",
+    "ctaLabel": "Start Gachapon",
+    "preparingLabel": "Dispensing…",
+    "resultModalTitle": "Gachapon Result",
+    "capsuleMachineLabel": "Capsule Machine",
+    "capsuleStatusIdleLabel": "Ready",
+    "capsuleStatusPreparingLabel": "Priming capsule…",
+    "capsuleStatusShakingLabel": "Shaking…",
+    "capsuleStatusOpeningLabel": "Opening…",
+    "capsuleStatusResultLabel": "Capsule opened!",
+    "capsuleDescription": "Every shake builds anticipation before the capsule bursts open to reveal your prize. Hold tight and watch the glow change as the machine prepares your reward.",
+    "prizeShowcaseTitle": "Prize Showcase",
+    "prizeShowcaseDescription": "Browse every prize currently loaded into the capsule.",
+    "prizeListLoadingText": "Loading prize lineup…",
+    "prizeListErrorText": "We could not load the prize list. Please refresh to try again.",
+    "attemptErrorText": "Something interrupted the gachapon attempt. Please try again.",
+    "defaultFlairText": "The capsule cracks open in a burst of light! 🎉",
+    "submissionEndpoint": "/api/games/gachapon/gacha-001/results",
+    "shakeDurationMs": 1200,
+    "explosionDurationMs": 650,
+    "defaultCapsuleColor": "#38bdf8",
+    "prizes": [
+      {
+        "id": "luminous-orb",
+        "name": "Luminous Orb",
+        "rarity": "common",
+        "rarityLabel": "Common",
+        "description": "A softly glowing orb that keeps your camp lit through the night.",
+        "weight": 45,
+        "capsuleColor": "#E5E7EB",
+        "flairText": "The orb hums gently as it rolls into your hands."
+      },
+      {
+        "id": "ember-charm",
+        "name": "Ember Charm",
+        "rarity": "uncommon",
+        "rarityLabel": "Uncommon",
+        "description": "A flickering charm that warms nearby allies by a few cozy degrees.",
+        "weight": 30,
+        "capsuleColor": "#86EFAC",
+        "flairText": "Sparks of emberlight trace the capsule as it opens."
+      },
+      {
+        "id": "aurora-cape",
+        "name": "Aurora Cape",
+        "rarity": "rare",
+        "rarityLabel": "Rare",
+        "description": "Shimmers with the northern lights and lets you glide short distances.",
+        "weight": 18,
+        "capsuleColor": "#93C5FD",
+        "flairText": "The cape unfurls with a cascade of aurora hues."
+      },
+      {
+        "id": "celestial-compass",
+        "name": "Celestial Compass",
+        "rarity": "epic",
+        "rarityLabel": "Epic",
+        "description": "Always points toward the nearest secret, no matter where you roam.",
+        "weight": 6,
+        "capsuleColor": "#C4B5FD",
+        "flairText": "Starlit runes ignite as the compass clicks into place."
+      },
+      {
+        "id": "dragon-heartfire",
+        "name": "Dragon Heartfire",
+        "rarity": "legendary",
+        "rarityLabel": "Legendary",
+        "description": "A fragment of dragon flame that grants a surge of courage to its bearer.",
+        "weight": 1,
+        "capsuleColor": "#FDE68A",
+        "flairText": "A plume of golden flame roars from the capsule's core."
+      }
+    ]
+  },
+  "fields": [
+    {
+      "name": "title",
+      "label": "Game title",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Headline displayed at the top of the experience."
+    },
+    {
+      "name": "tagline",
+      "label": "Tagline",
+      "type": "string",
+      "scope": "merchant",
+      "required": false,
+      "description": "Upper label displayed above the title."
+    },
+    {
+      "name": "description",
+      "label": "Description",
+      "type": "text",
+      "scope": "merchant",
+      "required": true,
+      "description": "Supporting copy that explains how the gachapon works."
+    },
+    {
+      "name": "ctaLabel",
+      "label": "Primary CTA label",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Label for the button that initiates a gachapon attempt."
+    },
+    {
+      "name": "preparingLabel",
+      "label": "Preparing state label",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Text displayed on the button while the capsule is being prepared."
+    },
+    {
+      "name": "resultModalTitle",
+      "label": "Result modal title",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Heading displayed on the prize reveal modal."
+    },
+    {
+      "name": "capsuleMachineLabel",
+      "label": "Capsule machine label",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Label shown above the capsule machine panel."
+    },
+    {
+      "name": "capsuleStatusIdleLabel",
+      "label": "Idle status label",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Status text displayed when the machine is idle."
+    },
+    {
+      "name": "capsuleStatusPreparingLabel",
+      "label": "Preparing status label",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Status text displayed while the prize is being prepared."
+    },
+    {
+      "name": "capsuleStatusShakingLabel",
+      "label": "Shaking status label",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Status text displayed while the capsule is shaking."
+    },
+    {
+      "name": "capsuleStatusOpeningLabel",
+      "label": "Opening status label",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Status text displayed during the opening animation."
+    },
+    {
+      "name": "capsuleStatusResultLabel",
+      "label": "Result status label",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Status text displayed when the prize is revealed."
+    },
+    {
+      "name": "capsuleDescription",
+      "label": "Capsule description",
+      "type": "text",
+      "scope": "merchant",
+      "required": true,
+      "description": "Supporting copy beneath the capsule machine."
+    },
+    {
+      "name": "prizeShowcaseTitle",
+      "label": "Prize showcase title",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Title for the prize showcase section."
+    },
+    {
+      "name": "prizeShowcaseDescription",
+      "label": "Prize showcase description",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Short description displayed beneath the prize showcase title."
+    },
+    {
+      "name": "prizeListLoadingText",
+      "label": "Prize list loading text",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Message shown while prize data is loading."
+    },
+    {
+      "name": "prizeListErrorText",
+      "label": "Prize list error text",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Message displayed when the prize list cannot be loaded."
+    },
+    {
+      "name": "attemptErrorText",
+      "label": "Attempt error message",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Error message surfaced when a gachapon attempt fails."
+    },
+    {
+      "name": "defaultFlairText",
+      "label": "Default flair text",
+      "type": "string",
+      "scope": "merchant",
+      "required": false,
+      "description": "Fallback message used if a prize does not define its own flair copy."
+    },
+    {
+      "name": "defaultCapsuleColor",
+      "label": "Default capsule color",
+      "type": "color",
+      "scope": "merchant",
+      "required": true,
+      "description": "Base color for the capsule when no prize is revealed yet."
+    },
+    {
+      "name": "shakeDurationMs",
+      "label": "Shake duration (ms)",
+      "type": "number",
+      "scope": "admin",
+      "required": true,
+      "description": "Duration of the shaking animation in milliseconds."
+    },
+    {
+      "name": "explosionDurationMs",
+      "label": "Explosion duration (ms)",
+      "type": "number",
+      "scope": "admin",
+      "required": true,
+      "description": "Duration of the capsule burst animation in milliseconds."
+    },
+    {
+      "name": "submissionEndpoint",
+      "label": "Result submission endpoint",
+      "type": "string",
+      "scope": "admin",
+      "required": true,
+      "description": "Endpoint that records the prize awarded after a gachapon attempt completes."
+    },
+    {
+      "name": "prizes",
+      "label": "Gachapon prizes",
+      "type": "array",
+      "scope": "admin",
+      "required": true,
+      "description": "Defines the prize pool, rarities, and odds for the capsule machine.",
+      "merchantEditableFields": [
+        "name",
+        "description",
+        "rarityLabel",
+        "flairText"
+      ],
+      "item": {
+        "type": "object",
+        "fields": [
+          { "name": "id", "type": "string", "required": true },
+          { "name": "name", "type": "string", "required": true },
+          { "name": "rarity", "type": "string", "required": true },
+          { "name": "rarityLabel", "type": "string", "required": true },
+          { "name": "description", "type": "string", "required": true },
+          { "name": "weight", "type": "number", "required": true },
+          { "name": "capsuleColor", "type": "color", "required": true },
+          { "name": "flairText", "type": "string", "required": false }
+        ]
+      }
+    }
+  ]
+}

--- a/src/games/gachapon-game/gachapon-game.js
+++ b/src/games/gachapon-game/gachapon-game.js
@@ -1,10 +1,8 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import gachaponConfig from './config';
 import { attemptGachapon, fetchAvailablePrizes } from './gachapon-api';
 import './gachapon-game.css';
-
-const SHAKE_DURATION = 1200;
-const EXPLOSION_DURATION = 650;
 
 const rarityAccentClasses = {
   common: 'border-gray-300 text-gray-200',
@@ -20,6 +18,84 @@ const rarityBackground = {
   rare: 'bg-sky-500/10',
   epic: 'bg-violet-500/10',
   legendary: 'bg-amber-500/10',
+};
+
+const defaultRarityLabels = {
+  common: 'Common',
+  uncommon: 'Uncommon',
+  rare: 'Rare',
+  epic: 'Epic',
+  legendary: 'Legendary',
+};
+
+const defaultRarityCapsuleColors = {
+  common: '#E5E7EB',
+  uncommon: '#86EFAC',
+  rare: '#93C5FD',
+  epic: '#C4B5FD',
+  legendary: '#FDE68A',
+};
+
+const toNonNegativeInteger = (value, fallback) => {
+  const parsed = Math.floor(Number(value));
+  if (Number.isFinite(parsed) && parsed >= 0) {
+    return parsed;
+  }
+  return fallback;
+};
+
+const normalisePrizes = (rawPrizes, fallbackPrizes, fallbackFlairText, defaultCapsuleColor) => {
+  const basePrizes = Array.isArray(rawPrizes) ? rawPrizes.filter((prize) => prize && typeof prize === 'object') : [];
+  const templatePrizes = Array.isArray(fallbackPrizes)
+    ? fallbackPrizes.filter((prize) => prize && typeof prize === 'object')
+    : [];
+
+  let effectivePrizes = basePrizes.length ? basePrizes : templatePrizes;
+
+  if (!effectivePrizes.length) {
+    effectivePrizes = [
+      {
+        id: 'gachapon-placeholder-1',
+        name: 'Mystery Capsule',
+        description: 'Configure gachapon prizes to replace this placeholder reward.',
+        rarity: 'common',
+        rarityLabel: 'Mystery',
+        weight: 1,
+        capsuleColor: defaultCapsuleColor,
+        flairText: fallbackFlairText,
+      },
+    ];
+  }
+
+  return effectivePrizes.map((prize, index) => {
+    const rarityValue =
+      typeof prize.rarity === 'string' && prize.rarity.trim()
+        ? prize.rarity.trim().toLowerCase()
+        : 'common';
+    const rarityLabel =
+      typeof prize.rarityLabel === 'string' && prize.rarityLabel.trim()
+        ? prize.rarityLabel
+        : defaultRarityLabels[rarityValue] ?? rarityValue.charAt(0).toUpperCase() + rarityValue.slice(1);
+    const weight = Number.isFinite(prize.weight) && prize.weight > 0 ? prize.weight : 1;
+    const capsuleColor =
+      typeof prize.capsuleColor === 'string' && prize.capsuleColor.trim()
+        ? prize.capsuleColor
+        : defaultRarityCapsuleColors[rarityValue] ?? defaultCapsuleColor;
+    const flairText =
+      typeof prize.flairText === 'string' && prize.flairText.trim() ? prize.flairText : fallbackFlairText;
+
+    return {
+      ...prize,
+      id: prize.id ?? `gachapon-prize-${index}`,
+      name: prize.name ?? `Prize ${index + 1}`,
+      description: prize.description ?? 'Configure prize details in the template options.',
+      rarity: rarityValue,
+      rarityLabel,
+      weight,
+      capsuleColor,
+      flairText,
+    };
+  });
 };
 
 const formatDropRate = (weight, totalWeight) => {
@@ -56,9 +132,93 @@ const PrizeCard = ({ prize, dropRate }) => {
   );
 };
 
-const GachaponGame = () => {
+const GachaponGame = ({ config = gachaponConfig }) => {
   const navigate = useNavigate();
-  const [prizes, setPrizes] = useState([]);
+
+  const baseDefaultFlair =
+    typeof gachaponConfig.defaultFlairText === 'string' && gachaponConfig.defaultFlairText.trim()
+      ? gachaponConfig.defaultFlairText
+      : 'The capsule cracks open in a burst of light! 🎉';
+
+  const baseCapsuleColor =
+    typeof gachaponConfig.defaultCapsuleColor === 'string' && gachaponConfig.defaultCapsuleColor.trim()
+      ? gachaponConfig.defaultCapsuleColor
+      : '#38bdf8';
+
+  const normalisedConfig = useMemo(() => {
+    const providedDefaultFlair =
+      typeof config?.defaultFlairText === 'string' && config.defaultFlairText.trim()
+        ? config.defaultFlairText
+        : baseDefaultFlair;
+
+    const providedDefaultCapsuleColor =
+      typeof config?.defaultCapsuleColor === 'string' && config.defaultCapsuleColor.trim()
+        ? config.defaultCapsuleColor
+        : baseCapsuleColor;
+
+    const prizes = normalisePrizes(
+      config?.prizes,
+      gachaponConfig.prizes,
+      providedDefaultFlair,
+      providedDefaultCapsuleColor,
+    );
+
+    const baseShake = toNonNegativeInteger(gachaponConfig.shakeDurationMs, 1200);
+    const baseExplosion = toNonNegativeInteger(gachaponConfig.explosionDurationMs, 650);
+
+    return {
+      ...gachaponConfig,
+      ...config,
+      prizes,
+      title: config?.title ?? gachaponConfig.title,
+      tagline: config?.tagline ?? gachaponConfig.tagline,
+      description: config?.description ?? gachaponConfig.description,
+      ctaLabel: config?.ctaLabel ?? gachaponConfig.ctaLabel ?? 'Start Gachapon',
+      preparingLabel: config?.preparingLabel ?? gachaponConfig.preparingLabel ?? 'Dispensing…',
+      resultModalTitle: config?.resultModalTitle ?? gachaponConfig.resultModalTitle ?? 'Gachapon Result',
+      capsuleMachineLabel:
+        config?.capsuleMachineLabel ?? gachaponConfig.capsuleMachineLabel ?? 'Capsule Machine',
+      capsuleStatusIdleLabel:
+        config?.capsuleStatusIdleLabel ?? gachaponConfig.capsuleStatusIdleLabel ?? 'Ready',
+      capsuleStatusPreparingLabel:
+        config?.capsuleStatusPreparingLabel ?? gachaponConfig.capsuleStatusPreparingLabel ?? 'Preparing…',
+      capsuleStatusShakingLabel:
+        config?.capsuleStatusShakingLabel ?? gachaponConfig.capsuleStatusShakingLabel ?? 'Shaking…',
+      capsuleStatusOpeningLabel:
+        config?.capsuleStatusOpeningLabel ?? gachaponConfig.capsuleStatusOpeningLabel ?? 'Opening…',
+      capsuleStatusResultLabel:
+        config?.capsuleStatusResultLabel ?? gachaponConfig.capsuleStatusResultLabel ?? 'Capsule opened!',
+      capsuleDescription:
+        config?.capsuleDescription ??
+        gachaponConfig.capsuleDescription ??
+        'Every shake builds anticipation before the capsule bursts open to reveal your prize.',
+      prizeShowcaseTitle:
+        config?.prizeShowcaseTitle ?? gachaponConfig.prizeShowcaseTitle ?? 'Prize Showcase',
+      prizeShowcaseDescription:
+        config?.prizeShowcaseDescription ??
+        gachaponConfig.prizeShowcaseDescription ??
+        'Browse every prize currently loaded into the capsule.',
+      prizeListLoadingText:
+        config?.prizeListLoadingText ??
+        gachaponConfig.prizeListLoadingText ??
+        'Loading prize lineup…',
+      prizeListErrorText:
+        config?.prizeListErrorText ??
+        gachaponConfig.prizeListErrorText ??
+        'We could not load the prize list. Please refresh to try again.',
+      attemptErrorText:
+        config?.attemptErrorText ??
+        gachaponConfig.attemptErrorText ??
+        'Something interrupted the gachapon attempt. Please try again.',
+      defaultFlairText: providedDefaultFlair,
+      defaultCapsuleColor: providedDefaultCapsuleColor,
+      submissionEndpoint: config?.submissionEndpoint ?? gachaponConfig.submissionEndpoint,
+      shakeDurationMs: toNonNegativeInteger(config?.shakeDurationMs, baseShake),
+      explosionDurationMs: toNonNegativeInteger(config?.explosionDurationMs, baseExplosion),
+    };
+  }, [baseCapsuleColor, baseDefaultFlair, config]);
+
+  const [prizes, setPrizes] = useState(normalisedConfig.prizes ?? []);
   const [loadingPrizes, setLoadingPrizes] = useState(true);
   const [prizeError, setPrizeError] = useState(null);
   const [isAttempting, setIsAttempting] = useState(false);
@@ -82,11 +242,19 @@ const GachaponGame = () => {
   }, []);
 
   useEffect(() => {
+    setPrizes(normalisedConfig.prizes ?? []);
+    setAnimationPhase('idle');
+    setResult(null);
+    setShowResultModal(false);
+    setAttemptError(null);
+  }, [normalisedConfig]);
+
+  useEffect(() => {
     let cancelled = false;
     setLoadingPrizes(true);
     setPrizeError(null);
 
-    fetchAvailablePrizes()
+    fetchAvailablePrizes(normalisedConfig)
       .then((availablePrizes) => {
         if (cancelled || !isMountedRef.current) {
           return;
@@ -97,7 +265,7 @@ const GachaponGame = () => {
         if (cancelled || !isMountedRef.current) {
           return;
         }
-        setPrizeError('We could not load the prize list. Please refresh to try again.');
+        setPrizeError(normalisedConfig.prizeListErrorText);
       })
       .finally(() => {
         if (cancelled || !isMountedRef.current) {
@@ -109,7 +277,7 @@ const GachaponGame = () => {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [normalisedConfig]);
 
   const totalWeight = useMemo(() => prizes.reduce((sum, prize) => sum + (prize.weight ?? 0), 0), [prizes]);
 
@@ -132,50 +300,70 @@ const GachaponGame = () => {
     setResult(null);
     setShowResultModal(false);
     setAnimationKey((prev) => prev + 1);
-    setAnimationPhase('shaking');
+    setAnimationPhase('preparing');
 
-    const attemptPromise = attemptGachapon();
-    attemptPromise.catch(() => {
-      // prevent unhandled rejection warnings; actual handling occurs below
-    });
+    attemptGachapon(normalisedConfig)
+      .then((outcome) => {
+        if (!isMountedRef.current) {
+          return;
+        }
 
-    queueTimeout(() => {
-      if (!isMountedRef.current) {
-        return;
-      }
-      setAnimationPhase('explosion');
+        setResult(outcome);
+        setAnimationPhase('shaking');
 
-      queueTimeout(() => {
-        attemptPromise
-          .then((outcome) => {
+        queueTimeout(() => {
+          if (!isMountedRef.current) {
+            return;
+          }
+
+          setAnimationPhase('explosion');
+
+          queueTimeout(() => {
             if (!isMountedRef.current) {
               return;
             }
-            setResult(outcome);
-            setShowResultModal(true);
+
             setAnimationPhase('result');
-          })
-          .catch(() => {
-            if (!isMountedRef.current) {
-              return;
-            }
-            setAttemptError('Something interrupted the gachapon attempt. Please try again.');
-            setAnimationPhase('idle');
-          })
-          .finally(() => {
-            if (!isMountedRef.current) {
-              return;
-            }
+            setShowResultModal(true);
             setIsAttempting(false);
-          });
-      }, EXPLOSION_DURATION);
-    }, SHAKE_DURATION);
+          }, normalisedConfig.explosionDurationMs);
+        }, normalisedConfig.shakeDurationMs);
+      })
+      .catch(() => {
+        if (!isMountedRef.current) {
+          return;
+        }
+        setAttemptError(normalisedConfig.attemptErrorText);
+        setAnimationPhase('idle');
+        setIsAttempting(false);
+      });
   };
 
   const closeModal = () => {
     setShowResultModal(false);
     setAnimationPhase('idle');
   };
+
+  const capsuleStatusLabel = (() => {
+    switch (animationPhase) {
+      case 'preparing':
+        return normalisedConfig.capsuleStatusPreparingLabel ?? 'Preparing…';
+      case 'shaking':
+        return normalisedConfig.capsuleStatusShakingLabel ?? 'Shaking…';
+      case 'explosion':
+        return normalisedConfig.capsuleStatusOpeningLabel ?? 'Opening…';
+      case 'result':
+        return normalisedConfig.capsuleStatusResultLabel ?? 'Capsule opened!';
+      default:
+        return normalisedConfig.capsuleStatusIdleLabel ?? 'Ready';
+    }
+  })();
+
+  const buttonLabel = isAttempting
+    ? normalisedConfig.preparingLabel ?? 'Dispensing…'
+    : normalisedConfig.ctaLabel ?? 'Start Gachapon';
+
+  const capsuleColor = result?.prize?.capsuleColor ?? normalisedConfig.defaultCapsuleColor ?? '#38bdf8';
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-slate-950 py-12 text-white">
@@ -187,17 +375,26 @@ const GachaponGame = () => {
 
       <div className="relative mx-auto flex w-full max-w-5xl flex-col items-center px-4">
         <div className="text-center">
-          <p className="text-sm uppercase tracking-[0.35em] text-indigo-300">Arcade Feature</p>
-          <h1 className="mt-2 text-4xl font-semibold text-white sm:text-5xl">Celestial Capsule Gachapon</h1>
-          <p className="mt-4 max-w-2xl text-sm text-slate-300 sm:text-base">
-            Pull the lever to see what treasure is sealed within the capsule. Every attempt draws from the same prize
-            pool, and your luck determines the rarity of your reward.
-          </p>
+          {normalisedConfig.tagline ? (
+            <p className="text-sm uppercase tracking-[0.35em] text-indigo-300">{normalisedConfig.tagline}</p>
+          ) : null}
+          <h1 className="mt-2 text-4xl font-semibold text-white sm:text-5xl">
+            {normalisedConfig.title ?? 'Gachapon Game'}
+          </h1>
+          {normalisedConfig.description ? (
+            <p className="mt-4 max-w-2xl text-sm text-slate-300 sm:text-base">
+              {normalisedConfig.description}
+            </p>
+          ) : null}
         </div>
 
         <div className="mt-10 w-full max-w-3xl overflow-hidden rounded-[2.5rem] border border-indigo-400/30 bg-slate-900/80 p-10 text-center shadow-2xl shadow-indigo-900/40 backdrop-blur">
           <div className="flex flex-col items-center gap-8">
-            <p className="text-xs uppercase tracking-[0.35em] text-indigo-300">Capsule Machine</p>
+            {normalisedConfig.capsuleMachineLabel ? (
+              <p className="text-xs uppercase tracking-[0.35em] text-indigo-300">
+                {normalisedConfig.capsuleMachineLabel}
+              </p>
+            ) : null}
             <div className="gachapon-stage relative flex h-80 w-full max-w-md items-center justify-center rounded-[2rem] border border-indigo-400/30 bg-slate-950/70 p-8 shadow-[0_24px_45px_rgba(15,23,42,0.55)]">
               <div className="relative flex h-full w-full flex-col items-center justify-center">
                 <div
@@ -209,32 +406,23 @@ const GachaponGame = () => {
                     className={`gachapon-capsule ${
                       animationPhase === 'explosion' || animationPhase === 'result' ? 'gachapon-capsule--hidden' : ''
                     }`}
-                    style={{ background: result?.prize?.capsuleColor ?? '#38bdf8' }}
+                    style={{ background: capsuleColor }}
                   />
                   <div className="absolute inset-x-8 bottom-6 rounded-full bg-slate-800/80 py-3 text-xs uppercase tracking-[0.3em] text-slate-400">
-                    {animationPhase === 'shaking'
-                      ? 'Shaking…'
-                      : animationPhase === 'explosion'
-                      ? 'Opening…'
-                      : animationPhase === 'result'
-                      ? 'Capsule opened!'
-                      : 'Ready'}
+                    {capsuleStatusLabel}
                   </div>
                 </div>
-                {animationPhase === 'explosion' && (
-                  <div key={animationKey} className="gachapon-explosion" />
-                )}
+                {animationPhase === 'explosion' ? <div key={animationKey} className="gachapon-explosion" /> : null}
               </div>
             </div>
-            <p className="max-w-lg text-sm text-indigo-100/80">
-              Every shake builds anticipation before the capsule bursts open to reveal your prize. Hold tight and watch
-              the glow change as the machine prepares your reward.
-            </p>
-            {attemptError && (
+            {normalisedConfig.capsuleDescription ? (
+              <p className="max-w-lg text-sm text-indigo-100/80">{normalisedConfig.capsuleDescription}</p>
+            ) : null}
+            {attemptError ? (
               <p className="w-full rounded-2xl border border-rose-500/40 bg-rose-500/10 px-5 py-3 text-sm text-rose-200" role="status">
                 {attemptError}
               </p>
-            )}
+            ) : null}
           </div>
         </div>
 
@@ -245,7 +433,7 @@ const GachaponGame = () => {
             disabled={isAttempting || loadingPrizes}
             className="gachapon-start-button"
           >
-            <span>{isAttempting ? 'Dispensing…' : 'Start Gachapon'}</span>
+            <span>{buttonLabel}</span>
           </button>
           <button
             type="button"
@@ -260,15 +448,17 @@ const GachaponGame = () => {
           <div className="flex flex-col gap-6">
             <div className="flex flex-col items-center justify-between gap-3 text-center sm:flex-row sm:text-left">
               <div>
-                <h2 className="text-lg font-semibold text-white sm:text-xl">Prize Showcase</h2>
-                <p className="mt-1 text-sm text-slate-400">Browse every prize currently loaded into the capsule.</p>
+                <h2 className="text-lg font-semibold text-white sm:text-xl">{normalisedConfig.prizeShowcaseTitle}</h2>
+                {normalisedConfig.prizeShowcaseDescription ? (
+                  <p className="mt-1 text-sm text-slate-400">{normalisedConfig.prizeShowcaseDescription}</p>
+                ) : null}
               </div>
               <span className="rounded-full border border-slate-700/60 bg-slate-950/60 px-4 py-1 text-xs uppercase tracking-[0.3em] text-slate-300">
                 {prizes.length} Rewards
               </span>
             </div>
             {loadingPrizes ? (
-              <p className="text-sm text-slate-400">Loading prize lineup…</p>
+              <p className="text-sm text-slate-400">{normalisedConfig.prizeListLoadingText}</p>
             ) : prizeError ? (
               <p className="text-sm text-rose-300">{prizeError}</p>
             ) : (
@@ -286,27 +476,24 @@ const GachaponGame = () => {
         </div>
       </div>
 
-      {showResultModal && result && (
+      {showResultModal && result ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4 py-10 backdrop-blur">
           <div className="w-full max-w-lg rounded-3xl border border-indigo-400/40 bg-slate-900/90 p-8 shadow-2xl shadow-indigo-900/50">
-            <p className="text-sm uppercase tracking-[0.25em] text-indigo-300">Gachapon Result</p>
+            <p className="text-sm uppercase tracking-[0.25em] text-indigo-300">{normalisedConfig.resultModalTitle}</p>
             <h3 className="mt-2 text-3xl font-semibold text-white">{result.prize.name}</h3>
             <p className="mt-1 text-sm text-slate-400">{result.prize.rarityLabel}</p>
             <div className="mt-5 flex items-center justify-center">
-              <div
-                className="gachapon-capsule-display"
-                style={{ background: result.prize.capsuleColor }}
-              />
+              <div className="gachapon-capsule-display" style={{ background: result.prize.capsuleColor }} />
             </div>
             <p className="mt-6 text-sm text-slate-300">{result.prize.description}</p>
-            <p className="mt-4 text-sm text-indigo-200">{result.flairText}</p>
+            <p className="mt-4 text-sm text-indigo-200">{result.flairText ?? normalisedConfig.defaultFlairText}</p>
             <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-end">
               <button
                 type="button"
                 className="rounded-full border border-slate-600 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-400 hover:text-white"
                 onClick={closeModal}
               >
-                Try Again
+                {normalisedConfig.ctaLabel ?? 'Start Gachapon'}
               </button>
               <button
                 type="button"
@@ -318,10 +505,9 @@ const GachaponGame = () => {
             </div>
           </div>
         </div>
-      )}
+      ) : null}
     </div>
   );
 };
 
 export default GachaponGame;
-

--- a/src/games/scratch-card-game/config/index.js
+++ b/src/games/scratch-card-game/config/index.js
@@ -1,0 +1,123 @@
+import template from './template.json';
+
+const previewMetadata = {
+  gameId: 'scr-001',
+  merchantId: 'merchant-demo'
+};
+
+const previewOptions = {
+  ...template.defaults
+};
+
+const templateFields = Array.isArray(template.fields) ? template.fields : [];
+
+const serialiseOptionValue = (field, value) => {
+  if (value === null) {
+    return null;
+  }
+
+  if (typeof value === 'undefined') {
+    return '';
+  }
+
+  const fieldType = field?.type;
+
+  if (fieldType === 'number' && typeof value === 'number') {
+    return value.toString();
+  }
+
+  if (fieldType === 'boolean' && typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+
+  if (fieldType === 'array' || fieldType === 'object' || fieldType === 'json') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value) || typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+
+  return String(value);
+};
+
+const buildOptionEntry = (field) => {
+  const optionName = field?.name;
+
+  if (!optionName) {
+    return null;
+  }
+
+  const hasCustomValue = Object.prototype.hasOwnProperty.call(previewOptions, optionName);
+  const optionValue = hasCustomValue ? previewOptions[optionName] : field?.default;
+
+  if (typeof optionValue === 'undefined') {
+    return null;
+  }
+
+  return {
+    input_name: optionName,
+    input_type: field?.type ?? 'string',
+    required: Boolean(field?.required),
+    value: serialiseOptionValue(field, optionValue)
+  };
+};
+
+const previewGameDocument = {
+  game_id: previewMetadata.gameId,
+  game_template_name: template.gameType,
+  merchant_id: previewMetadata.merchantId,
+  name: previewOptions.title ?? template.metadata?.name ?? '',
+  status: 'draft',
+  is_active: true,
+  hard_play_count_limit: 0,
+  play_count: 0,
+  prize_distribution_strategy: 'cascade',
+  options: templateFields.map((field) => buildOptionEntry(field)).filter(Boolean)
+};
+
+const scratchCardConfig = {
+  gameId: previewMetadata.gameId,
+  gameType: template.gameType,
+  title: previewOptions.title,
+  tagline: previewOptions.tagline,
+  description: previewOptions.description,
+  ctaLabel: previewOptions.ctaLabel,
+  scratchActionLabel: previewOptions.scratchActionLabel,
+  playAgainLabel: previewOptions.playAgainLabel,
+  preparingLabel: previewOptions.preparingLabel,
+  resultModalTitle: previewOptions.resultModalTitle,
+  prizeLedgerTitle: previewOptions.prizeLedgerTitle,
+  prizeLedgerSubtitle: previewOptions.prizeLedgerSubtitle,
+  prizeLedgerBadgeLabel: previewOptions.prizeLedgerBadgeLabel,
+  prizeListLoadingText: previewOptions.prizeListLoadingText,
+  prizeListErrorText: previewOptions.prizeListErrorText,
+  attemptErrorText: previewOptions.attemptErrorText,
+  defaultFlairText: previewOptions.defaultFlairText,
+  submissionEndpoint: previewOptions.submissionEndpoint,
+  prizes: previewOptions.prizes,
+  template,
+  templateVersion: template.version,
+  previewOptions,
+  previewMetadata,
+  fields: templateFields,
+  apiContract: {
+    method: 'POST',
+    path: '/games/list',
+    requestBody: {
+      game_ids: [previewMetadata.gameId],
+      merchant_id: previewMetadata.merchantId
+    },
+    responseType: 'application/json',
+    notes:
+      'POST /games/list returns Game documents with option values serialised as strings. Structured defaults are stringified during publishing.',
+    sampleResponse: previewGameDocument
+  },
+  gameDocument: previewGameDocument
+};
+
+export const scratchCardTemplate = template;
+export const scratchCardPreviewOptions = previewOptions;
+export const scratchCardPreviewGameDocument = previewGameDocument;
+
+export default scratchCardConfig;

--- a/src/games/scratch-card-game/config/template.json
+++ b/src/games/scratch-card-game/config/template.json
@@ -1,0 +1,243 @@
+{
+  "templateId": "scratch-card",
+  "gameType": "scratch-card",
+  "version": 1,
+  "metadata": {
+    "name": "Aurora Scratch Card",
+    "description": "Reveal foil-backed rewards by scratching away a shimmering cover.",
+    "thumbnailUrl": "/images/scratch-card-game-thumb.png"
+  },
+  "defaults": {
+    "title": "Aurora Scratch Card",
+    "tagline": "Glitterforge Games",
+    "description": "Claim a radiant foil, then do the scratching yourself to reveal the treasure hidden beneath. Every swipe clears the nebula shimmer until your prize erupts in full color.",
+    "ctaLabel": "Get a new card",
+    "scratchActionLabel": "Scratch the foil",
+    "playAgainLabel": "Get another card",
+    "preparingLabel": "Preparing card…",
+    "resultModalTitle": "Scratch Card Result",
+    "prizeLedgerTitle": "Prize Ledger",
+    "prizeLedgerSubtitle": "Review every reward hiding beneath the aurora foil.",
+    "prizeLedgerBadgeLabel": "Drop Rates",
+    "prizeListLoadingText": "Loading scratch card lineup…",
+    "prizeListErrorText": "We could not load the prize ledger. Please refresh to try again.",
+    "attemptErrorText": "Something interrupted the scratch card attempt. Please try again.",
+    "defaultFlairText": "The foil peels away and the prize gleams brilliantly! ✨",
+    "submissionEndpoint": "/api/games/scratch-card/scr-001/results",
+    "prizes": [
+      {
+        "id": "starlit-token",
+        "name": "Starlit Token",
+        "rarity": "common",
+        "rarityLabel": "Common",
+        "description": "A token etched with constellations, good for a single campfire wish.",
+        "weight": 45,
+        "foilColor": "#CBD5F5",
+        "glowColor": "rgba(96, 165, 250, 0.35)",
+        "flairText": "Starlight flickers across the token as it reveals itself."
+      },
+      {
+        "id": "glimmer-thread",
+        "name": "Glimmer Thread",
+        "rarity": "uncommon",
+        "rarityLabel": "Uncommon",
+        "description": "Woven from comet tails, it reinforces any gear you stitch it into.",
+        "weight": 30,
+        "foilColor": "#8DE6C9",
+        "glowColor": "rgba(52, 211, 153, 0.45)",
+        "flairText": "Threads of light twirl in the air as the prize emerges."
+      },
+      {
+        "id": "dawn-charm",
+        "name": "Charm of Dawn",
+        "rarity": "rare",
+        "rarityLabel": "Rare",
+        "description": "A radiant charm that greets every sunrise with a burst of optimism.",
+        "weight": 18,
+        "foilColor": "#95C6FF",
+        "glowColor": "rgba(59, 130, 246, 0.55)",
+        "flairText": "The charm gleams with the first light of morning."
+      },
+      {
+        "id": "eclipse-crest",
+        "name": "Eclipse Crest",
+        "rarity": "epic",
+        "rarityLabel": "Epic",
+        "description": "A crest forged from shadow and light, empowering the bearer at dusk.",
+        "weight": 6,
+        "foilColor": "#D4B3FF",
+        "glowColor": "rgba(167, 139, 250, 0.55)",
+        "flairText": "A halo of twilight blooms around the crest."
+      },
+      {
+        "id": "aurora-heart",
+        "name": "Aurora Heart",
+        "rarity": "legendary",
+        "rarityLabel": "Legendary",
+        "description": "A prismatic core that pulses with the aurora's rhythm and courage.",
+        "weight": 1,
+        "foilColor": "#FDE48A",
+        "glowColor": "rgba(251, 191, 36, 0.6)",
+        "flairText": "The aurora surges as the heart ignites in your hands."
+      }
+    ]
+  },
+  "fields": [
+    {
+      "name": "title",
+      "label": "Game title",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Headline displayed at the top of the experience."
+    },
+    {
+      "name": "tagline",
+      "label": "Tagline",
+      "type": "string",
+      "scope": "merchant",
+      "required": false,
+      "description": "Upper label displayed above the title."
+    },
+    {
+      "name": "description",
+      "label": "Description",
+      "type": "text",
+      "scope": "merchant",
+      "required": true,
+      "description": "Supporting copy that explains how the scratch card works."
+    },
+    {
+      "name": "ctaLabel",
+      "label": "Primary CTA label",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Label for the button that initiates a new scratch card."
+    },
+    {
+      "name": "scratchActionLabel",
+      "label": "Scratch action label",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Label shown on the primary button when the foil is ready to scratch."
+    },
+    {
+      "name": "playAgainLabel",
+      "label": "Play again label",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Label for the primary button after a prize has been revealed."
+    },
+    {
+      "name": "preparingLabel",
+      "label": "Preparing state label",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Text displayed on the button while the prize is being prepared."
+    },
+    {
+      "name": "resultModalTitle",
+      "label": "Result modal title",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Heading displayed on the prize reveal modal."
+    },
+    {
+      "name": "prizeLedgerTitle",
+      "label": "Prize ledger title",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Title for the prize ledger section."
+    },
+    {
+      "name": "prizeLedgerSubtitle",
+      "label": "Prize ledger subtitle",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Short description displayed beneath the prize ledger title."
+    },
+    {
+      "name": "prizeLedgerBadgeLabel",
+      "label": "Prize ledger badge label",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Label for the badge displayed alongside the prize ledger heading."
+    },
+    {
+      "name": "prizeListLoadingText",
+      "label": "Prize list loading text",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Message shown while the prize ledger is loading."
+    },
+    {
+      "name": "prizeListErrorText",
+      "label": "Prize list error text",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Message displayed when prize data cannot be loaded."
+    },
+    {
+      "name": "attemptErrorText",
+      "label": "Attempt error message",
+      "type": "string",
+      "scope": "merchant",
+      "required": true,
+      "description": "Error message surfaced when a scratch attempt fails."
+    },
+    {
+      "name": "defaultFlairText",
+      "label": "Default flair text",
+      "type": "string",
+      "scope": "merchant",
+      "required": false,
+      "description": "Fallback message used if a prize does not define its own flair copy."
+    },
+    {
+      "name": "submissionEndpoint",
+      "label": "Result submission endpoint",
+      "type": "string",
+      "scope": "admin",
+      "required": true,
+      "description": "Endpoint that records the prize awarded after a scratch completes."
+    },
+    {
+      "name": "prizes",
+      "label": "Scratch card prizes",
+      "type": "array",
+      "scope": "admin",
+      "required": true,
+      "description": "Defines the prize pool, associated rarities, and odds for the scratch card.",
+      "merchantEditableFields": [
+        "name",
+        "description",
+        "rarityLabel",
+        "flairText"
+      ],
+      "item": {
+        "type": "object",
+        "fields": [
+          { "name": "id", "type": "string", "required": true },
+          { "name": "name", "type": "string", "required": true },
+          { "name": "rarity", "type": "string", "required": true },
+          { "name": "rarityLabel", "type": "string", "required": true },
+          { "name": "description", "type": "string", "required": true },
+          { "name": "weight", "type": "number", "required": true },
+          { "name": "foilColor", "type": "color", "required": true },
+          { "name": "glowColor", "type": "color", "required": true },
+          { "name": "flairText", "type": "string", "required": false }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add template/config scaffolding for the scratch card and gachapon modules so we can load template metadata, defaults, and API contracts from one place
- refactor the scratch card and gachapon APIs/components to consume normalized config data and request the prize result before their animations run
- expose template defaults for copy, prize pools, button labels, and animation timings to prepare the games for API-driven customization

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d00b965800832a88103606bb9dca55