### PR TITLE
Add bootstrap-styled flip card classic module

### DIFF
--- a/src/games/flip-card-classic/config/index.js
+++ b/src/games/flip-card-classic/config/index.js
@@ -1,0 +1,1 @@
+export { unwrapMongoValue, toCleanString, toTitleCase, deriveCardsFromData } from '../flip-card-new/config';

--- a/src/games/flip-card-classic/flip-card-classic.css
+++ b/src/games/flip-card-classic/flip-card-classic.css
@@ -1,0 +1,513 @@
+.flip-classic-game {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  color: var(--flip-text-color, #0f172a);
+}
+
+.flip-classic-overlay {
+  position: absolute;
+  inset: 0;
+  opacity: 0.85;
+}
+
+.flip-classic-content {
+  position: relative;
+  z-index: 1;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.flip-classic-header {
+  text-align: center;
+}
+
+.flip-classic-logo {
+  max-width: 140px;
+  max-height: 140px;
+  object-fit: contain;
+}
+
+.flip-classic-scoreboard {
+  background: var(--flip-panel-bg, rgba(255, 255, 255, 0.92));
+  border: 1px solid var(--flip-panel-border, rgba(148, 163, 184, 0.28));
+  border-radius: 1.75rem;
+  box-shadow: 0 24px 60px -30px rgba(15, 23, 42, 0.22);
+  padding: 1.5rem;
+}
+
+.flip-classic-scoreboard h1 {
+  font-weight: 600;
+}
+
+.flip-classic-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.flip-classic-stat-card {
+  flex: 1 1 140px;
+  min-width: 0;
+  background: var(--flip-board-bg, rgba(239, 246, 255, 0.78));
+  border: 1px solid var(--flip-panel-border, rgba(148, 163, 184, 0.28));
+  border-radius: 1rem;
+  padding: 0.75rem 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: var(--flip-subtle-text, rgba(71, 85, 105, 0.75));
+  text-align: center;
+}
+
+.flip-classic-stat-value {
+  display: block;
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--flip-text-color, #0f172a);
+}
+
+.flip-classic-progress {
+  height: 0.75rem;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(148, 163, 184, 0.25);
+}
+
+.flip-classic-progress-bar {
+  height: 100%;
+  background: var(--flip-accent, #60a5fa);
+  transition: width 0.3s ease;
+}
+
+.flip-classic-grid {
+  position: relative;
+  border-radius: 2rem;
+  padding: 2rem;
+  background: var(--flip-board-bg, rgba(248, 250, 252, 0.85));
+  border: 1px solid var(--flip-panel-border, rgba(148, 163, 184, 0.28));
+  box-shadow: 0 30px 80px -40px rgba(15, 23, 42, 0.35);
+}
+
+.flip-classic-card-button {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  border-radius: 1.5rem;
+  border: 1px solid var(--flip-card-border, rgba(191, 219, 254, 0.9));
+  background: var(--flip-card-back-bg, rgba(226, 232, 240, 0.85));
+  cursor: pointer;
+  padding: 0;
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+  overflow: hidden;
+}
+
+.flip-classic-card-button:focus-visible {
+  outline: 2px solid var(--flip-accent, #60a5fa);
+  outline-offset: 2px;
+}
+
+.flip-classic-card-button:disabled {
+  cursor: not-allowed;
+}
+
+.flip-classic-card-button[data-face-visible="false"]:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 40px -26px rgba(15, 23, 42, 0.28);
+}
+
+.flip-classic-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  transition: transform var(--flip-duration, 0.4s) ease-out;
+}
+
+.flip-classic-card-button[data-face-visible="true"] .flip-classic-card-inner {
+  transform: rotateY(180deg);
+}
+
+.flip-classic-card-face {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: inherit;
+  backface-visibility: hidden;
+}
+
+.flip-classic-card-back {
+  background: var(--flip-card-back-bg, rgba(226, 232, 240, 0.85));
+}
+
+.flip-classic-card-front {
+  background: var(--flip-card-face-bg, rgba(239, 246, 255, 0.92));
+  transform: rotateY(180deg);
+}
+
+.flip-classic-card-back img,
+.flip-classic-card-front img {
+  max-width: 78%;
+  max-height: 78%;
+  object-fit: contain;
+  box-shadow: 0 20px 45px rgba(148, 163, 184, 0.35);
+}
+
+.flip-classic-card-label {
+  font-size: 0.65rem;
+  letter-spacing: 0.32em;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--flip-accent, #60a5fa);
+}
+
+.flip-classic-card-matched {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border-radius: inherit;
+  background: var(--flip-card-match-bg, rgba(191, 227, 255, 0.65));
+  color: var(--flip-text-color, #0f172a);
+  backdrop-filter: blur(6px);
+}
+
+.flip-classic-card-matched span {
+  margin-top: 0.35rem;
+  font-size: 0.6rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--flip-subtle-text, rgba(71, 85, 105, 0.75));
+  font-weight: 600;
+}
+
+.flip-classic-lock-overlay {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: rgba(15, 23, 42, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  z-index: 3;
+}
+
+.flip-classic-initial-countdown {
+  position: absolute;
+  top: 1rem;
+  right: 1.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.72);
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  z-index: 2;
+}
+
+.flip-classic-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.35);
+  z-index: 1050;
+}
+
+.flip-classic-modal {
+  width: 100%;
+  max-width: 420px;
+  border-radius: 1.75rem;
+  border: 1px solid var(--flip-panel-border, rgba(148, 163, 184, 0.28));
+  overflow: hidden;
+  padding: 2rem;
+}
+
+.flip-classic-modal button.btn-primary {
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.flip-classic-footer {
+  margin-top: 1.5rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--flip-subtle-text, rgba(71, 85, 105, 0.75));
+}
+
+@media (max-width: 991.98px) {
+  .flip-classic-grid {
+    padding: 1.5rem;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .flip-classic-grid {
+    padding: 1rem;
+  }
+
+  .flip-classic-card-button {
+    border-radius: 1.25rem;
+  }
+}
+/* Bootstrap-inspired utility fallbacks */
+.container {
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.d-flex {
+  display: flex !important;
+}
+
+.flex-wrap {
+  flex-wrap: wrap !important;
+}
+
+.flex-fill {
+  flex: 1 1 auto !important;
+}
+
+.align-items-center {
+  align-items: center !important;
+}
+
+.justify-content-center {
+  justify-content: center !important;
+}
+
+.justify-content-between {
+  justify-content: space-between !important;
+}
+
+.text-center {
+  text-align: center !important;
+}
+
+.text-uppercase {
+  text-transform: uppercase !important;
+}
+
+.text-muted {
+  color: rgba(100, 116, 139, 0.75) !important;
+}
+
+.fw-semibold {
+  font-weight: 600 !important;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+.rounded-pill {
+  border-radius: 999px !important;
+}
+
+.rounded-4 {
+  border-radius: 1.25rem !important;
+}
+
+.border {
+  border: 1px solid rgba(148, 163, 184, 0.28) !important;
+}
+
+.btn {
+  display: inline-block;
+  font-weight: 600;
+  text-align: center;
+  cursor: pointer;
+  border: 1px solid transparent;
+  padding: 0.55rem 1.1rem;
+  border-radius: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(148, 163, 184, 0.2);
+  color: #0f172a;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.btn:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: var(--flip-accent, #60a5fa);
+  border-color: var(--flip-accent, #60a5fa);
+  color: #ffffff;
+}
+
+.btn-primary:hover:not(:disabled) {
+  filter: brightness(0.95);
+}
+
+.w-100 {
+  width: 100% !important;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0 -0.75rem;
+}
+
+.row.g-3 {
+  row-gap: 1rem;
+  column-gap: 1rem;
+}
+
+.row.g-md-4 {
+  row-gap: 1.5rem;
+  column-gap: 1.5rem;
+}
+
+.col-4 {
+  width: 33.333%;
+  padding: 0 0.75rem;
+}
+
+@media (max-width: 575.98px) {
+  .col-4 {
+    width: 50%;
+  }
+}
+
+@media (min-width: 576px) {
+  .col-sm-3 {
+    width: 25%;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .col-sm-3 {
+    width: 50%;
+  }
+}
+
+.gap-3 {
+  gap: 1rem !important;
+}
+
+.g-md-4 {
+  gap: 1.5rem !important;
+}
+
+.p-3 {
+  padding: 1rem !important;
+}
+
+.p-4 {
+  padding: 1.5rem !important;
+}
+
+.p-5 {
+  padding: 2rem !important;
+}
+
+.px-3 {
+  padding-left: 1rem !important;
+  padding-right: 1rem !important;
+}
+
+.py-2 {
+  padding-top: 0.5rem !important;
+  padding-bottom: 0.5rem !important;
+}
+
+.py-5 {
+  padding-top: 2rem !important;
+  padding-bottom: 2rem !important;
+}
+
+.mt-2 {
+  margin-top: 0.5rem !important;
+}
+
+.mt-3 {
+  margin-top: 1rem !important;
+}
+
+.mt-4 {
+  margin-top: 1.5rem !important;
+}
+
+.mt-5 {
+  margin-top: 2rem !important;
+}
+
+.mb-0 {
+  margin-bottom: 0 !important;
+}
+
+.mb-2 {
+  margin-bottom: 0.5rem !important;
+}
+
+.mb-3 {
+  margin-bottom: 1rem !important;
+}
+
+.mb-4 {
+  margin-bottom: 1.5rem !important;
+}
+
+.badge.px-3 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.badge.py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.spinner-border {
+  display: inline-block;
+  width: 3rem;
+  height: 3rem;
+  border: 0.3rem solid rgba(226, 232, 240, 0.7);
+  border-radius: 50%;
+  border-top-color: currentColor;
+  animation: spin 0.85s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  border: 0 !important;
+}

--- a/src/games/flip-card-classic/flip-card-classic.js
+++ b/src/games/flip-card-classic/flip-card-classic.js
@@ -1,0 +1,696 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import FlipCard from './flip-card';
+import uniqueCardsArray from './unique-cards';
+import ResultsScreen from '../matching-game/results-screen';
+import { createThemeFromConfig, defaultTheme, isCssGradient } from './theme';
+import { deriveCardsFromData, toCleanString, unwrapMongoValue } from './config';
+import './flip-card-classic.css';
+
+const formatDuration = (seconds) => {
+  const safeSeconds = Number.isFinite(seconds) ? Math.max(0, Math.round(seconds)) : 0;
+  const minutes = Math.floor(safeSeconds / 60);
+  const remainingSeconds = safeSeconds % 60;
+
+  if (minutes <= 0) {
+    return `${remainingSeconds}s`;
+  }
+
+  return `${minutes}m ${remainingSeconds}s`;
+};
+
+const coerceNumber = (value) => {
+  const unwrapped = unwrapMongoValue(value);
+
+  if (typeof unwrapped === 'number') {
+    return Number.isFinite(unwrapped) ? unwrapped : NaN;
+  }
+
+  if (typeof unwrapped === 'string') {
+    const trimmed = unwrapped.trim();
+    if (!trimmed) {
+      return NaN;
+    }
+
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : NaN;
+  }
+
+  return NaN;
+};
+
+const getNumberOption = (value, fallback) => {
+  const parsed = coerceNumber(value);
+  if (Number.isFinite(parsed)) {
+    return parsed;
+  }
+  return fallback;
+};
+
+const GameStatusModal = ({ status, movesLeft, timeElapsed, onSubmit, isSubmitting, theme }) => {
+  const isWin = status === 'won';
+  const title = isWin ? 'You did it!' : 'Better luck next time';
+  const description = isWin
+    ? 'You matched every card before using all of your moves.'
+    : 'You ran out of moves before all of the pairs were discovered.';
+
+  const modalStyle = {
+    background: theme?.panelBackgroundColor || '#ffffff',
+    borderColor: theme?.panelBorderColor || 'rgba(148, 163, 184, 0.28)',
+    color: theme?.textColor || '#1f2937'
+  };
+
+  const accentColor = theme?.accentColor || '#60a5fa';
+  const buttonBackground = theme?.buttonBackgroundColor || accentColor;
+  const buttonText = theme?.buttonTextColor || '#ffffff';
+  const buttonStyle = {
+    background: buttonBackground,
+    borderColor: buttonBackground,
+    color: buttonText,
+    '--flip-accent': buttonBackground
+  };
+
+  return (
+    <div className="flip-classic-modal-backdrop" role="dialog" aria-modal="true">
+      <div className="flip-classic-modal" style={modalStyle}>
+        <div className="text-center">
+          <h3 className="fw-semibold mb-2">{title}</h3>
+          <p className="text-muted mb-4" style={{ color: theme?.subtleTextColor || 'rgba(100, 116, 139, 0.75)' }}>
+            {description}
+          </p>
+          <div className="d-flex justify-content-between gap-3 mb-4 flex-wrap text-uppercase" style={{ color: theme?.subtleTextColor || 'rgba(100, 116, 139, 0.75)', fontSize: '0.65rem', letterSpacing: '0.32em' }}>
+            <div className="flex-fill text-center p-3 border rounded-4" style={{ borderColor: theme?.panelBorderColor || 'rgba(148, 163, 184, 0.28)', background: theme?.boardBackgroundColor || 'rgba(239, 246, 255, 0.82)' }}>
+              <span>Outcome</span>
+              <span className="flip-classic-stat-value">{isWin ? 'Won' : 'Lost'}</span>
+            </div>
+            <div className="flex-fill text-center p-3 border rounded-4" style={{ borderColor: theme?.panelBorderColor || 'rgba(148, 163, 184, 0.28)', background: theme?.boardBackgroundColor || 'rgba(239, 246, 255, 0.82)' }}>
+              <span>Moves left</span>
+              <span className="flip-classic-stat-value">{movesLeft}</span>
+            </div>
+            <div className="flex-fill text-center p-3 border rounded-4" style={{ borderColor: theme?.panelBorderColor || 'rgba(148, 163, 184, 0.28)', background: theme?.boardBackgroundColor || 'rgba(239, 246, 255, 0.82)' }}>
+              <span>Time</span>
+              <span className="flip-classic-stat-value">{formatDuration(timeElapsed)}</span>
+            </div>
+          </div>
+          <button
+            type="button"
+            className="btn btn-primary w-100"
+            onClick={onSubmit}
+            disabled={isSubmitting}
+            style={buttonStyle}
+          >
+            {isSubmitting ? 'Submitting…' : 'Submit results'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const swap = (array, i, j) => {
+  const temp = array[i];
+  array[i] = array[j];
+  array[j] = temp;
+};
+
+const shuffleCards = (array) => {
+  const length = array.length;
+  for (let i = length; i > 0; i--) {
+    const randomIndex = Math.floor(Math.random() * i);
+    const currIndex = i - 1;
+    swap(array, currIndex, randomIndex);
+  }
+  return array;
+};
+
+const mockSubmitResults = (url, payload) => new Promise((resolve) => {
+  setTimeout(() => {
+    resolve(payload);
+  }, 800);
+});
+
+const FlipCardClassicGame = ({ config }) => {
+  const cardsFromConfig = useMemo(() => {
+    const derivedCards = deriveCardsFromData(config);
+    if (derivedCards.length > 0) {
+      return derivedCards;
+    }
+    return uniqueCardsArray;
+  }, [config]);
+
+  const [cards] = useState(() => shuffleCards(cardsFromConfig.concat(cardsFromConfig)));
+  const totalPairs = cards.length / 2;
+  const moveLimit = Math.max(0, getNumberOption(config?.move_limit ?? config?.moveLimit, 8));
+  const initialRevealDuration = Math.max(0, getNumberOption(config?.initial_reveal_seconds ?? config?.initialRevealSeconds, 0));
+  const cardUpflipSecondsRaw = getNumberOption(config?.card_upflip_seconds ?? config?.cardUpflipSeconds, 1);
+  const cardUpflipSeconds = cardUpflipSecondsRaw >= 0 ? cardUpflipSecondsRaw : 1;
+  const cardUpflipDurationMs = cardUpflipSeconds * 1000;
+  const evaluationDelayMs = Math.min(cardUpflipDurationMs, 500);
+  const flipBackDelayMs = Math.max(cardUpflipDurationMs - evaluationDelayMs, 0);
+
+  const [openCards, setOpenCards] = useState([]);
+  const [clearedCards, setClearedCards] = useState({});
+  const [moves, setMoves] = useState(0);
+  const [result, setResult] = useState(null);
+  const [gameStatus, setGameStatus] = useState('playing');
+  const [showModal, setShowModal] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isInitialRevealActive, setIsInitialRevealActive] = useState(initialRevealDuration > 0);
+  const [shouldDisableAllCards, setShouldDisableAllCards] = useState(initialRevealDuration > 0);
+  const [elapsedTime, setElapsedTime] = useState(0);
+  const [assetsLoaded, setAssetsLoaded] = useState(false);
+  const [initialRevealCountdown, setInitialRevealCountdown] = useState(
+    initialRevealDuration > 0 ? Math.ceil(initialRevealDuration) : 0
+  );
+  const [liveElapsedTime, setLiveElapsedTime] = useState(0);
+
+  const gameStartTimeRef = useRef(Date.now());
+  const gameStatusRef = useRef('playing');
+  const flipBackTimeoutRef = useRef(null);
+  const evaluationTimeoutRef = useRef(null);
+  const initialRevealTimeoutRef = useRef(null);
+  const preloadedSourcesRef = useRef('');
+
+  const movesLeft = Math.max(moveLimit - moves, 0);
+
+  const cardBackImage = useMemo(() => {
+    const camel = toCleanString(config?.cardBackImage);
+    if (camel) {
+      return camel;
+    }
+    const snake = toCleanString(config?.card_back_image);
+    if (snake) {
+      return snake;
+    }
+    return '/images/matching-game-assets/white-tiffin-assets/white-tiffin-logo.png';
+  }, [config?.cardBackImage, config?.card_back_image]);
+
+  const theme = useMemo(() => createThemeFromConfig(config || {}), [config]);
+
+  const headerSubtitle = useMemo(() => {
+    const description = toCleanString(config?.description);
+    if (description) {
+      return description;
+    }
+
+    const subtitle = toCleanString(config?.subtitle);
+    if (subtitle) {
+      return subtitle;
+    }
+
+    return '';
+  }, [config]);
+
+  const headerTitle = toCleanString(config?.title) || toCleanString(config?.name) || 'Flip Card Classic';
+
+  const gameId = toCleanString(config?.gameId) || toCleanString(config?.game_id) || 'flip-classic-001';
+  const gameType = toCleanString(config?.gameType) || toCleanString(config?.game_type) || 'flip-card-classic';
+  const submissionEndpoint =
+    toCleanString(config?.submissionEndpoint) || toCleanString(config?.submission_endpoint);
+
+  const flipDurationMs = useMemo(() => {
+    const parsed = Number(theme?.cardFlipDurationMs);
+    if (Number.isFinite(parsed) && parsed >= 120) {
+      return parsed;
+    }
+    return defaultTheme.cardFlipDurationMs;
+  }, [theme?.cardFlipDurationMs]);
+
+  const backgroundStyle = useMemo(() => {
+    const style = {
+      backgroundColor: theme.backgroundColor || defaultTheme.backgroundColor
+    };
+
+    const backgroundImage = toCleanString(theme.backgroundImage);
+    if (backgroundImage) {
+      if (isCssGradient(backgroundImage)) {
+        style.backgroundImage = backgroundImage;
+      } else {
+        style.backgroundImage = `url(${backgroundImage})`;
+        style.backgroundSize = 'cover';
+        style.backgroundPosition = 'center';
+        style.backgroundRepeat = 'no-repeat';
+      }
+    }
+
+    return style;
+  }, [theme.backgroundColor, theme.backgroundImage]);
+
+  const overlayStyle = useMemo(
+    () => ({ background: theme.backgroundOverlayColor || defaultTheme.backgroundOverlayColor }),
+    [theme.backgroundOverlayColor]
+  );
+
+  const pairsFound = useMemo(() => Object.keys(clearedCards).length, [clearedCards]);
+
+  const progressPercentage = useMemo(() => {
+    if (totalPairs <= 0) {
+      return 0;
+    }
+    return Math.min(100, Math.round((pairsFound / totalPairs) * 100));
+  }, [pairsFound, totalPairs]);
+
+  const formattedLiveDuration = formatDuration(liveElapsedTime);
+  const isBoardLocked = shouldDisableAllCards && !isInitialRevealActive && gameStatus === 'playing';
+
+  const stopAllTimeouts = () => {
+    if (initialRevealTimeoutRef.current) {
+      clearTimeout(initialRevealTimeoutRef.current);
+      initialRevealTimeoutRef.current = null;
+    }
+    if (flipBackTimeoutRef.current) {
+      clearTimeout(flipBackTimeoutRef.current);
+      flipBackTimeoutRef.current = null;
+    }
+    if (evaluationTimeoutRef.current) {
+      clearTimeout(evaluationTimeoutRef.current);
+      evaluationTimeoutRef.current = null;
+    }
+  };
+
+  useEffect(() => () => stopAllTimeouts(), []);
+
+  useEffect(() => {
+    gameStatusRef.current = gameStatus;
+  }, [gameStatus]);
+
+  useEffect(() => {
+    const backgroundImageSource = toCleanString(theme.backgroundImage);
+    const imageSources = [
+      ...cardsFromConfig.map((card) => card?.image).filter(Boolean),
+      cardBackImage,
+      isCssGradient(backgroundImageSource) ? null : backgroundImageSource
+    ].filter(Boolean);
+
+    const uniqueSources = Array.from(new Set(imageSources));
+    const sortedKey = uniqueSources.slice().sort().join('|');
+
+    if (sortedKey === preloadedSourcesRef.current && assetsLoaded) {
+      return;
+    }
+
+    preloadedSourcesRef.current = sortedKey;
+
+    if (uniqueSources.length === 0) {
+      setAssetsLoaded(true);
+      return;
+    }
+
+    let isCancelled = false;
+
+    setShouldDisableAllCards(true);
+    setAssetsLoaded(false);
+
+    const preloadPromises = uniqueSources.map((src) => new Promise((resolve) => {
+      const img = new Image();
+      img.onload = resolve;
+      img.onerror = resolve;
+      img.src = src;
+    }));
+
+    Promise.all(preloadPromises).then(() => {
+      if (!isCancelled) {
+        setAssetsLoaded(true);
+      }
+    });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [assetsLoaded, cardBackImage, cardsFromConfig, theme.backgroundImage]);
+
+  useEffect(() => {
+    if (initialRevealTimeoutRef.current) {
+      clearTimeout(initialRevealTimeoutRef.current);
+      initialRevealTimeoutRef.current = null;
+    }
+
+    if (!assetsLoaded) {
+      return undefined;
+    }
+
+    gameStartTimeRef.current = Date.now();
+    setLiveElapsedTime(0);
+    setElapsedTime(0);
+
+    if (initialRevealDuration > 0) {
+      setIsInitialRevealActive(true);
+      setShouldDisableAllCards(true);
+      setInitialRevealCountdown(Math.ceil(initialRevealDuration));
+      initialRevealTimeoutRef.current = setTimeout(() => {
+        setIsInitialRevealActive(false);
+        if (gameStatusRef.current === 'playing') {
+          setShouldDisableAllCards(false);
+        }
+        initialRevealTimeoutRef.current = null;
+      }, initialRevealDuration * 1000);
+    } else {
+      setIsInitialRevealActive(false);
+      setInitialRevealCountdown(0);
+      if (gameStatusRef.current === 'playing') {
+        setShouldDisableAllCards(false);
+      }
+    }
+
+    return () => {
+      if (initialRevealTimeoutRef.current) {
+        clearTimeout(initialRevealTimeoutRef.current);
+        initialRevealTimeoutRef.current = null;
+      }
+    };
+  }, [initialRevealDuration, assetsLoaded]);
+
+  useEffect(() => {
+    if (!isInitialRevealActive || initialRevealDuration <= 0) {
+      setInitialRevealCountdown(0);
+      return undefined;
+    }
+
+    setInitialRevealCountdown(Math.ceil(initialRevealDuration));
+
+    const interval = setInterval(() => {
+      setInitialRevealCountdown((prev) => (prev > 0 ? prev - 1 : 0));
+    }, 1000);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [isInitialRevealActive, initialRevealDuration]);
+
+  useEffect(() => {
+    if (!assetsLoaded || gameStatus !== 'playing') {
+      return undefined;
+    }
+
+    const interval = setInterval(() => {
+      const now = Date.now();
+      const secondsElapsed = Math.floor((now - gameStartTimeRef.current) / 1000);
+      setLiveElapsedTime(secondsElapsed);
+    }, 1000);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [assetsLoaded, gameStatus]);
+
+  useEffect(() => {
+    if (openCards.length !== 2) {
+      return undefined;
+    }
+
+    const [firstIndex, secondIndex] = openCards;
+
+    const evaluate = () => {
+      const first = cards[firstIndex];
+      const second = cards[secondIndex];
+
+      if (!first || !second) {
+        setOpenCards([]);
+        setShouldDisableAllCards(false);
+        return;
+      }
+
+      if (first.type === second.type) {
+        setClearedCards((prev) => ({ ...prev, [first.type]: true }));
+        setOpenCards([]);
+        setShouldDisableAllCards(false);
+        return;
+      }
+
+      flipBackTimeoutRef.current = setTimeout(() => {
+        setOpenCards([]);
+        setShouldDisableAllCards(false);
+        flipBackTimeoutRef.current = null;
+      }, flipBackDelayMs);
+    };
+
+    if (evaluationTimeoutRef.current) {
+      clearTimeout(evaluationTimeoutRef.current);
+      evaluationTimeoutRef.current = null;
+    }
+
+    evaluationTimeoutRef.current = setTimeout(() => {
+      evaluate();
+      evaluationTimeoutRef.current = null;
+    }, evaluationDelayMs);
+
+    return () => {
+      if (evaluationTimeoutRef.current) {
+        clearTimeout(evaluationTimeoutRef.current);
+        evaluationTimeoutRef.current = null;
+      }
+    };
+  }, [openCards, evaluationDelayMs, flipBackDelayMs, cards]);
+
+  useEffect(() => {
+    if (Object.keys(clearedCards).length === totalPairs && totalPairs > 0) {
+      setGameStatus('won');
+      setShowModal(true);
+      const finalElapsedTime = Math.floor((Date.now() - gameStartTimeRef.current) / 1000);
+      setElapsedTime(finalElapsedTime);
+      setShouldDisableAllCards(true);
+    }
+  }, [clearedCards, totalPairs]);
+
+  useEffect(() => {
+    if (movesLeft <= 0 && gameStatus === 'playing') {
+      setGameStatus('lost');
+      setShowModal(true);
+      setShouldDisableAllCards(true);
+      const finalElapsedTime = Math.floor((Date.now() - gameStartTimeRef.current) / 1000);
+      setElapsedTime(finalElapsedTime);
+    }
+  }, [movesLeft, gameStatus]);
+
+  const handleCardClick = (index) => {
+    if (shouldDisableAllCards || gameStatusRef.current !== 'playing' || isInitialRevealActive) {
+      return;
+    }
+
+    if (openCards.includes(index)) {
+      return;
+    }
+
+    if (openCards.length === 1) {
+      setOpenCards((prev) => [...prev, index]);
+      setMoves((prevMoves) => prevMoves + 1);
+      setShouldDisableAllCards(true);
+    } else {
+      if (flipBackTimeoutRef.current) {
+        clearTimeout(flipBackTimeoutRef.current);
+        flipBackTimeoutRef.current = null;
+      }
+      setOpenCards([index]);
+    }
+  };
+
+  const checkIsFlipped = (index) => isInitialRevealActive || openCards.includes(index);
+
+  const checkIsInactive = (card) => Boolean(clearedCards[card.type]);
+
+  const handleSubmitResults = () => {
+    if (isSubmitting || gameStatusRef.current === 'playing') {
+      return;
+    }
+
+    setIsSubmitting(true);
+    const finalElapsedTime = elapsedTime || Math.floor((Date.now() - gameStartTimeRef.current) / 1000);
+    const payload = {
+      gameId,
+      gameType,
+      outcome: gameStatus === 'won' ? 'Won' : 'Lost',
+      movesLeft,
+      timeElapsed: finalElapsedTime
+    };
+    const url = submissionEndpoint || `/api/${gameType}/${gameId}`;
+
+    mockSubmitResults(url, payload)
+      .then((response) => {
+        setResult(response);
+      })
+      .finally(() => {
+        setIsSubmitting(false);
+      });
+  };
+
+  if (!assetsLoaded) {
+    return (
+      <div className="flip-classic-game" style={backgroundStyle} role="status" aria-live="polite">
+        <div className="flip-classic-overlay" style={overlayStyle} aria-hidden="true" />
+        <div className="flip-classic-content d-flex align-items-center justify-content-center text-center">
+          <div>
+            <div
+              className="spinner-border mb-4"
+              role="status"
+              style={{ color: theme.accentColor || defaultTheme.accentColor }}
+            >
+              <span className="visually-hidden">Loading…</span>
+            </div>
+            <p className="fw-semibold" style={{ color: theme.titleColor || defaultTheme.titleColor }}>
+              Shuffling your cards
+            </p>
+            <p className="text-muted" style={{ color: theme.subtleTextColor || defaultTheme.subtleTextColor }}>
+              Loading artwork and preparing the deck…
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (result) {
+    return <ResultsScreen {...result} />;
+  }
+
+  return (
+    <div className="flip-classic-game" style={backgroundStyle}>
+      <div className="flip-classic-overlay" style={overlayStyle} aria-hidden="true" />
+      <div className="flip-classic-content container py-5">
+        <header
+          className="flip-classic-scoreboard mb-4"
+          style={{
+            '--flip-panel-bg': theme.panelBackgroundColor || defaultTheme.panelBackgroundColor,
+            '--flip-panel-border': theme.panelBorderColor || defaultTheme.panelBorderColor,
+            '--flip-subtle-text': theme.subtleTextColor || defaultTheme.subtleTextColor,
+            '--flip-text-color': theme.titleColor || defaultTheme.titleColor,
+            '--flip-board-bg': theme.boardBackgroundColor || defaultTheme.boardBackgroundColor
+          }}
+        >
+          <div className="flip-classic-header mb-4">
+            <span
+              className="badge rounded-pill px-3 py-2 text-uppercase"
+              style={{
+                background: theme.cardMatchedBackgroundColor || defaultTheme.cardMatchedBackgroundColor,
+                color: theme.accentColor || defaultTheme.accentColor,
+                letterSpacing: '0.32em',
+                fontSize: '0.6rem'
+              }}
+            >
+              Flip & Match
+            </span>
+            <h1 className="mt-3" style={{ color: theme.titleColor || defaultTheme.titleColor }}>
+              {headerTitle}
+            </h1>
+            {headerSubtitle && (
+              <p className="text-muted mb-0" style={{ color: theme.subtleTextColor || defaultTheme.subtleTextColor }}>
+                {headerSubtitle}
+              </p>
+            )}
+          </div>
+          <div className="flip-classic-stats">
+            <div className="flip-classic-stat-card">
+              Moves
+              <span className="flip-classic-stat-value">{movesLeft}</span>
+            </div>
+            <div className="flip-classic-stat-card">
+              Pairs
+              <span className="flip-classic-stat-value">{pairsFound}/{totalPairs}</span>
+            </div>
+            <div className="flip-classic-stat-card">
+              Time
+              <span className="flip-classic-stat-value">{formattedLiveDuration}</span>
+            </div>
+          </div>
+          <div className="mt-4">
+            <div className="d-flex justify-content-between text-uppercase" style={{ fontSize: '0.7rem', letterSpacing: '0.32em', color: theme.subtleTextColor || defaultTheme.subtleTextColor }}>
+              <span>Round progress</span>
+              <span>{progressPercentage}%</span>
+            </div>
+            <div className="flip-classic-progress mt-2">
+              <div
+                className="flip-classic-progress-bar"
+                style={{ width: `${progressPercentage}%`, '--flip-accent': theme.accentColor || defaultTheme.accentColor }}
+              />
+            </div>
+          </div>
+          {isInitialRevealActive && (
+            <div
+              className="mt-4 p-3 border rounded-4 text-uppercase"
+              style={{
+                borderColor: theme.cardBorderColor || defaultTheme.cardBorderColor,
+                background: theme.cardMatchedBackgroundColor || defaultTheme.cardMatchedBackgroundColor,
+                color: theme.titleColor || defaultTheme.titleColor,
+                fontSize: '0.65rem',
+                letterSpacing: '0.32em'
+              }}
+            >
+              <div className="d-flex justify-content-between">
+                <span>Memorise the cards</span>
+                {initialRevealCountdown > 0 && (
+                  <span style={{ color: theme.subtleTextColor || defaultTheme.subtleTextColor }}>
+                    Starts in {initialRevealCountdown}s
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+        </header>
+        <main
+          className="flip-classic-grid"
+          style={{
+            '--flip-board-bg': theme.boardBackgroundColor || defaultTheme.boardBackgroundColor,
+            '--flip-panel-border': theme.boardBorderColor || defaultTheme.boardBorderColor
+          }}
+        >
+          <div className="d-flex justify-content-between text-uppercase" style={{ fontSize: '0.65rem', letterSpacing: '0.32em', color: theme.subtleTextColor || defaultTheme.subtleTextColor }}>
+            <span>Find all {totalPairs} pairs</span>
+            <span>{isInitialRevealActive ? 'Memorise' : isBoardLocked ? 'Checking' : 'Flip away'}</span>
+          </div>
+          {isBoardLocked && (
+            <div
+              className="mt-3 text-center p-3 border rounded-4 text-uppercase"
+              style={{
+                borderColor: theme.cardBorderColor || defaultTheme.cardBorderColor,
+                background: 'rgba(255, 255, 255, 0.75)',
+                color: theme.subtleTextColor || defaultTheme.subtleTextColor,
+                fontSize: '0.65rem',
+                letterSpacing: '0.3em'
+              }}
+            >
+              Checking match…
+            </div>
+          )}
+          <div className="mt-4">
+            <div className="row g-3 g-md-4">
+              {cards.map((card, index) => (
+                <div key={index} className="col-4 col-sm-3">
+                  <FlipCard
+                    card={card}
+                    index={index}
+                    isDisabled={shouldDisableAllCards}
+                    isInactive={checkIsInactive(card)}
+                    isFlipped={checkIsFlipped(index)}
+                    onClick={handleCardClick}
+                    cardBackImage={cardBackImage}
+                    theme={theme}
+                    flipDurationMs={flipDurationMs}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+          {isInitialRevealActive && initialRevealCountdown > 0 && (
+            <div className="flip-classic-initial-countdown">{initialRevealCountdown}s</div>
+          )}
+          {shouldDisableAllCards && !isInitialRevealActive && (
+            <div className="flip-classic-lock-overlay">Please wait…</div>
+          )}
+        </main>
+        <div className="flip-classic-footer">
+          Finish the round before your moves run out to claim the top reward.
+        </div>
+      </div>
+      {showModal && (
+        <GameStatusModal
+          status={gameStatus}
+          movesLeft={movesLeft}
+          timeElapsed={elapsedTime}
+          onSubmit={handleSubmitResults}
+          isSubmitting={isSubmitting}
+          theme={theme}
+        />
+      )}
+    </div>
+  );
+};
+
+export default FlipCardClassicGame;

--- a/src/games/flip-card-classic/flip-card.js
+++ b/src/games/flip-card-classic/flip-card.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { IoCheckmarkCircle } from 'react-icons/io5';
+import './flip-card-classic.css';
+
+const FlipCardClassic = ({
+  onClick,
+  card,
+  index,
+  isInactive,
+  isFlipped,
+  isDisabled,
+  cardBackImage,
+  theme,
+  flipDurationMs
+}) => {
+  const isCardFaceVisible = isFlipped || isInactive;
+
+  const handleClick = () => {
+    if (!isCardFaceVisible && !isDisabled && !isInactive) {
+      onClick(index);
+    }
+  };
+
+  const buttonLabel = isInactive
+    ? `${card?.type || 'Card'} already matched`
+    : isCardFaceVisible
+      ? `Card showing ${card?.type || 'card'}`
+      : `Flip card ${index + 1}`;
+
+  const buttonStyle = {
+    '--flip-accent': theme?.accentColor || '#60a5fa',
+    '--flip-card-border': theme?.cardBorderColor || 'rgba(191, 219, 254, 0.9)',
+    '--flip-card-back-bg': theme?.cardBackBackgroundColor || 'rgba(226, 232, 240, 0.85)',
+    '--flip-card-face-bg': theme?.cardFaceBackgroundColor || 'rgba(239, 246, 255, 0.92)',
+    '--flip-card-match-bg': theme?.cardMatchedBackgroundColor || 'rgba(191, 227, 255, 0.65)',
+    '--flip-duration': `${flipDurationMs}ms`
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={isDisabled || isInactive}
+      aria-label={buttonLabel}
+      className="flip-classic-card-button"
+      style={buttonStyle}
+      data-face-visible={isCardFaceVisible}
+    >
+      <div className="flip-classic-card-inner">
+        <div className="flip-classic-card-face flip-classic-card-back">
+          {cardBackImage ? (
+            <img src={cardBackImage} alt="Card back" />
+          ) : (
+            <span className="flip-classic-card-label">Flip</span>
+          )}
+        </div>
+        <div className="flip-classic-card-face flip-classic-card-front">
+          <img
+            src={card.image}
+            alt={card.altText || card.type || 'Card front'}
+          />
+        </div>
+      </div>
+      {isInactive && (
+        <div className="flip-classic-card-matched">
+          <IoCheckmarkCircle size={40} color={theme?.accentColor || '#60a5fa'} />
+          <span>Matched</span>
+        </div>
+      )}
+    </button>
+  );
+};
+
+export default FlipCardClassic;

--- a/src/games/flip-card-classic/index.js
+++ b/src/games/flip-card-classic/index.js
@@ -1,0 +1,112 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import FlipCardClassicGame from './flip-card-classic';
+import sampleFlipCardClassicGameDocument from './sample-game-document';
+import { toCleanString } from './config';
+
+const mockFetchFlipCardClassicConfig = () =>
+  new Promise((resolve, reject) => {
+    try {
+      setTimeout(() => {
+        if (typeof structuredClone === 'function') {
+          resolve(structuredClone(sampleFlipCardClassicGameDocument));
+          return;
+        }
+
+        resolve(JSON.parse(JSON.stringify(sampleFlipCardClassicGameDocument)));
+      }, 400);
+    } catch (error) {
+      reject(error);
+    }
+  });
+
+const getGameIdentifier = (data) => {
+  if (!data || typeof data !== 'object') {
+    return '';
+  }
+
+  const snakeCaseId = toCleanString(data.game_id);
+  if (snakeCaseId) {
+    return snakeCaseId;
+  }
+
+  return toCleanString(data.gameId);
+};
+
+const ErrorState = ({ message, onBack }) => (
+  <div className="p-4 text-center">
+    <h3 className="fw-semibold">Game failed to load</h3>
+    <p className="text-muted">{message}</p>
+    {onBack && (
+      <button type="button" onClick={onBack} className="btn btn-primary mt-3">
+        Go back
+      </button>
+    )}
+  </div>
+);
+
+const LoadingState = () => (
+  <div className="d-flex justify-content-center align-items-center p-5 text-muted">Loading…</div>
+);
+
+export default function FlipCardClassicGameInit({ onBack }) {
+  const [config, setConfig] = useState(null);
+  const [error, setError] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setIsLoading(true);
+    setError(null);
+
+    mockFetchFlipCardClassicConfig()
+      .then((data) => {
+        if (cancelled) {
+          return;
+        }
+        if (!data) {
+          throw new Error('Game configuration was not found.');
+        }
+        setConfig(data);
+        setIsLoading(false);
+      })
+      .catch((fetchError) => {
+        if (cancelled) {
+          return;
+        }
+        const message =
+          fetchError instanceof Error
+            ? fetchError.message || 'Failed to load the Flip Card Classic configuration.'
+            : 'Failed to load the Flip Card Classic configuration.';
+        setError(message);
+        setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const hasValidConfig = useMemo(() => Boolean(getGameIdentifier(config)), [config]);
+
+  if (error) {
+    return <ErrorState message={error} onBack={onBack} />;
+  }
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (!hasValidConfig) {
+    return (
+      <ErrorState
+        message="This game no longer exists or its configuration is missing."
+        onBack={onBack}
+      />
+    );
+  }
+
+  return <FlipCardClassicGame config={config} onBack={onBack} />;
+}
+
+export { deriveCardsFromData } from './config';

--- a/src/games/flip-card-classic/sample-game-document.js
+++ b/src/games/flip-card-classic/sample-game-document.js
@@ -1,0 +1,1 @@
+export { default } from '../flip-card-new/sample-game-document';

--- a/src/games/flip-card-classic/theme.js
+++ b/src/games/flip-card-classic/theme.js
@@ -1,0 +1,1 @@
+export { createThemeFromConfig, defaultTheme, isCssGradient } from '../flip-card-new/theme';

--- a/src/games/flip-card-classic/unique-cards.js
+++ b/src/games/flip-card-classic/unique-cards.js
@@ -1,0 +1,1 @@
+export { default } from '../flip-card-new/unique-cards';


### PR DESCRIPTION
## Summary
- add a new flip-card-classic module that mirrors the flip-card-new gameplay without Tailwind
- implement a vanilla React + bootstrap-style presentation layer with reusable CSS utilities
- share the existing flip-card configuration, theme, and sample data to keep the original template structure

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daa327c9e8832ab23cf80e679c21d2