### PR TITLE
Add dashboard theme previews for game modules

### DIFF
--- a/src/games/flip-card-new/flip-card-new-theme-preview.js
+++ b/src/games/flip-card-new/flip-card-new-theme-preview.js
@@ -1,0 +1,381 @@
+import React, { useMemo } from 'react';
+import { flipCardNewPreviewOptions } from './config';
+
+const DEFAULT_OPTIONS = flipCardNewPreviewOptions ?? {};
+const DEFAULT_THEME = DEFAULT_OPTIONS.theme ?? {};
+const DEFAULT_TITLE = DEFAULT_OPTIONS.title ?? 'Flip Card Challenge';
+const DEFAULT_DESCRIPTION =
+  DEFAULT_OPTIONS.description ?? 'Preview how the refreshed flip-card experience responds to theme changes.';
+
+const toCleanString = (value) => (typeof value === 'string' ? value.trim() : '');
+const isCssGradient = (value) => typeof value === 'string' && value.includes('gradient(');
+const getColor = (value, fallback, fallbackAlt) => {
+  const trimmed = toCleanString(value);
+  if (trimmed) {
+    return trimmed;
+  }
+  const fallbackTrimmed = toCleanString(fallback);
+  if (fallbackTrimmed) {
+    return fallbackTrimmed;
+  }
+  return fallbackAlt;
+};
+
+const COLOR_SECTIONS = [
+  {
+    title: 'Layout & Panels',
+    fields: [
+      { key: 'backgroundColor', label: 'Background' },
+      { key: 'backgroundOverlayColor', label: 'Overlay' },
+      { key: 'panelBackgroundColor', label: 'Panel background' },
+      { key: 'panelBorderColor', label: 'Panel border' },
+      { key: 'panelShadowColor', label: 'Panel shadow' },
+      { key: 'boardBackgroundColor', label: 'Board background' },
+      { key: 'boardBorderColor', label: 'Board border' },
+      { key: 'boardShadowColor', label: 'Board shadow' }
+    ]
+  },
+  {
+    title: 'Cards',
+    fields: [
+      { key: 'cardBackBackgroundColor', label: 'Card back' },
+      { key: 'cardFaceBackgroundColor', label: 'Card face' },
+      { key: 'cardBorderColor', label: 'Card border' },
+      { key: 'cardShadowColor', label: 'Card shadow' },
+      { key: 'cardMatchedBackgroundColor', label: 'Matched card' },
+      { key: 'cardMatchedGlowColor', label: 'Match glow' }
+    ]
+  },
+  {
+    title: 'Typography & Accents',
+    fields: [
+      { key: 'accentColor', label: 'Accent' },
+      { key: 'titleColor', label: 'Headline text' },
+      { key: 'textColor', label: 'Body text' },
+      { key: 'subtleTextColor', label: 'Secondary text' }
+    ]
+  },
+  {
+    title: 'Buttons',
+    fields: [
+      { key: 'buttonBackgroundColor', label: 'Button background' },
+      { key: 'buttonHoverBackgroundColor', label: 'Hover background' },
+      { key: 'buttonTextColor', label: 'Button text' }
+    ]
+  }
+];
+
+const ColorSwatch = ({ label, value, isCustom }) => {
+  const displayValue = toCleanString(value);
+  return (
+    <div className="flex flex-col rounded-xl border border-slate-200/70 bg-white/80 p-3 shadow-sm shadow-slate-200/60">
+      <div className="flex items-center justify-between text-xs font-medium text-slate-600">
+        <span>{label}</span>
+        <span
+          className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+            isCustom ? 'bg-sky-100 text-sky-700' : 'bg-slate-100 text-slate-500'
+          }`}
+        >
+          {isCustom ? 'Custom' : 'Default'}
+        </span>
+      </div>
+      <div
+        className="mt-3 h-12 w-full overflow-hidden rounded-lg border border-slate-200/80"
+        style={{
+          background: displayValue || 'linear-gradient(135deg, rgba(148,163,184,0.25), rgba(203,213,225,0.45))'
+        }}
+      />
+      <div className="mt-2 break-words text-[11px] text-slate-500">{displayValue || 'Not set'}</div>
+    </div>
+  );
+};
+
+const FlipCardNewThemePreview = ({ theme, title, description }) => {
+  const mergedTheme = useMemo(() => ({ ...DEFAULT_THEME, ...(theme || {}) }), [theme]);
+  const heading = toCleanString(title) || DEFAULT_TITLE;
+  const body = toCleanString(description) || DEFAULT_DESCRIPTION;
+
+  const backgroundStyle = useMemo(() => {
+    const style = {
+      backgroundColor: getColor(mergedTheme.backgroundColor, DEFAULT_THEME.backgroundColor, '#fdfaf5')
+    };
+    const backgroundImage =
+      toCleanString(mergedTheme.backgroundImage) || toCleanString(DEFAULT_THEME.backgroundImage);
+    if (backgroundImage) {
+      if (isCssGradient(backgroundImage)) {
+        style.backgroundImage = backgroundImage;
+      } else {
+        style.backgroundImage = `url(${backgroundImage})`;
+        style.backgroundSize = 'cover';
+        style.backgroundPosition = 'center';
+        style.backgroundRepeat = 'no-repeat';
+      }
+    }
+    return style;
+  }, [mergedTheme]);
+
+  const overlayColor = getColor(
+    mergedTheme.backgroundOverlayColor,
+    DEFAULT_THEME.backgroundOverlayColor,
+    'rgba(255,255,255,0.82)'
+  );
+  const accentColor = getColor(mergedTheme.accentColor, DEFAULT_THEME.accentColor, '#60a5fa');
+  const subtleTextColor = getColor(
+    mergedTheme.subtleTextColor,
+    DEFAULT_THEME.subtleTextColor,
+    'rgba(100,116,139,0.75)'
+  );
+  const titleColor = getColor(mergedTheme.titleColor, DEFAULT_THEME.titleColor, '#0f172a');
+  const textColor = getColor(mergedTheme.textColor, DEFAULT_THEME.textColor, '#1f2937');
+  const buttonBackground = getColor(
+    mergedTheme.buttonBackgroundColor,
+    DEFAULT_THEME.buttonBackgroundColor,
+    accentColor
+  );
+  const buttonHoverBackground = getColor(
+    mergedTheme.buttonHoverBackgroundColor,
+    DEFAULT_THEME.buttonHoverBackgroundColor,
+    accentColor
+  );
+  const buttonTextColor = getColor(mergedTheme.buttonTextColor, DEFAULT_THEME.buttonTextColor, '#ffffff');
+  const panelShadow = getColor(
+    mergedTheme.panelShadowColor,
+    DEFAULT_THEME.panelShadowColor,
+    'rgba(148,163,184,0.26)'
+  );
+  const boardShadow = getColor(
+    mergedTheme.boardShadowColor,
+    DEFAULT_THEME.boardShadowColor,
+    'rgba(100,116,139,0.24)'
+  );
+  const cardShadow = getColor(
+    mergedTheme.cardShadowColor,
+    DEFAULT_THEME.cardShadowColor,
+    'rgba(148,163,184,0.4)'
+  );
+  const matchedGlow = getColor(
+    mergedTheme.cardMatchedGlowColor,
+    DEFAULT_THEME.cardMatchedGlowColor,
+    accentColor
+  );
+
+  const panelStyle = {
+    background: getColor(
+      mergedTheme.panelBackgroundColor,
+      DEFAULT_THEME.panelBackgroundColor,
+      'rgba(255,255,255,0.88)'
+    ),
+    borderColor: getColor(
+      mergedTheme.panelBorderColor,
+      DEFAULT_THEME.panelBorderColor,
+      'rgba(148,163,184,0.32)'
+    ),
+    boxShadow: panelShadow ? `0 34px 80px -45px ${panelShadow}` : undefined
+  };
+
+  const boardStyle = {
+    background: getColor(
+      mergedTheme.boardBackgroundColor,
+      DEFAULT_THEME.boardBackgroundColor,
+      'rgba(255,255,255,0.92)'
+    ),
+    borderColor: getColor(
+      mergedTheme.boardBorderColor,
+      DEFAULT_THEME.boardBorderColor,
+      'rgba(191,219,254,0.7)'
+    ),
+    boxShadow: boardShadow ? `0 45px 120px -65px ${boardShadow}` : undefined
+  };
+
+  const cardBorderColor = getColor(
+    mergedTheme.cardBorderColor,
+    DEFAULT_THEME.cardBorderColor,
+    'rgba(191,219,254,0.9)'
+  );
+  const cardBackBackground = getColor(
+    mergedTheme.cardBackBackgroundColor,
+    DEFAULT_THEME.cardBackBackgroundColor,
+    'rgba(226,232,240,0.85)'
+  );
+  const cardFaceBackground = getColor(
+    mergedTheme.cardFaceBackgroundColor,
+    DEFAULT_THEME.cardFaceBackgroundColor,
+    'rgba(239,246,255,0.92)'
+  );
+  const matchedBackground = getColor(
+    mergedTheme.cardMatchedBackgroundColor,
+    DEFAULT_THEME.cardMatchedBackgroundColor,
+    'rgba(191,227,255,0.65)'
+  );
+
+  const cardBaseStyle = {
+    borderColor: cardBorderColor,
+    boxShadow: cardShadow ? `0 28px 55px -40px ${cardShadow}` : undefined
+  };
+
+  const cardBackStyle = {
+    ...cardBaseStyle,
+    background: cardBackBackground,
+    color: accentColor
+  };
+
+  const cardFrontStyle = {
+    ...cardBaseStyle,
+    background: cardFaceBackground,
+    color: titleColor
+  };
+
+  const matchedCardStyle = {
+    ...cardBaseStyle,
+    background: matchedBackground,
+    color: titleColor,
+    boxShadow: matchedGlow
+      ? `0 0 0 2px ${matchedBackground}, 0 30px 60px -40px ${matchedGlow}`
+      : cardBaseStyle.boxShadow
+  };
+
+  const swatchSections = COLOR_SECTIONS.map((section) => ({
+    ...section,
+    fields: section.fields.map((field) => ({
+      ...field,
+      value: mergedTheme[field.key],
+      isCustom: Boolean(theme && toCleanString(theme[field.key]))
+    }))
+  }));
+
+  return (
+    <div className="space-y-6">
+      <div className="overflow-hidden rounded-[32px] border border-slate-200/60 bg-white shadow-[0_30px_80px_-45px_rgba(15,23,42,0.38)]">
+        <div className="relative">
+          <div className="absolute inset-0" style={backgroundStyle} />
+          <div className="absolute inset-0" style={{ background: overlayColor }} />
+          <div className="relative space-y-6 px-8 py-10">
+            <div className="space-y-2">
+              <p
+                className="text-xs font-semibold uppercase tracking-[0.3em]"
+                style={{ color: subtleTextColor }}
+              >
+                Flip card preview
+              </p>
+              <h2 className="text-2xl font-semibold tracking-tight" style={{ color: titleColor }}>
+                {heading}
+              </h2>
+              <p className="text-sm leading-relaxed" style={{ color: textColor }}>
+                {body}
+              </p>
+            </div>
+            <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
+              <div className="rounded-3xl border p-5 shadow-sm" style={panelStyle}>
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <p
+                      className="text-xs uppercase tracking-[0.24em]"
+                      style={{ color: subtleTextColor }}
+                    >
+                      Moves left
+                    </p>
+                    <p className="text-2xl font-semibold" style={{ color: titleColor }}>
+                      6
+                    </p>
+                  </div>
+                  <div>
+                    <p
+                      className="text-xs uppercase tracking-[0.24em]"
+                      style={{ color: subtleTextColor }}
+                    >
+                      Pairs found
+                    </p>
+                    <p className="text-2xl font-semibold" style={{ color: titleColor }}>
+                      4 / 8
+                    </p>
+                  </div>
+                </div>
+                <div className="mt-6 space-y-3">
+                  <div className="flex items-center justify-between text-xs">
+                    <span style={{ color: subtleTextColor }}>Progress</span>
+                    <span style={{ color: titleColor }}>60%</span>
+                  </div>
+                  <div className="h-2 w-full overflow-hidden rounded-full bg-white/60">
+                    <div
+                      className="h-full rounded-full"
+                      style={{ background: accentColor, width: '60%' }}
+                    />
+                  </div>
+                </div>
+                <div className="mt-6 rounded-2xl border border-dashed border-slate-200/60 bg-white/60 p-4 text-xs" style={{ color: subtleTextColor }}>
+                  Hover colour preview: <span style={{ color: accentColor }}>{buttonHoverBackground}</span>
+                </div>
+                <button
+                  type="button"
+                  className="mt-6 w-full rounded-2xl px-5 py-3 text-sm font-semibold transition"
+                  style={{ background: buttonBackground, color: buttonTextColor }}
+                >
+                  Submit score
+                </button>
+              </div>
+              <div className="rounded-3xl border p-5" style={boardStyle}>
+                <div className="grid grid-cols-4 gap-3 text-sm font-semibold">
+                  <div
+                    className="flex aspect-[3/4] items-center justify-center rounded-xl border"
+                    style={cardFrontStyle}
+                  >
+                    ☀️
+                  </div>
+                  <div
+                    className="flex aspect-[3/4] items-center justify-center rounded-xl border"
+                    style={cardBackStyle}
+                  >
+                    ?
+                  </div>
+                  <div
+                    className="flex aspect-[3/4] items-center justify-center rounded-xl border"
+                    style={matchedCardStyle}
+                  >
+                    ✅
+                  </div>
+                  <div
+                    className="flex aspect-[3/4] items-center justify-center rounded-xl border"
+                    style={{ ...cardFrontStyle, color: subtleTextColor }}
+                  >
+                    💫
+                  </div>
+                </div>
+                <div className="mt-6 grid gap-3 text-xs" style={{ color: subtleTextColor }}>
+                  <div className="flex items-center justify-between">
+                    <span>Time elapsed</span>
+                    <span style={{ color: titleColor }}>01:12</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Next reward</span>
+                    <span style={{ color: accentColor }}>Free drink</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="space-y-4">
+        {swatchSections.map((section) => (
+          <div key={section.title} className="space-y-3">
+            <h3 className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-500">
+              {section.title}
+            </h3>
+            <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {section.fields.map((field) => (
+                <ColorSwatch
+                  key={field.key}
+                  label={field.label}
+                  value={field.value}
+                  isCustom={field.isCustom}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default FlipCardNewThemePreview;

--- a/src/games/gachapon-game/gachapon-theme-preview.js
+++ b/src/games/gachapon-game/gachapon-theme-preview.js
@@ -1,0 +1,178 @@
+import React, { useMemo } from 'react';
+import { gachaponPreviewOptions } from './config';
+
+const DEFAULT_OPTIONS = gachaponPreviewOptions ?? {};
+const DEFAULT_PRIZES = Array.isArray(DEFAULT_OPTIONS.prizes) ? DEFAULT_OPTIONS.prizes : [];
+const DEFAULT_CAPSULE_COLOR = DEFAULT_OPTIONS.defaultCapsuleColor ?? '#38bdf8';
+const DEFAULT_FLAIR =
+  DEFAULT_OPTIONS.defaultFlairText ?? 'The capsule cracks open in a burst of light! 🎉';
+
+const toCleanString = (value) => (typeof value === 'string' ? value.trim() : '');
+const getColor = (value, fallback, fallbackAlt) => {
+  const trimmed = toCleanString(value);
+  if (trimmed) {
+    return trimmed;
+  }
+  const fallbackTrimmed = toCleanString(fallback);
+  if (fallbackTrimmed) {
+    return fallbackTrimmed;
+  }
+  return fallbackAlt;
+};
+
+const CapsuleColorSwatch = ({ label, value, isCustom }) => {
+  const displayValue = toCleanString(value);
+  return (
+    <div className="flex flex-col rounded-xl border border-slate-200/70 bg-white/85 p-3 shadow-sm shadow-slate-200/60">
+      <div className="flex items-center justify-between text-xs font-medium text-slate-600">
+        <span>{label}</span>
+        <span
+          className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+            isCustom ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-500'
+          }`}
+        >
+          {isCustom ? 'Custom' : 'Default'}
+        </span>
+      </div>
+      <div
+        className="mt-3 h-12 w-full overflow-hidden rounded-lg border border-slate-200/80"
+        style={{
+          background: displayValue || 'linear-gradient(135deg, rgba(148,163,184,0.25), rgba(203,213,225,0.45))'
+        }}
+      />
+      <div className="mt-2 break-words text-[11px] text-slate-500">{displayValue || 'Not set'}</div>
+    </div>
+  );
+};
+
+const GachaponThemePreview = ({ defaultCapsuleColor, prizes, defaultFlairText }) => {
+  const capsuleColor = getColor(defaultCapsuleColor, DEFAULT_CAPSULE_COLOR, '#38bdf8');
+  const fallbackPrizes = DEFAULT_PRIZES;
+  const providedPrizes = Array.isArray(prizes) ? prizes : [];
+  const heroFlair = toCleanString(defaultFlairText) || DEFAULT_FLAIR;
+
+  const previewPrizes = useMemo(() => {
+    const source = providedPrizes.length ? providedPrizes : fallbackPrizes;
+    return source.slice(0, 4).map((prize, index) => {
+      const fallback = fallbackPrizes[index] ?? {};
+      const color = getColor(prize?.capsuleColor, fallback.capsuleColor, capsuleColor);
+      const label =
+        toCleanString(prize?.rarityLabel) ||
+        toCleanString(prize?.name) ||
+        toCleanString(fallback.rarityLabel) ||
+        toCleanString(fallback.name) ||
+        `Prize ${index + 1}`;
+      const flair =
+        toCleanString(prize?.flairText) ||
+        toCleanString(fallback.flairText) ||
+        toCleanString(defaultFlairText) ||
+        DEFAULT_FLAIR;
+      const isCustom = Boolean(providedPrizes.length && toCleanString(providedPrizes[index]?.capsuleColor));
+
+      return {
+        id: prize?.id ?? fallback.id ?? `gachapon-prize-${index}`,
+        label,
+        color,
+        flair,
+        isCustom
+      };
+    });
+  }, [providedPrizes, fallbackPrizes, capsuleColor, defaultFlairText]);
+
+  const swatchEntries = useMemo(() => {
+    const entries = [
+      {
+        label: 'Default capsule',
+        value: capsuleColor,
+        isCustom: Boolean(toCleanString(defaultCapsuleColor))
+      }
+    ];
+
+    previewPrizes.forEach((prize, index) => {
+      entries.push({
+        label: `${prize.label} colour`,
+        value: prize.color,
+        isCustom: prize.isCustom,
+        id: prize.id ?? `gachapon-swatch-${index}`
+      });
+    });
+
+    return entries;
+  }, [capsuleColor, defaultCapsuleColor, previewPrizes]);
+
+  return (
+    <div className="space-y-6">
+      <div className="overflow-hidden rounded-[32px] border border-slate-800/50 bg-slate-950 text-slate-100 shadow-[0_30px_90px_-45px_rgba(2,6,23,0.8)]">
+        <div className="relative px-8 py-10">
+          <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900 opacity-95" />
+          <div className="relative grid gap-8 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+            <div className="flex flex-col items-center gap-4 text-center">
+              <div
+                className="relative flex h-40 w-40 items-center justify-center rounded-full border-4 border-slate-900/60 shadow-[0_40px_80px_-45px_rgba(56,189,248,0.55)]"
+                style={{ background: capsuleColor }}
+              >
+                <div className="absolute inset-x-6 bottom-4 h-4 rounded-full bg-white/40 blur" />
+                <span className="relative text-3xl font-semibold text-slate-900/80">✨</span>
+              </div>
+              <div className="space-y-1">
+                <p className="text-xs uppercase tracking-[0.32em] text-slate-400">Default capsule</p>
+                <p className="text-sm font-semibold text-slate-100">{capsuleColor}</p>
+              </div>
+              <p className="max-w-xs text-sm text-slate-400">{heroFlair}</p>
+            </div>
+            <div className="space-y-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-400">
+                Prize capsule accents
+              </p>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {previewPrizes.map((prize) => (
+                  <div
+                    key={prize.id}
+                    className="flex h-full flex-col justify-between rounded-2xl border border-slate-800 bg-slate-900/70 p-4 shadow-lg shadow-slate-900/40"
+                  >
+                    <div className="flex items-center gap-3">
+                      <div
+                        className="flex h-12 w-12 items-center justify-center rounded-full border border-white/20 text-lg"
+                        style={{
+                          background: prize.color || 'linear-gradient(135deg, rgba(148,163,184,0.25), rgba(203,213,225,0.45))'
+                        }}
+                      >
+                        🎁
+                      </div>
+                      <div>
+                        <p className="text-xs uppercase tracking-wide text-slate-400">{prize.label}</p>
+                        <p className="text-sm font-semibold text-slate-100">{prize.color || 'Not set'}</p>
+                      </div>
+                    </div>
+                    <p className="mt-3 line-clamp-2 text-xs text-slate-400">{prize.flair}</p>
+                    <span
+                      className={`mt-3 inline-flex w-fit rounded-full px-2.5 py-0.5 text-[10px] font-semibold tracking-wide ${
+                        prize.isCustom
+                          ? 'bg-emerald-500/10 text-emerald-300'
+                          : 'bg-slate-800 text-slate-400'
+                      }`}
+                    >
+                      {prize.isCustom ? 'Custom colour' : 'Default colour'}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {swatchEntries.map((entry) => (
+          <CapsuleColorSwatch
+            key={entry.id ?? entry.label}
+            label={entry.label}
+            value={entry.value}
+            isCustom={entry.isCustom}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default GachaponThemePreview;

--- a/src/games/matching-game/matching-game-theme-preview.js
+++ b/src/games/matching-game/matching-game-theme-preview.js
@@ -1,0 +1,381 @@
+import React, { useMemo } from 'react';
+import { matchingGamePreviewOptions } from './config';
+
+const DEFAULT_OPTIONS = matchingGamePreviewOptions ?? {};
+const DEFAULT_THEME = DEFAULT_OPTIONS.theme ?? {};
+const DEFAULT_TITLE = DEFAULT_OPTIONS.title ?? 'Matching Game';
+const DEFAULT_DESCRIPTION =
+  DEFAULT_OPTIONS.description ?? 'Flip the cards and find every pair before your moves run out.';
+
+const toCleanString = (value) => (typeof value === 'string' ? value.trim() : '');
+const isCssGradient = (value) => typeof value === 'string' && value.includes('gradient(');
+const getColor = (value, fallback, fallbackAlt) => {
+  const trimmed = toCleanString(value);
+  if (trimmed) {
+    return trimmed;
+  }
+  const fallbackTrimmed = toCleanString(fallback);
+  if (fallbackTrimmed) {
+    return fallbackTrimmed;
+  }
+  return fallbackAlt;
+};
+
+const COLOR_SECTIONS = [
+  {
+    title: 'Layout & Panels',
+    fields: [
+      { key: 'backgroundColor', label: 'Background' },
+      { key: 'backgroundOverlayColor', label: 'Overlay' },
+      { key: 'panelBackgroundColor', label: 'Panel background' },
+      { key: 'panelBorderColor', label: 'Panel border' },
+      { key: 'panelShadowColor', label: 'Panel shadow' },
+      { key: 'boardBackgroundColor', label: 'Board background' },
+      { key: 'boardBorderColor', label: 'Board border' },
+      { key: 'boardShadowColor', label: 'Board shadow' }
+    ]
+  },
+  {
+    title: 'Cards',
+    fields: [
+      { key: 'cardBackBackgroundColor', label: 'Card back' },
+      { key: 'cardFaceBackgroundColor', label: 'Card face' },
+      { key: 'cardBorderColor', label: 'Card border' },
+      { key: 'cardShadowColor', label: 'Card shadow' },
+      { key: 'cardMatchedBackgroundColor', label: 'Matched card' },
+      { key: 'cardMatchedGlowColor', label: 'Match glow' }
+    ]
+  },
+  {
+    title: 'Typography & Accents',
+    fields: [
+      { key: 'accentColor', label: 'Accent' },
+      { key: 'titleColor', label: 'Headline text' },
+      { key: 'textColor', label: 'Body text' },
+      { key: 'subtleTextColor', label: 'Secondary text' }
+    ]
+  },
+  {
+    title: 'Buttons',
+    fields: [
+      { key: 'buttonBackgroundColor', label: 'Button background' },
+      { key: 'buttonHoverBackgroundColor', label: 'Hover background' },
+      { key: 'buttonTextColor', label: 'Button text' }
+    ]
+  }
+];
+
+const ColorSwatch = ({ label, value, isCustom }) => {
+  const displayValue = toCleanString(value);
+  return (
+    <div className="flex flex-col rounded-xl border border-slate-200/70 bg-white/80 p-3 shadow-sm shadow-slate-200/60">
+      <div className="flex items-center justify-between text-xs font-medium text-slate-600">
+        <span>{label}</span>
+        <span
+          className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+            isCustom ? 'bg-sky-100 text-sky-700' : 'bg-slate-100 text-slate-500'
+          }`}
+        >
+          {isCustom ? 'Custom' : 'Default'}
+        </span>
+      </div>
+      <div
+        className="mt-3 h-12 w-full overflow-hidden rounded-lg border border-slate-200/80"
+        style={{
+          background: displayValue || 'linear-gradient(135deg, rgba(148,163,184,0.25), rgba(203,213,225,0.45))'
+        }}
+      />
+      <div className="mt-2 break-words text-[11px] text-slate-500">{displayValue || 'Not set'}</div>
+    </div>
+  );
+};
+
+const MatchingGameThemePreview = ({ theme, title, description }) => {
+  const mergedTheme = useMemo(() => ({ ...DEFAULT_THEME, ...(theme || {}) }), [theme]);
+  const heading = toCleanString(title) || DEFAULT_TITLE;
+  const body = toCleanString(description) || DEFAULT_DESCRIPTION;
+
+  const backgroundStyle = useMemo(() => {
+    const style = {
+      backgroundColor: getColor(mergedTheme.backgroundColor, DEFAULT_THEME.backgroundColor, '#fdfaf5')
+    };
+    const backgroundImage =
+      toCleanString(mergedTheme.backgroundImage) || toCleanString(DEFAULT_THEME.backgroundImage);
+    if (backgroundImage) {
+      if (isCssGradient(backgroundImage)) {
+        style.backgroundImage = backgroundImage;
+      } else {
+        style.backgroundImage = `url(${backgroundImage})`;
+        style.backgroundSize = 'cover';
+        style.backgroundPosition = 'center';
+        style.backgroundRepeat = 'no-repeat';
+      }
+    }
+    return style;
+  }, [mergedTheme]);
+
+  const overlayColor = getColor(
+    mergedTheme.backgroundOverlayColor,
+    DEFAULT_THEME.backgroundOverlayColor,
+    'rgba(255,255,255,0.82)'
+  );
+  const accentColor = getColor(mergedTheme.accentColor, DEFAULT_THEME.accentColor, '#60a5fa');
+  const subtleTextColor = getColor(
+    mergedTheme.subtleTextColor,
+    DEFAULT_THEME.subtleTextColor,
+    'rgba(100,116,139,0.75)'
+  );
+  const titleColor = getColor(mergedTheme.titleColor, DEFAULT_THEME.titleColor, '#0f172a');
+  const textColor = getColor(mergedTheme.textColor, DEFAULT_THEME.textColor, '#1f2937');
+  const buttonBackground = getColor(
+    mergedTheme.buttonBackgroundColor,
+    DEFAULT_THEME.buttonBackgroundColor,
+    accentColor
+  );
+  const buttonHoverBackground = getColor(
+    mergedTheme.buttonHoverBackgroundColor,
+    DEFAULT_THEME.buttonHoverBackgroundColor,
+    accentColor
+  );
+  const buttonTextColor = getColor(mergedTheme.buttonTextColor, DEFAULT_THEME.buttonTextColor, '#ffffff');
+  const panelShadow = getColor(
+    mergedTheme.panelShadowColor,
+    DEFAULT_THEME.panelShadowColor,
+    'rgba(148,163,184,0.26)'
+  );
+  const boardShadow = getColor(
+    mergedTheme.boardShadowColor,
+    DEFAULT_THEME.boardShadowColor,
+    'rgba(100,116,139,0.24)'
+  );
+  const cardShadow = getColor(
+    mergedTheme.cardShadowColor,
+    DEFAULT_THEME.cardShadowColor,
+    'rgba(148,163,184,0.4)'
+  );
+  const matchedGlow = getColor(
+    mergedTheme.cardMatchedGlowColor,
+    DEFAULT_THEME.cardMatchedGlowColor,
+    accentColor
+  );
+
+  const panelStyle = {
+    background: getColor(
+      mergedTheme.panelBackgroundColor,
+      DEFAULT_THEME.panelBackgroundColor,
+      'rgba(255,255,255,0.88)'
+    ),
+    borderColor: getColor(
+      mergedTheme.panelBorderColor,
+      DEFAULT_THEME.panelBorderColor,
+      'rgba(148,163,184,0.32)'
+    ),
+    boxShadow: panelShadow ? `0 34px 80px -45px ${panelShadow}` : undefined
+  };
+
+  const boardStyle = {
+    background: getColor(
+      mergedTheme.boardBackgroundColor,
+      DEFAULT_THEME.boardBackgroundColor,
+      'rgba(255,255,255,0.92)'
+    ),
+    borderColor: getColor(
+      mergedTheme.boardBorderColor,
+      DEFAULT_THEME.boardBorderColor,
+      'rgba(191,219,254,0.7)'
+    ),
+    boxShadow: boardShadow ? `0 45px 120px -65px ${boardShadow}` : undefined
+  };
+
+  const cardBorderColor = getColor(
+    mergedTheme.cardBorderColor,
+    DEFAULT_THEME.cardBorderColor,
+    'rgba(191,219,254,0.9)'
+  );
+  const cardBackBackground = getColor(
+    mergedTheme.cardBackBackgroundColor,
+    DEFAULT_THEME.cardBackBackgroundColor,
+    'rgba(226,232,240,0.85)'
+  );
+  const cardFaceBackground = getColor(
+    mergedTheme.cardFaceBackgroundColor,
+    DEFAULT_THEME.cardFaceBackgroundColor,
+    'rgba(239,246,255,0.92)'
+  );
+  const matchedBackground = getColor(
+    mergedTheme.cardMatchedBackgroundColor,
+    DEFAULT_THEME.cardMatchedBackgroundColor,
+    'rgba(191,227,255,0.65)'
+  );
+
+  const cardBaseStyle = {
+    borderColor: cardBorderColor,
+    boxShadow: cardShadow ? `0 28px 55px -40px ${cardShadow}` : undefined
+  };
+
+  const cardBackStyle = {
+    ...cardBaseStyle,
+    background: cardBackBackground,
+    color: accentColor
+  };
+
+  const cardFrontStyle = {
+    ...cardBaseStyle,
+    background: cardFaceBackground,
+    color: titleColor
+  };
+
+  const matchedCardStyle = {
+    ...cardBaseStyle,
+    background: matchedBackground,
+    color: titleColor,
+    boxShadow: matchedGlow
+      ? `0 0 0 2px ${matchedBackground}, 0 30px 60px -40px ${matchedGlow}`
+      : cardBaseStyle.boxShadow
+  };
+
+  const swatchSections = COLOR_SECTIONS.map((section) => ({
+    ...section,
+    fields: section.fields.map((field) => ({
+      ...field,
+      value: mergedTheme[field.key],
+      isCustom: Boolean(theme && toCleanString(theme[field.key]))
+    }))
+  }));
+
+  return (
+    <div className="space-y-6">
+      <div className="overflow-hidden rounded-[32px] border border-slate-200/60 bg-white shadow-[0_30px_80px_-45px_rgba(15,23,42,0.38)]">
+        <div className="relative">
+          <div className="absolute inset-0" style={backgroundStyle} />
+          <div className="absolute inset-0" style={{ background: overlayColor }} />
+          <div className="relative space-y-6 px-8 py-10">
+            <div className="space-y-2">
+              <p
+                className="text-xs font-semibold uppercase tracking-[0.3em]"
+                style={{ color: subtleTextColor }}
+              >
+                Matching game preview
+              </p>
+              <h2 className="text-2xl font-semibold tracking-tight" style={{ color: titleColor }}>
+                {heading}
+              </h2>
+              <p className="text-sm leading-relaxed" style={{ color: textColor }}>
+                {body}
+              </p>
+            </div>
+            <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
+              <div className="rounded-3xl border p-5 shadow-sm" style={panelStyle}>
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <p
+                      className="text-xs uppercase tracking-[0.24em]"
+                      style={{ color: subtleTextColor }}
+                    >
+                      Moves left
+                    </p>
+                    <p className="text-2xl font-semibold" style={{ color: titleColor }}>
+                      6
+                    </p>
+                  </div>
+                  <div>
+                    <p
+                      className="text-xs uppercase tracking-[0.24em]"
+                      style={{ color: subtleTextColor }}
+                    >
+                      Pairs found
+                    </p>
+                    <p className="text-2xl font-semibold" style={{ color: titleColor }}>
+                      4 / 8
+                    </p>
+                  </div>
+                </div>
+                <div className="mt-6 space-y-3">
+                  <div className="flex items-center justify-between text-xs">
+                    <span style={{ color: subtleTextColor }}>Progress</span>
+                    <span style={{ color: titleColor }}>60%</span>
+                  </div>
+                  <div className="h-2 w-full overflow-hidden rounded-full bg-white/60">
+                    <div
+                      className="h-full rounded-full"
+                      style={{ background: accentColor, width: '60%' }}
+                    />
+                  </div>
+                </div>
+                <div className="mt-6 rounded-2xl border border-dashed border-slate-200/60 bg-white/60 p-4 text-xs" style={{ color: subtleTextColor }}>
+                  Hover colour preview: <span style={{ color: accentColor }}>{buttonHoverBackground}</span>
+                </div>
+                <button
+                  type="button"
+                  className="mt-6 w-full rounded-2xl px-5 py-3 text-sm font-semibold transition"
+                  style={{ background: buttonBackground, color: buttonTextColor }}
+                >
+                  Submit score
+                </button>
+              </div>
+              <div className="rounded-3xl border p-5" style={boardStyle}>
+                <div className="grid grid-cols-4 gap-3 text-sm font-semibold">
+                  <div
+                    className="flex aspect-[3/4] items-center justify-center rounded-xl border"
+                    style={cardFrontStyle}
+                  >
+                    ☀️
+                  </div>
+                  <div
+                    className="flex aspect-[3/4] items-center justify-center rounded-xl border"
+                    style={cardBackStyle}
+                  >
+                    ?
+                  </div>
+                  <div
+                    className="flex aspect-[3/4] items-center justify-center rounded-xl border"
+                    style={matchedCardStyle}
+                  >
+                    ✅
+                  </div>
+                  <div
+                    className="flex aspect-[3/4] items-center justify-center rounded-xl border"
+                    style={{ ...cardFrontStyle, color: subtleTextColor }}
+                  >
+                    💫
+                  </div>
+                </div>
+                <div className="mt-6 grid gap-3 text-xs" style={{ color: subtleTextColor }}>
+                  <div className="flex items-center justify-between">
+                    <span>Time elapsed</span>
+                    <span style={{ color: titleColor }}>01:12</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Next reward</span>
+                    <span style={{ color: accentColor }}>Free drink</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="space-y-4">
+        {swatchSections.map((section) => (
+          <div key={section.title} className="space-y-3">
+            <h3 className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-500">
+              {section.title}
+            </h3>
+            <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {section.fields.map((field) => (
+                <ColorSwatch
+                  key={field.key}
+                  label={field.label}
+                  value={field.value}
+                  isCustom={field.isCustom}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default MatchingGameThemePreview;

--- a/src/games/scratch-card-game/scratch-card-theme-preview.js
+++ b/src/games/scratch-card-game/scratch-card-theme-preview.js
@@ -1,0 +1,183 @@
+import React, { useMemo } from 'react';
+import { scratchCardPreviewOptions } from './config';
+
+const DEFAULT_OPTIONS = scratchCardPreviewOptions ?? {};
+const DEFAULT_PRIZES = Array.isArray(DEFAULT_OPTIONS.prizes) ? DEFAULT_OPTIONS.prizes : [];
+const DEFAULT_TITLE = DEFAULT_OPTIONS.title ?? 'Scratch & Reveal';
+const DEFAULT_DESCRIPTION =
+  DEFAULT_OPTIONS.description ?? 'Peel back the foil to uncover prizes and a glowing palette.';
+
+const toCleanString = (value) => (typeof value === 'string' ? value.trim() : '');
+const getColor = (value, fallback, fallbackAlt) => {
+  const trimmed = toCleanString(value);
+  if (trimmed) {
+    return trimmed;
+  }
+  const fallbackTrimmed = toCleanString(fallback);
+  if (fallbackTrimmed) {
+    return fallbackTrimmed;
+  }
+  return fallbackAlt;
+};
+
+const ScratchGradientSwatch = ({ label, foil, glow, isCustom }) => {
+  const foilValue = toCleanString(foil);
+  const glowValue = toCleanString(glow);
+  const gradient = `linear-gradient(135deg, ${foilValue || '#cbd5f5'}, ${glowValue || foilValue || '#64748b'})`;
+
+  return (
+    <div className="flex flex-col rounded-xl border border-slate-200/70 bg-white/85 p-3 shadow-sm shadow-slate-200/60">
+      <div className="flex items-center justify-between text-xs font-medium text-slate-600">
+        <span>{label}</span>
+        <span
+          className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+            isCustom ? 'bg-amber-100 text-amber-700' : 'bg-slate-100 text-slate-500'
+          }`}
+        >
+          {isCustom ? 'Custom' : 'Default'}
+        </span>
+      </div>
+      <div
+        className="mt-3 h-12 w-full overflow-hidden rounded-lg border border-slate-200/80"
+        style={{ background: gradient }}
+      />
+      <div className="mt-2 space-y-1 text-[11px] text-slate-500">
+        <p>Foil: {foilValue || 'Not set'}</p>
+        <p>Glow: {glowValue || 'Not set'}</p>
+      </div>
+    </div>
+  );
+};
+
+const ScratchCardThemePreview = ({ prizes, title, description }) => {
+  const providedPrizes = Array.isArray(prizes) ? prizes : [];
+  const heading = toCleanString(title) || DEFAULT_TITLE;
+  const body = toCleanString(description) || DEFAULT_DESCRIPTION;
+
+  const previewPrizes = useMemo(() => {
+    const source = providedPrizes.length ? providedPrizes : DEFAULT_PRIZES;
+    return source.slice(0, 5).map((prize, index) => {
+      const fallback = DEFAULT_PRIZES[index] ?? {};
+      const foil = getColor(prize?.foilColor, fallback.foilColor, '#cbd5f5');
+      const glow = getColor(prize?.glowColor, fallback.glowColor, 'rgba(148, 163, 184, 0.45)');
+      const label =
+        toCleanString(prize?.rarityLabel) ||
+        toCleanString(prize?.name) ||
+        toCleanString(fallback.rarityLabel) ||
+        toCleanString(fallback.name) ||
+        `Prize ${index + 1}`;
+      const isCustom = Boolean(
+        providedPrizes.length &&
+          (toCleanString(providedPrizes[index]?.foilColor) || toCleanString(providedPrizes[index]?.glowColor))
+      );
+
+      return {
+        id: prize?.id ?? fallback.id ?? `scratch-prize-${index}`,
+        label,
+        foil,
+        glow,
+        isCustom
+      };
+    });
+  }, [providedPrizes]);
+
+  const heroPrize = previewPrizes[0] ?? {
+    label: 'Prize reveal',
+    foil: '#cbd5f5',
+    glow: 'rgba(148, 163, 184, 0.45)'
+  };
+  const heroGradient = `linear-gradient(135deg, ${heroPrize.foil}, ${heroPrize.glow || heroPrize.foil})`;
+
+  return (
+    <div className="space-y-6">
+      <div className="overflow-hidden rounded-[32px] border border-slate-200/60 bg-slate-950 text-slate-100 shadow-[0_30px_90px_-45px_rgba(15,23,42,0.65)]">
+        <div className="relative px-8 py-10">
+          <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900 opacity-95" />
+          <div className="relative grid gap-8 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+            <div className="space-y-6">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">
+                  Scratch card palette preview
+                </p>
+                <h2 className="text-2xl font-semibold tracking-tight text-white">{heading}</h2>
+                <p className="text-sm leading-relaxed text-white/80">{body}</p>
+              </div>
+              <div className="relative overflow-hidden rounded-[28px] border border-white/15 bg-slate-900/70 px-6 py-8">
+                <div className="absolute inset-0 opacity-90" style={{ background: heroGradient }} />
+                <div
+                  className="absolute inset-5 rounded-[24px] border border-white/30 bg-white/10 backdrop-blur-sm"
+                  style={{ boxShadow: `0 0 70px ${heroPrize.glow || 'rgba(255,255,255,0.25)'}` }}
+                />
+                <div className="relative flex h-full flex-col items-center justify-center text-center">
+                  <p className="text-xs uppercase tracking-[0.28em] text-white/75">Foil reveal</p>
+                  <h3 className="mt-2 text-2xl font-semibold text-white">{heroPrize.label}</h3>
+                  <p className="mt-3 max-w-xs text-sm text-white/80">
+                    This mock scratch area reflects the selected foil and glow colours.
+                  </p>
+                  <div className="mt-5 flex items-center gap-4 text-xs">
+                    <span className="flex items-center gap-2 rounded-full bg-white/15 px-3 py-1">
+                      <span className="h-3 w-3 rounded-full" style={{ background: heroPrize.foil }} />
+                      Foil
+                    </span>
+                    <span className="flex items-center gap-2 rounded-full bg-white/15 px-3 py-1">
+                      <span className="h-3 w-3 rounded-full" style={{ background: heroPrize.glow }} />
+                      Glow
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="space-y-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.32em] text-white/60">
+                Foil & glow palette
+              </p>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {previewPrizes.map((prize) => {
+                  const gradient = `linear-gradient(135deg, ${prize.foil}, ${prize.glow || prize.foil})`;
+                  return (
+                    <div
+                      key={prize.id}
+                      className="flex h-full flex-col justify-between rounded-2xl border border-white/15 bg-slate-900/70 p-4 shadow-lg shadow-slate-900/40"
+                    >
+                      <div className="flex items-center gap-3">
+                        <div
+                          className="h-12 w-12 rounded-xl border border-white/25"
+                          style={{ background: gradient }}
+                        />
+                        <div>
+                          <p className="text-xs uppercase tracking-wide text-white/70">{prize.label}</p>
+                          <p className="text-[11px] text-white/70">Foil: {prize.foil || 'Not set'}</p>
+                          <p className="text-[11px] text-white/70">Glow: {prize.glow || 'Not set'}</p>
+                        </div>
+                      </div>
+                      <span
+                        className={`mt-3 inline-flex w-fit rounded-full px-2.5 py-0.5 text-[10px] font-semibold tracking-wide ${
+                          prize.isCustom ? 'bg-amber-500/10 text-amber-200' : 'bg-white/10 text-white/60'
+                        }`}
+                      >
+                        {prize.isCustom ? 'Custom palette' : 'Default palette'}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {previewPrizes.map((prize) => (
+          <ScratchGradientSwatch
+            key={`scratch-swatch-${prize.id}`}
+            label={prize.label}
+            foil={prize.foil}
+            glow={prize.glow}
+            isCustom={prize.isCustom}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ScratchCardThemePreview;


### PR DESCRIPTION
## Summary
- add a theme preview component to the matching game module that renders sample UI and colour swatches
- introduce a flip-card-new preview with the same palette visualisation so merchants can see updates live
- surface capsule and scratch-card colour previews for gachapon and scratch-card games to reflect their palette fields

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d091f446a0832a91dfefeafd33f651