### PR TITLE
Restyle classic scratch and gachapon themes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,8 @@ import PrecisionTimerGameInit from './games/precision-timer-game/precision-timer
 import ShakeOffGame from './games/shake-off-game/shake-off-game';
 import GachaponGame from './games/gachapon-game/gachapon-game';
 import ScratchCardGame from './games/scratch-card-game/scratch-card-game';
+import ScratchCardClassicGameInit from './games/scratch-card-classic';
+import GachaponClassicGameInit from './games/gachapon-classic';
 import VocalLiftGameInit from './games/vocal-lift-game/vocal-lift-game-init';
 
 function App() {
@@ -29,6 +31,8 @@ function App() {
               <Route path="/game6" element={<GachaponGame />} />
               <Route path="/game7" element={<ScratchCardGame />} />
               <Route path="/game8" element={<VocalLiftGameInit />} />
+              <Route path="/scratch-classic" element={<ScratchCardClassicGameInit />} />
+              <Route path="/gachapon-classic" element={<GachaponClassicGameInit />} />
             </Routes>
           </div>
         </Router>

--- a/src/components/home/home-nav.js
+++ b/src/components/home/home-nav.js
@@ -76,6 +76,16 @@ const HomeNav = () => {
             <p>Radiant Scratch Card</p>
           </div>
         </Link>
+        <Link to="/scratch-classic">
+          <div className="flex flex-col items-center justify-center">
+            <img
+              src="/images/scratch-card-game-thumb.svg"
+              alt="Scratch Card Classic Thumbnail"
+              className="h-48 w-48 rounded-md object-contain"
+            />
+            <p>Scratch Card Classic</p>
+          </div>
+        </Link>
         <Link to="/game8">
           <div className="flex flex-col items-center justify-center">
             <img
@@ -84,6 +94,16 @@ const HomeNav = () => {
               className="h-48 w-48 rounded-md object-contain"
             />
             <p>Flip Card (New)</p>
+          </div>
+        </Link>
+        <Link to="/gachapon-classic">
+          <div className="flex flex-col items-center justify-center">
+            <img
+              src="/images/gachapon-game-thumb.svg"
+              alt="Gachapon Classic Thumbnail"
+              className="h-48 w-48 rounded-md object-contain"
+            />
+            <p>Gachapon Classic</p>
           </div>
         </Link>
           <Link to="/game9">

--- a/src/games/gachapon-classic/config/index.js
+++ b/src/games/gachapon-classic/config/index.js
@@ -1,0 +1,178 @@
+export const unwrapMongoValue = (value) => {
+  if (value && typeof value === 'object') {
+    if (value.$numberInt !== undefined) {
+      return unwrapMongoValue(value.$numberInt);
+    }
+    if (value.$numberDouble !== undefined) {
+      return unwrapMongoValue(value.$numberDouble);
+    }
+    if (value.$numberLong !== undefined) {
+      return unwrapMongoValue(value.$numberLong);
+    }
+    if (value.$numberDecimal !== undefined) {
+      return unwrapMongoValue(value.$numberDecimal);
+    }
+    if (value.$oid !== undefined) {
+      return unwrapMongoValue(value.$oid);
+    }
+    if (value.$date !== undefined) {
+      return unwrapMongoValue(value.$date);
+    }
+    if (value.value !== undefined) {
+      return unwrapMongoValue(value.value);
+    }
+  }
+
+  return value;
+};
+
+export const toCleanString = (value) => {
+  const unwrapped = unwrapMongoValue(value);
+  if (typeof unwrapped === 'string') {
+    return unwrapped.trim();
+  }
+  if (typeof unwrapped === 'number' && Number.isFinite(unwrapped)) {
+    return `${unwrapped}`;
+  }
+  return '';
+};
+
+export const coerceNumber = (value) => {
+  const unwrapped = unwrapMongoValue(value);
+
+  if (typeof unwrapped === 'number') {
+    return Number.isFinite(unwrapped) ? unwrapped : NaN;
+  }
+
+  if (typeof unwrapped === 'string') {
+    const trimmed = unwrapped.trim();
+    if (!trimmed) {
+      return NaN;
+    }
+
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : NaN;
+  }
+
+  return NaN;
+};
+
+export const toPositiveInteger = (value, fallback) => {
+  const parsed = coerceNumber(value);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return Math.floor(parsed);
+  }
+  return fallback;
+};
+
+export const defaultPrizes = [
+  {
+    id: 'gachapon-classic-orb',
+    name: 'Luminous Orb',
+    description: 'A softly glowing orb that keeps your camp lit through the night.',
+    rarity: 'common',
+    weight: 40,
+    capsuleColor: '#E5E7EB'
+  },
+  {
+    id: 'gachapon-classic-charm',
+    name: 'Ember Charm',
+    description: 'A flickering charm that warms nearby allies by a few cozy degrees.',
+    rarity: 'uncommon',
+    weight: 28,
+    capsuleColor: '#86EFAC'
+  },
+  {
+    id: 'gachapon-classic-cape',
+    name: 'Aurora Cape',
+    description: 'Shimmers with the northern lights and lets you glide short distances.',
+    rarity: 'rare',
+    weight: 18,
+    capsuleColor: '#93C5FD'
+  },
+  {
+    id: 'gachapon-classic-compass',
+    name: 'Celestial Compass',
+    description: 'Always points toward the nearest secret, no matter where you roam.',
+    rarity: 'epic',
+    weight: 10,
+    capsuleColor: '#C4B5FD'
+  },
+  {
+    id: 'gachapon-classic-heartfire',
+    name: 'Dragon Heartfire',
+    description: "A fragment of dragon flame that grants a surge of courage to its bearer.",
+    rarity: 'legendary',
+    weight: 4,
+    capsuleColor: '#FDE68A'
+  }
+];
+
+export const defaultGachaponClassicConfig = {
+  game_id: 'gacha-classic-001',
+  game_template_id: 'gachapon-classic',
+  title: 'Celestial Capsule Machine',
+  description: 'Pull the lever to see what treasure is sealed within the capsule.',
+  primaryColor: '#ff4d6d',
+  secondaryColor: '#2bcdfb',
+  tertiaryColor: '#25064c',
+  backgroundImage: '/images/pattern-bg.png',
+  machineImage: '/images/gachapon-game-thumb.svg',
+  capsuleImage: '/images/gachapon-game-thumb.svg',
+  submissionEndpoint: '/api/games/gachapon/gacha-classic-001/results',
+  prizes: defaultPrizes
+};
+
+export const rarityOrder = ['common', 'uncommon', 'rare', 'epic', 'legendary'];
+
+const rarityLabels = {
+  common: 'Common',
+  uncommon: 'Uncommon',
+  rare: 'Rare',
+  epic: 'Epic',
+  legendary: 'Legendary'
+};
+
+export const derivePrizes = (data) => {
+  const source = Array.isArray(data?.prizes) ? data.prizes : [];
+  const effective = source.length ? source : defaultPrizes;
+
+  return effective.map((prize, index) => {
+    const rarity = toCleanString(prize?.rarity)?.toLowerCase() || rarityOrder[index] || 'common';
+    const weight = coerceNumber(prize?.weight);
+    return {
+      id: prize?.id || `gachapon-prize-${index + 1}`,
+      name: toCleanString(prize?.name) || `Prize ${index + 1}`,
+      description:
+        toCleanString(prize?.description) || 'Configure prize details in the merchant dashboard.',
+      rarity,
+      rarityLabel: toCleanString(prize?.rarityLabel) || rarityLabels[rarity] || rarityLabels.common,
+      weight: Number.isFinite(weight) && weight > 0 ? weight : defaultPrizes[index]?.weight || 1,
+      capsuleColor: toCleanString(prize?.capsuleColor) || defaultPrizes[index]?.capsuleColor || '#E5E7EB'
+    };
+  });
+};
+
+export const createThemeFromConfig = (config) => {
+  const base = config || {};
+  return {
+    primaryColor: toCleanString(base.primaryColor) || defaultGachaponClassicConfig.primaryColor,
+    secondaryColor: toCleanString(base.secondaryColor) || defaultGachaponClassicConfig.secondaryColor,
+    tertiaryColor: toCleanString(base.tertiaryColor) || defaultGachaponClassicConfig.tertiaryColor,
+    backgroundImage: toCleanString(base.backgroundImage) || defaultGachaponClassicConfig.backgroundImage,
+    machineImage: toCleanString(base.machineImage) || defaultGachaponClassicConfig.machineImage,
+    capsuleImage: toCleanString(base.capsuleImage) || defaultGachaponClassicConfig.capsuleImage
+  };
+};
+
+export const normalizeGachaponConfig = (config) => {
+  const theme = createThemeFromConfig(config);
+  return {
+    ...defaultGachaponClassicConfig,
+    ...config,
+    prizes: derivePrizes(config),
+    theme
+  };
+};
+
+export default defaultGachaponClassicConfig;

--- a/src/games/gachapon-classic/gachapon-classic.css
+++ b/src/games/gachapon-classic/gachapon-classic.css
@@ -1,0 +1,616 @@
+.gachapon-classic-game {
+  position: relative;
+  min-height: 100vh;
+  padding: clamp(2.75rem, 8vw, 4.5rem) clamp(1rem, 4vw, 1.75rem) clamp(4rem, 9vw, 5.5rem);
+  color: var(--gachapon-foreground, #fff7ff);
+  background-color: var(--gachapon-tertiary, #25064c);
+  background-image: var(--gachapon-background, none);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.gachapon-classic-game::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(
+      circle at 15% 20%,
+      rgba(var(--gachapon-primary-rgb, 255, 77, 109), 0.32),
+      transparent 60%
+    ),
+    radial-gradient(
+      circle at 85% 75%,
+      rgba(var(--gachapon-secondary-rgb, 43, 205, 251), 0.28),
+      transparent 55%
+    ),
+    radial-gradient(
+      circle at 50% 50%,
+      rgba(255, 189, 57, 0.18),
+      transparent 65%
+    );
+  pointer-events: none;
+}
+
+.gachapon-classic-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    160deg,
+    rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.78),
+    rgba(var(--gachapon-secondary-rgb, 43, 205, 251), 0.22)
+  );
+  opacity: 0.9;
+}
+
+.gachapon-classic-content {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 1120px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 5vw, 3rem);
+}
+
+.gachapon-classic-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .gachapon-classic-header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.gachapon-classic-heading {
+  max-width: 560px;
+}
+
+.gachapon-classic-tagline {
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.7rem;
+  opacity: 0.75;
+  margin-bottom: 0.4rem;
+}
+
+.gachapon-classic-title {
+  font-size: clamp(1.9rem, 3vw, 2.6rem);
+  font-weight: 600;
+  margin: 0;
+}
+
+.gachapon-classic-description {
+  margin-top: 0.4rem;
+  margin-bottom: 0;
+  line-height: 1.6;
+  opacity: 0.85;
+}
+
+.gachapon-classic-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.gachapon-classic-primary,
+.gachapon-classic-secondary {
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.75rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.gachapon-classic-primary {
+  background: linear-gradient(
+    135deg,
+    var(--gachapon-primary, #ff4d6d),
+    var(--gachapon-secondary, #2bcdfb)
+  );
+  color: var(--gachapon-contrast, #210039);
+  box-shadow: 0 22px 44px rgba(var(--gachapon-secondary-rgb, 43, 205, 251), 0.35);
+}
+
+.gachapon-classic-primary:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 30px 60px rgba(var(--gachapon-secondary-rgb, 43, 205, 251), 0.45);
+}
+
+.gachapon-classic-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.gachapon-classic-secondary {
+  background: rgba(var(--gachapon-secondary-rgb, 43, 205, 251), 0.18);
+  color: var(--gachapon-foreground, #fff7ff);
+  box-shadow: 0 12px 26px rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.35);
+}
+
+.gachapon-classic-secondary:hover {
+  transform: translateY(-1px);
+}
+
+.gachapon-classic-layout {
+  display: grid;
+  gap: 2rem;
+}
+
+.gachapon-classic-stage {
+  background: linear-gradient(
+    160deg,
+    rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.82),
+    rgba(var(--gachapon-primary-rgb, 255, 77, 109), 0.22),
+    rgba(255, 189, 57, 0.18)
+  );
+  border-radius: 2rem;
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  border: 1px solid rgba(var(--gachapon-foreground-rgb, 255, 247, 255), 0.18);
+  box-shadow: 0 40px 90px -35px rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.55);
+}
+
+.gachapon-classic-machine-wrapper {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 900px) {
+  .gachapon-classic-machine-wrapper {
+    grid-template-columns: minmax(0, 1fr) 300px;
+    align-items: stretch;
+  }
+}
+
+.gachapon-classic-machine {
+  position: relative;
+  width: 100%;
+  max-width: 360px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  filter: drop-shadow(0 30px 50px rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.55));
+}
+
+.gachapon-classic-machine__top {
+  width: 72%;
+  height: 80px;
+  border-radius: 999px 999px 40px 40px;
+  background: linear-gradient(
+    135deg,
+    rgba(var(--gachapon-secondary-rgb, 43, 205, 251), 0.35),
+    rgba(var(--gachapon-primary-rgb, 255, 77, 109), 0.28)
+  );
+  border: 1px solid rgba(var(--gachapon-foreground-rgb, 255, 247, 255), 0.4);
+}
+
+.gachapon-classic-machine__body {
+  position: relative;
+  width: 100%;
+  padding: 2.5rem 2rem 1.75rem;
+  border-radius: 32px;
+  background: linear-gradient(
+    160deg,
+    rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.9),
+    rgba(var(--gachapon-primary-rgb, 255, 77, 109), 0.26)
+  );
+  border: 1px solid rgba(var(--gachapon-foreground-rgb, 255, 247, 255), 0.28);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.gachapon-classic-machine__body::before {
+  content: '';
+  position: absolute;
+  inset: 12px;
+  border-radius: 24px;
+  background-image: var(--gachapon-machine-image, none);
+  background-size: cover;
+  background-position: center;
+  opacity: 0.22;
+  pointer-events: none;
+}
+
+.gachapon-classic-machine__window {
+  position: relative;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 220px;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at top,
+    rgba(var(--gachapon-secondary-rgb, 43, 205, 251), 0.3),
+    rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.9)
+  );
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.gachapon-classic-capsule {
+  position: relative;
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  box-shadow: inset 0 -18px 25px rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.4), inset 0 10px 20px rgba(255, 255, 255, 0.28);
+  transition: transform 0.35s ease, opacity 0.3s ease;
+}
+
+.gachapon-classic-capsule::before {
+  content: '';
+  position: absolute;
+  inset: 18%;
+  border-radius: 50%;
+  background-image: var(--gachapon-capsule-image, none);
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
+  opacity: 0.8;
+  mix-blend-mode: screen;
+}
+
+.gachapon-classic-capsule__glow {
+  position: absolute;
+  inset: -30%;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.85), transparent 65%);
+  filter: blur(20px);
+  transition: opacity 0.4s ease;
+  opacity: 0;
+}
+
+.gachapon-classic-machine__handle {
+  position: absolute;
+  right: -38px;
+  top: 45%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.gachapon-classic-machine__handle-stick {
+  width: 6px;
+  height: 64px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.8), rgba(var(--gachapon-foreground-rgb, 255, 247, 255), 0.5));
+}
+
+.gachapon-classic-machine__handle-knob {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: var(--gachapon-primary, #ff4d6d);
+  box-shadow: 0 12px 24px rgba(var(--gachapon-secondary-rgb, 43, 205, 251), 0.4);
+}
+
+.gachapon-classic-machine__base {
+  width: 85%;
+  height: 36px;
+  border-radius: 0 0 24px 24px;
+  background: linear-gradient(180deg, rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.95), rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.75));
+  border: 1px solid rgba(var(--gachapon-foreground-rgb, 255, 247, 255), 0.25);
+}
+
+.gachapon-classic-machine--preparing .gachapon-classic-capsule {
+  opacity: 0.6;
+  transform: scale(0.92);
+}
+
+.gachapon-classic-machine--shaking .gachapon-classic-capsule {
+  animation: gachapon-classic-shake 0.45s ease-in-out infinite;
+}
+
+.gachapon-classic-machine--opening .gachapon-classic-capsule {
+  animation: gachapon-classic-pop 0.7s ease forwards;
+}
+
+@keyframes gachapon-classic-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-6px);
+  }
+  50% {
+    transform: translateX(6px);
+  }
+  75% {
+    transform: translateX(-4px);
+  }
+}
+
+@keyframes gachapon-classic-pop {
+  0% {
+    transform: translateY(0) scale(1);
+  }
+  40% {
+    transform: translateY(-20px) scale(1.05);
+  }
+  100% {
+    transform: translateY(120px) scale(0.85);
+    opacity: 0;
+  }
+}
+
+.gachapon-classic-status {
+  background: linear-gradient(
+    150deg,
+    rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.78),
+    rgba(var(--gachapon-secondary-rgb, 43, 205, 251), 0.2),
+    rgba(255, 189, 57, 0.16)
+  );
+  border-radius: 1.75rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(var(--gachapon-foreground-rgb, 255, 247, 255), 0.18);
+  box-shadow: 0 24px 50px -24px rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.gachapon-classic-status__badge {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  background: rgba(var(--gachapon-secondary-rgb, 43, 205, 251), 0.24);
+  padding: 0.6rem 0.9rem;
+  border-radius: 999px;
+  text-align: center;
+}
+
+.gachapon-classic-status__copy {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  opacity: 0.8;
+  margin: 0;
+}
+
+.gachapon-classic-error {
+  font-size: 0.85rem;
+  color: #fecdd3;
+  background: rgba(248, 113, 113, 0.12);
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(248, 113, 113, 0.25);
+}
+
+.gachapon-classic-result {
+  padding: 1rem;
+  border-radius: 1.25rem;
+  background: linear-gradient(
+    150deg,
+    rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.68),
+    rgba(var(--gachapon-primary-rgb, 255, 77, 109), 0.24)
+  );
+  border: 1px solid rgba(var(--gachapon-foreground-rgb, 255, 247, 255), 0.18);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.gachapon-classic-result h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.gachapon-classic-result p {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.85;
+  line-height: 1.6;
+}
+
+.gachapon-classic-prizes {
+  background: linear-gradient(
+    150deg,
+    rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.74),
+    rgba(var(--gachapon-secondary-rgb, 43, 205, 251), 0.24),
+    rgba(255, 189, 57, 0.18)
+  );
+  border-radius: 2rem;
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  border: 1px solid rgba(var(--gachapon-foreground-rgb, 255, 247, 255), 0.18);
+  box-shadow: 0 30px 70px -30px rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.48);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.gachapon-classic-prizes__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.gachapon-classic-prizes__header p {
+  margin: 0.35rem 0 0;
+  opacity: 0.75;
+  max-width: 520px;
+}
+
+.gachapon-classic-prizes__state {
+  font-size: 0.95rem;
+  opacity: 0.8;
+}
+
+.gachapon-classic-prizes__state--error {
+  color: #fecdd3;
+}
+
+.gachapon-classic-prizes__grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+@media (min-width: 680px) {
+  .gachapon-classic-prizes__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.gachapon-classic-prize-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border-radius: 1.5rem;
+  padding: 1.25rem 1.35rem;
+  border: 1px solid rgba(var(--gachapon-foreground-rgb, 255, 247, 255), 0.24);
+  background: linear-gradient(
+    160deg,
+    rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.78),
+    rgba(var(--gachapon-primary-rgb, 255, 77, 109), 0.28),
+    rgba(var(--gachapon-secondary-rgb, 43, 205, 251), 0.25)
+  );
+  box-shadow: 0 24px 48px -28px rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.55);
+  gap: 1.15rem;
+}
+
+.gachapon-classic-prize-card__rarity {
+  margin: 0;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  letter-spacing: 0.24em;
+  opacity: 0.75;
+}
+
+.gachapon-classic-prize-card__title {
+  margin: 0.35rem 0 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.gachapon-classic-prize-card__description {
+  margin: 0.5rem 0 0;
+  opacity: 0.8;
+  line-height: 1.5;
+  font-size: 0.95rem;
+}
+
+.gachapon-classic-prize-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.22em;
+  opacity: 0.75;
+}
+
+.gachapon-classic-prize-card__footer strong {
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  color: var(--gachapon-secondary, #2bcdfb);
+}
+
+.gachapon-classic-prize-card--common {
+  border-color: rgba(var(--gachapon-foreground-rgb, 255, 247, 255), 0.35);
+}
+
+.gachapon-classic-prize-card--uncommon {
+  border-color: rgba(255, 192, 67, 0.45);
+  box-shadow: 0 24px 48px -26px rgba(255, 192, 67, 0.3);
+}
+
+.gachapon-classic-prize-card--rare {
+  border-color: rgba(135, 255, 173, 0.45);
+  box-shadow: 0 24px 48px -26px rgba(135, 255, 173, 0.3);
+}
+
+.gachapon-classic-prize-card--epic {
+  border-color: rgba(114, 183, 255, 0.45);
+  box-shadow: 0 24px 48px -26px rgba(114, 183, 255, 0.3);
+}
+
+.gachapon-classic-prize-card--legendary {
+  border-color: rgba(212, 145, 255, 0.5);
+  box-shadow: 0 24px 48px -24px rgba(212, 145, 255, 0.32);
+}
+
+.gachapon-classic-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+  padding: 1.5rem;
+}
+
+.gachapon-classic-modal__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.75);
+}
+
+.gachapon-classic-modal__panel {
+  position: relative;
+  width: min(420px, 100%);
+  border-radius: 2rem;
+  padding: 2.5rem 2rem;
+  text-align: center;
+  background: linear-gradient(
+    160deg,
+    rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.88),
+    rgba(var(--gachapon-primary-rgb, 255, 77, 109), 0.3)
+  );
+  border: 1px solid rgba(var(--gachapon-foreground-rgb, 255, 247, 255), 0.24);
+  box-shadow: 0 40px 90px -30px rgba(var(--gachapon-tertiary-rgb, 37, 6, 76), 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.gachapon-classic-modal__badge {
+  align-self: center;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(var(--gachapon-secondary-rgb, 43, 205, 251), 0.35);
+  background: rgba(var(--gachapon-secondary-rgb, 43, 205, 251), 0.18);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
+}
+
+.gachapon-classic-modal__title {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 600;
+}
+
+.gachapon-classic-modal__description {
+  margin: 0;
+  font-size: 0.95rem;
+  opacity: 0.85;
+  line-height: 1.6;
+}
+
+@media (max-width: 720px) {
+  .gachapon-classic-actions {
+    flex-wrap: wrap;
+  }
+
+  .gachapon-classic-stage,
+  .gachapon-classic-prizes {
+    border-radius: 1.5rem;
+  }
+
+  .gachapon-classic-machine__handle {
+    right: -24px;
+  }
+}

--- a/src/games/gachapon-classic/gachapon-classic.js
+++ b/src/games/gachapon-classic/gachapon-classic.js
@@ -1,0 +1,355 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { attemptGachapon, fetchAvailablePrizes } from '../gachapon-game/gachapon-api';
+import { createThemeFromConfig, derivePrizes, normalizeGachaponConfig, rarityOrder } from './config';
+import './gachapon-classic.css';
+
+const toRgbComponents = (hexColor, fallback) => {
+  if (typeof hexColor !== 'string') {
+    return fallback;
+  }
+
+  const normalized = hexColor.trim();
+  if (!normalized) {
+    return fallback;
+  }
+
+  const hexMatch = normalized.match(/^#?([0-9a-f]{3}|[0-9a-f]{6})$/i);
+  if (!hexMatch) {
+    return fallback;
+  }
+
+  let hex = hexMatch[1];
+  if (hex.length === 3) {
+    hex = hex
+      .split('')
+      .map((char) => `${char}${char}`)
+      .join('');
+  }
+
+  const intVal = parseInt(hex, 16);
+  if (Number.isNaN(intVal)) {
+    return fallback;
+  }
+
+  const r = (intVal >> 16) & 255;
+  const g = (intVal >> 8) & 255;
+  const b = intVal & 255;
+  return `${r}, ${g}, ${b}`;
+};
+
+const formatDropRate = (weight, totalWeight) => {
+  if (!totalWeight) {
+    return '—';
+  }
+
+  const percentage = (weight / totalWeight) * 100;
+  if (percentage < 0.1) {
+    return '<0.1%';
+  }
+
+  return `${percentage.toFixed(1)}%`;
+};
+
+const PrizeCard = ({ prize, dropRate }) => (
+  <div className={`gachapon-classic-prize-card gachapon-classic-prize-card--${prize.rarity || 'common'}`}>
+    <div>
+      <p className="gachapon-classic-prize-card__rarity">{prize.rarityLabel}</p>
+      <h3 className="gachapon-classic-prize-card__title">{prize.name}</h3>
+      <p className="gachapon-classic-prize-card__description">{prize.description}</p>
+    </div>
+    <div className="gachapon-classic-prize-card__footer">
+      <span>Drop rate</span>
+      <strong>{dropRate}</strong>
+    </div>
+  </div>
+);
+
+const GachaponClassicGame = ({ config }) => {
+  const navigate = useNavigate();
+
+  const mergedConfig = useMemo(() => normalizeGachaponConfig(config), [config]);
+  const theme = useMemo(() => createThemeFromConfig(mergedConfig.theme || mergedConfig), [mergedConfig]);
+  const [prizes, setPrizes] = useState(() => derivePrizes(mergedConfig));
+  const [loadingPrizes, setLoadingPrizes] = useState(true);
+  const [prizeError, setPrizeError] = useState(null);
+  const [isAttempting, setIsAttempting] = useState(false);
+  const [animationPhase, setAnimationPhase] = useState('idle');
+  const [result, setResult] = useState(null);
+  const [showResultModal, setShowResultModal] = useState(false);
+  const [attemptError, setAttemptError] = useState(null);
+  const [animationKey, setAnimationKey] = useState(0);
+
+  const timeoutsRef = useRef([]);
+  const isMountedRef = useRef(true);
+
+  const backgroundStyle = useMemo(
+    () => ({
+      '--gachapon-primary': theme.primaryColor,
+      '--gachapon-primary-rgb': toRgbComponents(theme.primaryColor, '255, 77, 109'),
+      '--gachapon-secondary': theme.secondaryColor,
+      '--gachapon-secondary-rgb': toRgbComponents(theme.secondaryColor, '43, 205, 251'),
+      '--gachapon-tertiary': theme.tertiaryColor,
+      '--gachapon-tertiary-rgb': toRgbComponents(theme.tertiaryColor, '37, 6, 76'),
+      '--gachapon-foreground': '#fff7ff',
+      '--gachapon-foreground-rgb': '255, 247, 255',
+      '--gachapon-contrast': '#210039',
+      '--gachapon-background': theme.backgroundImage ? `url(${theme.backgroundImage})` : 'none',
+      '--gachapon-machine-image': theme.machineImage ? `url(${theme.machineImage})` : 'none',
+      '--gachapon-capsule-image': theme.capsuleImage ? `url(${theme.capsuleImage})` : 'none'
+    }),
+    [theme]
+  );
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+      timeoutsRef.current.forEach(clearTimeout);
+      timeoutsRef.current = [];
+    };
+  }, []);
+
+  useEffect(() => {
+    setPrizes(derivePrizes(mergedConfig));
+    setAnimationPhase('idle');
+    setResult(null);
+    setShowResultModal(false);
+    setAttemptError(null);
+  }, [mergedConfig]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadingPrizes(true);
+    setPrizeError(null);
+
+    fetchAvailablePrizes(mergedConfig)
+      .then((availablePrizes) => {
+        if (cancelled || !isMountedRef.current) {
+          return;
+        }
+        if (Array.isArray(availablePrizes) && availablePrizes.length) {
+          setPrizes(availablePrizes);
+        }
+      })
+      .catch(() => {
+        if (cancelled || !isMountedRef.current) {
+          return;
+        }
+        setPrizeError('We could not load the prize list. Please refresh to try again.');
+      })
+      .finally(() => {
+        if (cancelled || !isMountedRef.current) {
+          return;
+        }
+        setLoadingPrizes(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [mergedConfig]);
+
+  const totalWeight = useMemo(
+    () => prizes.reduce((sum, prize) => sum + (Number.isFinite(prize.weight) ? prize.weight : 0), 0),
+    [prizes]
+  );
+
+  const queueTimeout = (callback, delay) => {
+    const timeoutId = setTimeout(callback, delay);
+    timeoutsRef.current.push(timeoutId);
+    return timeoutId;
+  };
+
+  const handleAttempt = () => {
+    if (isAttempting || loadingPrizes) {
+      return;
+    }
+
+    timeoutsRef.current.forEach(clearTimeout);
+    timeoutsRef.current = [];
+
+    setIsAttempting(true);
+    setAttemptError(null);
+    setResult(null);
+    setShowResultModal(false);
+    setAnimationKey((prev) => prev + 1);
+    setAnimationPhase('preparing');
+
+    attemptGachapon(mergedConfig)
+      .then((outcome) => {
+        if (!isMountedRef.current) {
+          return;
+        }
+
+        setResult(outcome);
+        setAnimationPhase('shaking');
+
+        queueTimeout(() => {
+          if (!isMountedRef.current) {
+            return;
+          }
+
+          setAnimationPhase('opening');
+
+          queueTimeout(() => {
+            if (!isMountedRef.current) {
+              return;
+            }
+
+            setAnimationPhase('result');
+            setShowResultModal(true);
+            setIsAttempting(false);
+          }, 700);
+        }, 1200);
+      })
+      .catch(() => {
+        if (!isMountedRef.current) {
+          return;
+        }
+        setAttemptError('Something interrupted the gachapon attempt. Please try again.');
+        setAnimationPhase('idle');
+        setIsAttempting(false);
+      });
+  };
+
+  const closeModal = () => {
+    setShowResultModal(false);
+    setAnimationPhase('idle');
+  };
+
+  const capsuleStatusLabel = (() => {
+    switch (animationPhase) {
+      case 'preparing':
+        return 'Preparing…';
+      case 'shaking':
+        return 'Shaking…';
+      case 'opening':
+        return 'Opening…';
+      case 'result':
+        return 'Capsule opened!';
+      default:
+        return 'Ready';
+    }
+  })();
+
+  const buttonLabel = isAttempting ? 'Dispensing…' : 'Start Gachapon';
+  const capsuleColor = result?.prize?.capsuleColor || theme.primaryColor;
+  const rarity = result?.prize?.rarity?.toLowerCase();
+  const rarityIndex = rarity ? Math.max(0, rarityOrder.indexOf(rarity)) : 0;
+  const glowStrength = 0.25 + rarityIndex * 0.1;
+
+  return (
+    <div className="gachapon-classic-game" style={backgroundStyle}>
+      <div className="gachapon-classic-overlay" />
+      <div className="gachapon-classic-content">
+        <header className="gachapon-classic-header">
+          <div className="gachapon-classic-heading">
+            <p className="gachapon-classic-tagline">Capsule experience</p>
+            <h1 className="gachapon-classic-title">{mergedConfig.title}</h1>
+            <p className="gachapon-classic-description">{mergedConfig.description}</p>
+          </div>
+          <div className="gachapon-classic-actions">
+            <button type="button" className="gachapon-classic-secondary" onClick={() => navigate(-1)}>
+              Back to store
+            </button>
+            <button
+              type="button"
+              className="gachapon-classic-primary"
+              onClick={handleAttempt}
+              disabled={isAttempting || loadingPrizes}
+            >
+              {buttonLabel}
+            </button>
+          </div>
+        </header>
+
+        <main className="gachapon-classic-layout">
+          <section className="gachapon-classic-stage">
+            <div className="gachapon-classic-machine-wrapper">
+              <div
+                className={`gachapon-classic-machine gachapon-classic-machine--${animationPhase}`}
+                key={animationKey}
+              >
+                <div className="gachapon-classic-machine__top" />
+                <div className="gachapon-classic-machine__body">
+                  <div className="gachapon-classic-machine__window">
+                    <div
+                      className="gachapon-classic-capsule"
+                      style={{ backgroundColor: capsuleColor }}
+                    >
+                      <div
+                        className="gachapon-classic-capsule__glow"
+                        style={{ opacity: animationPhase === 'result' ? glowStrength : 0 }}
+                      />
+                    </div>
+                  </div>
+                  <div className="gachapon-classic-machine__handle">
+                    <span className="gachapon-classic-machine__handle-knob" />
+                    <span className="gachapon-classic-machine__handle-stick" />
+                  </div>
+                </div>
+                <div className="gachapon-classic-machine__base" />
+              </div>
+
+              <aside className="gachapon-classic-status">
+                <div className="gachapon-classic-status__badge">{capsuleStatusLabel}</div>
+                <p className="gachapon-classic-status__copy">
+                  Every shake builds anticipation before the capsule bursts open to reveal your prize.
+                </p>
+                {attemptError ? <div className="gachapon-classic-error">{attemptError}</div> : null}
+                {result ? (
+                  <div className="gachapon-classic-result">
+                    <h3>{result.prize?.name ?? 'Mystery Capsule'}</h3>
+                    <p>{result.flairText ?? 'The capsule cracks open in a burst of light!'}</p>
+                  </div>
+                ) : null}
+              </aside>
+            </div>
+          </section>
+
+          <section className="gachapon-classic-prizes">
+            <div className="gachapon-classic-prizes__header">
+              <h2>Prize showcase</h2>
+              <p>Browse every prize currently loaded into the capsule.</p>
+            </div>
+            {loadingPrizes ? (
+              <p className="gachapon-classic-prizes__state">Loading prize lineup…</p>
+            ) : prizeError ? (
+              <p className="gachapon-classic-prizes__state gachapon-classic-prizes__state--error">{prizeError}</p>
+            ) : (
+              <div className="gachapon-classic-prizes__grid">
+                {prizes.map((prize) => (
+                  <PrizeCard
+                    key={prize.id}
+                    prize={prize}
+                    dropRate={formatDropRate(prize.weight ?? 0, totalWeight)}
+                  />
+                ))}
+              </div>
+            )}
+          </section>
+        </main>
+      </div>
+
+      {showResultModal && result ? (
+        <div className="gachapon-classic-modal" role="dialog" aria-modal="true">
+          <div className="gachapon-classic-modal__overlay" />
+          <div className="gachapon-classic-modal__panel">
+            <div className="gachapon-classic-modal__badge">{result.prize?.rarityLabel ?? 'Mystery'}</div>
+            <h3 className="gachapon-classic-modal__title">{result.prize?.name ?? 'Gachapon Result'}</h3>
+            <p className="gachapon-classic-modal__description">
+              {result.flairText ?? 'The capsule cracks open in a burst of light!'}
+            </p>
+            <button type="button" className="gachapon-classic-primary" onClick={closeModal}>
+              Close
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default GachaponClassicGame;

--- a/src/games/gachapon-classic/index.js
+++ b/src/games/gachapon-classic/index.js
@@ -1,0 +1,112 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import GachaponClassicGame from './gachapon-classic';
+import sampleGachaponClassicGameDocument from './sample-game-document';
+import { toCleanString } from './config';
+
+const mockFetchGachaponClassicConfig = () =>
+  new Promise((resolve, reject) => {
+    try {
+      setTimeout(() => {
+        if (typeof structuredClone === 'function') {
+          resolve(structuredClone(sampleGachaponClassicGameDocument));
+          return;
+        }
+
+        resolve(JSON.parse(JSON.stringify(sampleGachaponClassicGameDocument)));
+      }, 400);
+    } catch (error) {
+      reject(error);
+    }
+  });
+
+const getGameIdentifier = (data) => {
+  if (!data || typeof data !== 'object') {
+    return '';
+  }
+
+  const snakeCaseId = toCleanString(data.game_id);
+  if (snakeCaseId) {
+    return snakeCaseId;
+  }
+
+  return toCleanString(data.gameId);
+};
+
+const ErrorState = ({ message, onBack }) => (
+  <div className="p-4 text-center text-light">
+    <h3 className="fw-semibold">Game failed to load</h3>
+    <p className="text-muted">{message}</p>
+    {onBack && (
+      <button type="button" onClick={onBack} className="btn btn-primary mt-3">
+        Go back
+      </button>
+    )}
+  </div>
+);
+
+const LoadingState = () => (
+  <div className="d-flex justify-content-center align-items-center p-5 text-light">Loading…</div>
+);
+
+export default function GachaponClassicGameInit({ onBack }) {
+  const [config, setConfig] = useState(null);
+  const [error, setError] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setIsLoading(true);
+    setError(null);
+
+    mockFetchGachaponClassicConfig()
+      .then((data) => {
+        if (cancelled) {
+          return;
+        }
+        if (!data) {
+          throw new Error('Game configuration was not found.');
+        }
+        setConfig(data);
+        setIsLoading(false);
+      })
+      .catch((fetchError) => {
+        if (cancelled) {
+          return;
+        }
+        const message =
+          fetchError instanceof Error
+            ? fetchError.message || 'Failed to load the gachapon configuration.'
+            : 'Failed to load the gachapon configuration.';
+        setError(message);
+        setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const hasValidConfig = useMemo(() => Boolean(getGameIdentifier(config)), [config]);
+
+  if (error) {
+    return <ErrorState message={error} onBack={onBack} />;
+  }
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (!hasValidConfig) {
+    return (
+      <ErrorState
+        message="This game no longer exists or its configuration is missing."
+        onBack={onBack}
+      />
+    );
+  }
+
+  return <GachaponClassicGame config={config} />;
+}
+
+export { createThemeFromConfig, derivePrizes } from './config';

--- a/src/games/gachapon-classic/sample-game-document.js
+++ b/src/games/gachapon-classic/sample-game-document.js
@@ -1,0 +1,8 @@
+import { defaultGachaponClassicConfig } from './config';
+
+const sampleGachaponClassicGameDocument = {
+  ...defaultGachaponClassicConfig,
+  prizes: defaultGachaponClassicConfig.prizes.map((prize) => ({ ...prize }))
+};
+
+export default sampleGachaponClassicGameDocument;

--- a/src/games/scratch-card-classic/config/index.js
+++ b/src/games/scratch-card-classic/config/index.js
@@ -1,0 +1,172 @@
+export const unwrapMongoValue = (value) => {
+  if (value && typeof value === 'object') {
+    if (value.$numberInt !== undefined) {
+      return unwrapMongoValue(value.$numberInt);
+    }
+    if (value.$numberDouble !== undefined) {
+      return unwrapMongoValue(value.$numberDouble);
+    }
+    if (value.$numberLong !== undefined) {
+      return unwrapMongoValue(value.$numberLong);
+    }
+    if (value.$numberDecimal !== undefined) {
+      return unwrapMongoValue(value.$numberDecimal);
+    }
+    if (value.$oid !== undefined) {
+      return unwrapMongoValue(value.$oid);
+    }
+    if (value.$date !== undefined) {
+      return unwrapMongoValue(value.$date);
+    }
+    if (value.value !== undefined) {
+      return unwrapMongoValue(value.value);
+    }
+  }
+
+  return value;
+};
+
+export const toCleanString = (value) => {
+  const unwrapped = unwrapMongoValue(value);
+  if (typeof unwrapped === 'string') {
+    return unwrapped.trim();
+  }
+  if (typeof unwrapped === 'number' && Number.isFinite(unwrapped)) {
+    return `${unwrapped}`;
+  }
+  return '';
+};
+
+export const coerceNumber = (value) => {
+  const unwrapped = unwrapMongoValue(value);
+
+  if (typeof unwrapped === 'number') {
+    return Number.isFinite(unwrapped) ? unwrapped : NaN;
+  }
+
+  if (typeof unwrapped === 'string') {
+    const trimmed = unwrapped.trim();
+    if (!trimmed) {
+      return NaN;
+    }
+
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : NaN;
+  }
+
+  return NaN;
+};
+
+export const toPositiveInteger = (value, fallback) => {
+  const parsed = coerceNumber(value);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return Math.floor(parsed);
+  }
+  return fallback;
+};
+
+export const defaultPrizes = [
+  {
+    id: 'scratch-classic-token',
+    name: 'Aurora Token',
+    description: 'A shimmering token ready to be exchanged for campfire delights.',
+    rarity: 'common',
+    weight: 40
+  },
+  {
+    id: 'scratch-classic-thread',
+    name: 'Gleamthread',
+    description: 'Woven light that reinforces any gear it touches.',
+    rarity: 'uncommon',
+    weight: 28
+  },
+  {
+    id: 'scratch-classic-charm',
+    name: 'Charm of Dawn',
+    description: 'A radiant charm that greets every sunrise with a burst of optimism.',
+    rarity: 'rare',
+    weight: 18
+  },
+  {
+    id: 'scratch-classic-crest',
+    name: 'Eclipse Crest',
+    description: 'A crest forged from shadow and light, empowering the bearer at dusk.',
+    rarity: 'epic',
+    weight: 10
+  },
+  {
+    id: 'scratch-classic-heart',
+    name: 'Aurora Heart',
+    description: "A prismatic core that pulses with the aurora's rhythm and courage.",
+    rarity: 'legendary',
+    weight: 4
+  }
+];
+
+export const defaultScratchCardClassicConfig = {
+  game_id: 'scr-classic-001',
+  game_template_id: 'scratch-card-classic',
+  title: 'Aurora Scratch Card',
+  description: 'Peel back the foil to uncover tonight\'s glowing surprise.',
+  primaryColor: '#f5e3c3',
+  secondaryColor: '#f4b942',
+  tertiaryColor: '#0a0a0a',
+  backgroundImage: '/images/pattern-bg.png',
+  logoImage: '/logo512.png',
+  cardBackImage: '/images/matching-game-assets/card-back.png',
+  submissionEndpoint: '/api/games/scratch-card/scr-classic-001/results',
+  prizes: defaultPrizes
+};
+
+export const rarityOrder = ['common', 'uncommon', 'rare', 'epic', 'legendary'];
+
+const rarityLabels = {
+  common: 'Common',
+  uncommon: 'Uncommon',
+  rare: 'Rare',
+  epic: 'Epic',
+  legendary: 'Legendary'
+};
+
+export const derivePrizes = (data) => {
+  const source = Array.isArray(data?.prizes) ? data.prizes : [];
+  const effective = source.length ? source : defaultPrizes;
+
+  return effective.map((prize, index) => {
+    const rarity = toCleanString(prize?.rarity)?.toLowerCase() || rarityOrder[index] || 'common';
+    const weight = coerceNumber(prize?.weight);
+    return {
+      id: prize?.id || `scratch-prize-${index + 1}`,
+      name: toCleanString(prize?.name) || `Prize ${index + 1}`,
+      description:
+        toCleanString(prize?.description) || 'Configure prize details in the merchant dashboard.',
+      rarity,
+      rarityLabel: toCleanString(prize?.rarityLabel) || rarityLabels[rarity] || rarityLabels.common,
+      weight: Number.isFinite(weight) && weight > 0 ? weight : defaultPrizes[index]?.weight || 1
+    };
+  });
+};
+
+export const createThemeFromConfig = (config) => {
+  const base = config || {};
+  return {
+    primaryColor: toCleanString(base.primaryColor) || defaultScratchCardClassicConfig.primaryColor,
+    secondaryColor: toCleanString(base.secondaryColor) || defaultScratchCardClassicConfig.secondaryColor,
+    tertiaryColor: toCleanString(base.tertiaryColor) || defaultScratchCardClassicConfig.tertiaryColor,
+    backgroundImage: toCleanString(base.backgroundImage) || defaultScratchCardClassicConfig.backgroundImage,
+    logoImage: toCleanString(base.logoImage) || defaultScratchCardClassicConfig.logoImage,
+    cardBackImage: toCleanString(base.cardBackImage) || defaultScratchCardClassicConfig.cardBackImage
+  };
+};
+
+export const normalizeScratchCardConfig = (config) => {
+  const theme = createThemeFromConfig(config);
+  return {
+    ...defaultScratchCardClassicConfig,
+    ...config,
+    prizes: derivePrizes(config),
+    theme
+  };
+};
+
+export default defaultScratchCardClassicConfig;

--- a/src/games/scratch-card-classic/index.js
+++ b/src/games/scratch-card-classic/index.js
@@ -1,0 +1,112 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import ScratchCardClassicGame from './scratch-card-classic';
+import sampleScratchCardClassicGameDocument from './sample-game-document';
+import { toCleanString } from './config';
+
+const mockFetchScratchCardClassicConfig = () =>
+  new Promise((resolve, reject) => {
+    try {
+      setTimeout(() => {
+        if (typeof structuredClone === 'function') {
+          resolve(structuredClone(sampleScratchCardClassicGameDocument));
+          return;
+        }
+
+        resolve(JSON.parse(JSON.stringify(sampleScratchCardClassicGameDocument)));
+      }, 400);
+    } catch (error) {
+      reject(error);
+    }
+  });
+
+const getGameIdentifier = (data) => {
+  if (!data || typeof data !== 'object') {
+    return '';
+  }
+
+  const snakeCaseId = toCleanString(data.game_id);
+  if (snakeCaseId) {
+    return snakeCaseId;
+  }
+
+  return toCleanString(data.gameId);
+};
+
+const ErrorState = ({ message, onBack }) => (
+  <div className="p-4 text-center text-light">
+    <h3 className="fw-semibold">Game failed to load</h3>
+    <p className="text-muted">{message}</p>
+    {onBack && (
+      <button type="button" onClick={onBack} className="btn btn-primary mt-3">
+        Go back
+      </button>
+    )}
+  </div>
+);
+
+const LoadingState = () => (
+  <div className="d-flex justify-content-center align-items-center p-5 text-light">Loading…</div>
+);
+
+export default function ScratchCardClassicGameInit({ onBack }) {
+  const [config, setConfig] = useState(null);
+  const [error, setError] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setIsLoading(true);
+    setError(null);
+
+    mockFetchScratchCardClassicConfig()
+      .then((data) => {
+        if (cancelled) {
+          return;
+        }
+        if (!data) {
+          throw new Error('Game configuration was not found.');
+        }
+        setConfig(data);
+        setIsLoading(false);
+      })
+      .catch((fetchError) => {
+        if (cancelled) {
+          return;
+        }
+        const message =
+          fetchError instanceof Error
+            ? fetchError.message || 'Failed to load the scratch card configuration.'
+            : 'Failed to load the scratch card configuration.';
+        setError(message);
+        setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const hasValidConfig = useMemo(() => Boolean(getGameIdentifier(config)), [config]);
+
+  if (error) {
+    return <ErrorState message={error} onBack={onBack} />;
+  }
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (!hasValidConfig) {
+    return (
+      <ErrorState
+        message="This game no longer exists or its configuration is missing."
+        onBack={onBack}
+      />
+    );
+  }
+
+  return <ScratchCardClassicGame config={config} />;
+}
+
+export { createThemeFromConfig, derivePrizes } from './config';

--- a/src/games/scratch-card-classic/sample-game-document.js
+++ b/src/games/scratch-card-classic/sample-game-document.js
@@ -1,0 +1,8 @@
+import { defaultScratchCardClassicConfig } from './config';
+
+const sampleScratchCardClassicGameDocument = {
+  ...defaultScratchCardClassicConfig,
+  prizes: defaultScratchCardClassicConfig.prizes.map((prize) => ({ ...prize }))
+};
+
+export default sampleScratchCardClassicGameDocument;

--- a/src/games/scratch-card-classic/scratch-card-classic.css
+++ b/src/games/scratch-card-classic/scratch-card-classic.css
@@ -1,0 +1,665 @@
+.scratch-classic-game {
+  position: relative;
+  min-height: 100vh;
+  padding: clamp(2.75rem, 8vw, 4.5rem) clamp(1rem, 4vw, 1.75rem) clamp(4rem, 9vw, 5.5rem);
+  color: var(--scratch-foreground, #fff8e8);
+  background-color: var(--scratch-tertiary, #0a0a0a);
+  background-image: var(--scratch-background, none);
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.scratch-classic-game::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    160deg,
+    rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.88),
+    rgba(var(--scratch-secondary-rgb, 244, 185, 66), 0.22)
+  );
+  z-index: 0;
+}
+
+.scratch-classic-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    150deg,
+    rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.5),
+    rgba(var(--scratch-primary-rgb, 245, 227, 195), 0.18)
+  );
+  opacity: 0.92;
+}
+
+.scratch-classic-content {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 1120px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 5vw, 3rem);
+}
+
+.scratch-classic-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .scratch-classic-header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.scratch-classic-branding {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.scratch-classic-logo {
+  width: 72px;
+  height: 72px;
+  object-fit: contain;
+  border-radius: 20px;
+  background: rgba(var(--scratch-primary-rgb, 245, 227, 195), 0.15);
+  padding: 0.75rem;
+  box-shadow: 0 12px 24px rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.35);
+}
+
+.scratch-classic-tagline {
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.3em;
+  opacity: 0.7;
+  margin-bottom: 0.35rem;
+}
+
+.scratch-classic-title {
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+  font-weight: 600;
+  margin: 0;
+}
+
+.scratch-classic-description {
+  margin-top: 0.35rem;
+  margin-bottom: 0;
+  max-width: 560px;
+  line-height: 1.6;
+  opacity: 0.85;
+}
+
+.scratch-classic-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.scratch-classic-primary,
+.scratch-classic-secondary {
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.75rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.scratch-classic-primary {
+  background: linear-gradient(135deg, var(--scratch-primary, #f5e3c3), var(--scratch-secondary, #f4b942));
+  color: var(--scratch-contrast, #1d1304);
+  box-shadow: 0 20px 40px rgba(var(--scratch-secondary-rgb, 244, 185, 66), 0.35);
+}
+
+.scratch-classic-primary:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 26px 54px rgba(var(--scratch-secondary-rgb, 244, 185, 66), 0.45);
+}
+
+.scratch-classic-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.scratch-classic-secondary {
+  background: rgba(var(--scratch-primary-rgb, 245, 227, 195), 0.18);
+  color: var(--scratch-foreground, #fff8e8);
+  box-shadow: 0 10px 24px rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.3);
+}
+
+.scratch-classic-secondary:hover {
+  transform: translateY(-1px);
+}
+
+.scratch-classic-layout {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 992px) {
+  .scratch-classic-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.scratch-classic-stage {
+  background: linear-gradient(
+    160deg,
+    rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.82),
+    rgba(var(--scratch-primary-rgb, 245, 227, 195), 0.16)
+  );
+  border-radius: 2rem;
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  border: 1px solid rgba(var(--scratch-foreground-rgb, 255, 248, 232), 0.18);
+  box-shadow: 0 40px 90px -35px rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.55);
+}
+
+.scratch-classic-card-wrapper {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 900px) {
+  .scratch-classic-card-wrapper {
+    grid-template-columns: minmax(0, 1fr) 280px;
+    align-items: stretch;
+  }
+}
+
+.scratch-classic-card {
+  position: relative;
+  width: 100%;
+  max-width: 420px;
+  margin: 0 auto;
+  aspect-ratio: 3 / 2;
+  border-radius: 28px;
+  padding: 1.25rem;
+  background: linear-gradient(
+    160deg,
+    rgba(var(--scratch-secondary-rgb, 244, 185, 66), 0.35),
+    rgba(var(--scratch-primary-rgb, 245, 227, 195), 0.32)
+  );
+  box-shadow: 0 30px 60px rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.6);
+  transform-style: preserve-3d;
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+
+.scratch-classic-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.15), rgba(var(--scratch-primary-rgb, 245, 227, 195), 0));
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.scratch-classic-card--scratching {
+  animation: scratch-classic-wiggle 0.18s ease-in-out infinite;
+}
+
+.scratch-classic-card--revealed {
+  transform: translateY(-4px) scale(1.03);
+  box-shadow: 0 36px 80px rgba(var(--scratch-primary-rgb, 245, 227, 195), 0.55);
+}
+
+@keyframes scratch-classic-wiggle {
+  0% {
+    transform: rotate(0deg) translate3d(0, 0, 0);
+  }
+  25% {
+    transform: rotate(-1.5deg) translate3d(-4px, 2px, 0);
+  }
+  50% {
+    transform: rotate(1.5deg) translate3d(4px, -3px, 0);
+  }
+  75% {
+    transform: rotate(-1.2deg) translate3d(-3px, -2px, 0);
+  }
+  100% {
+    transform: rotate(0deg) translate3d(0, 0, 0);
+  }
+}
+
+.scratch-classic-card__inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 22px;
+  overflow: hidden;
+  background: linear-gradient(170deg, rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.92), rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.88));
+  box-shadow: inset 0 0 0 1px rgba(var(--scratch-foreground-rgb, 255, 248, 232), 0.18);
+}
+
+.scratch-classic-reward {
+  position: absolute;
+  inset: 12px;
+  border-radius: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: var(--scratch-foreground, #fff8e8);
+  padding: 1.75rem;
+  background: rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.75);
+  box-shadow: inset 0 0 0 1px rgba(var(--scratch-foreground-rgb, 255, 248, 232), 0.24);
+  opacity: 0.45;
+  transform: scale(0.96);
+  transition: opacity 0.45s ease, transform 0.45s ease, box-shadow 0.45s ease;
+  background-size: cover;
+  background-position: center;
+}
+
+.scratch-classic-card--revealed .scratch-classic-reward {
+  opacity: 1;
+  transform: scale(1);
+  box-shadow: inset 0 0 0 1px rgba(var(--scratch-foreground-rgb, 255, 248, 232), 0.3), 0 30px 60px rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.45);
+}
+
+.scratch-classic-reward__glow {
+  position: absolute;
+  inset: -35%;
+  border-radius: inherit;
+  filter: blur(26px);
+  opacity: 0;
+  transition: opacity 0.45s ease;
+}
+
+.scratch-classic-card--revealed .scratch-classic-reward__glow {
+  opacity: 1;
+}
+
+.scratch-classic-reward__body {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  z-index: 1;
+}
+
+.scratch-classic-reward__rarity {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  opacity: 0.7;
+  margin: 0;
+}
+
+.scratch-classic-reward__title {
+  font-size: 1.35rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.scratch-classic-reward__helper {
+  font-size: 0.8rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  opacity: 0.75;
+  margin: 0;
+}
+
+.scratch-classic-foil {
+  position: absolute;
+  inset: 12px;
+  border-radius: 18px;
+  overflow: hidden;
+  transition: opacity 0.45s ease, transform 0.45s ease;
+  pointer-events: none;
+}
+
+.scratch-classic-foil--interactive {
+  pointer-events: auto;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.scratch-classic-foil--cleared {
+  opacity: 0;
+  transform: scale(1.03);
+  pointer-events: none;
+}
+
+.scratch-classic-foil__canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  touch-action: none;
+  cursor: grab;
+}
+
+.scratch-classic-foil__canvas--inactive {
+  cursor: not-allowed;
+}
+
+.scratch-classic-foil__canvas--cleared {
+  cursor: default;
+}
+
+.scratch-classic-foil__noise,
+.scratch-classic-foil__shine {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.scratch-classic-foil__noise {
+  background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160" fill="none"%3E%3Cg opacity="0.5"%3E%3Ccircle cx="16" cy="16" r="1" fill="white"/%3E%3Ccircle cx="32" cy="56" r="1" fill="white"/%3E%3Ccircle cx="48" cy="24" r="1" fill="white"/%3E%3Ccircle cx="72" cy="48" r="1" fill="white"/%3E%3Ccircle cx="96" cy="20" r="1" fill="white"/%3E%3Ccircle cx="120" cy="60" r="1" fill="white"/%3E%3Ccircle cx="140" cy="28" r="1" fill="white"/%3E%3Ccircle cx="12" cy="120" r="1" fill="white"/%3E%3Ccircle cx="44" cy="136" r="1" fill="white"/%3E%3Ccircle cx="84" cy="124" r="1" fill="white"/%3E%3Ccircle cx="108" cy="108" r="1" fill="white"/%3E%3Ccircle cx="132" cy="144" r="1" fill="white"/%3E%3C/g%3E%3C/svg%3E');
+  mix-blend-mode: screen;
+  opacity: 0.45;
+}
+
+.scratch-classic-foil__shine {
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.45), rgba(255, 255, 255, 0));
+  mix-blend-mode: screen;
+  opacity: 0.6;
+}
+
+.scratch-classic-foil__message {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  font-size: 0.9rem;
+  padding: 1.25rem;
+  opacity: 0;
+  color: rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.85);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  transition: opacity 0.3s ease;
+}
+
+.scratch-classic-foil__message--visible {
+  opacity: 1;
+}
+
+.scratch-classic-foil__detail {
+  font-size: 0.75rem;
+  font-weight: 500;
+  margin-top: 0.35rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.scratch-classic-status {
+  background: linear-gradient(
+    150deg,
+    rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.78),
+    rgba(var(--scratch-secondary-rgb, 244, 185, 66), 0.18)
+  );
+  border-radius: 1.75rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(var(--scratch-foreground-rgb, 255, 248, 232), 0.18);
+  box-shadow: 0 24px 50px -24px rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.scratch-classic-status__badge {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  background: rgba(var(--scratch-primary-rgb, 245, 227, 195), 0.2);
+  padding: 0.6rem 0.9rem;
+  border-radius: 999px;
+  text-align: center;
+}
+
+.scratch-classic-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.scratch-classic-progress__track {
+  height: 0.75rem;
+  border-radius: 999px;
+  background: rgba(var(--scratch-foreground-rgb, 255, 248, 232), 0.25);
+  overflow: hidden;
+}
+
+.scratch-classic-progress__fill {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, var(--scratch-secondary, #f4b942), var(--scratch-primary, #f5e3c3));
+  transition: width 0.3s ease;
+}
+
+.scratch-classic-progress__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.scratch-classic-status__detail {
+  font-size: 0.85rem;
+  line-height: 1.6;
+  opacity: 0.85;
+}
+
+.scratch-classic-status__detail span {
+  color: var(--scratch-primary, #f5e3c3);
+  font-weight: 600;
+}
+
+.scratch-classic-error {
+  font-size: 0.85rem;
+  color: #fecdd3;
+  background: rgba(248, 113, 113, 0.12);
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(248, 113, 113, 0.25);
+}
+
+.scratch-classic-prizes {
+  background: linear-gradient(
+    150deg,
+    rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.74),
+    rgba(var(--scratch-primary-rgb, 245, 227, 195), 0.22)
+  );
+  border-radius: 2rem;
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  border: 1px solid rgba(var(--scratch-foreground-rgb, 255, 248, 232), 0.18);
+  box-shadow: 0 30px 70px -30px rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.48);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.scratch-classic-prizes__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.scratch-classic-prizes__header p {
+  margin: 0.35rem 0 0;
+  opacity: 0.75;
+  max-width: 520px;
+}
+
+.scratch-classic-prizes__state {
+  font-size: 0.95rem;
+  opacity: 0.8;
+}
+
+.scratch-classic-prizes__state--error {
+  color: #fecdd3;
+}
+
+.scratch-classic-prizes__grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+@media (min-width: 680px) {
+  .scratch-classic-prizes__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.scratch-classic-prize-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border-radius: 1.5rem;
+  padding: 1.25rem 1.35rem;
+  border: 1px solid rgba(var(--scratch-foreground-rgb, 255, 248, 232), 0.24);
+  background: linear-gradient(
+    160deg,
+    rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.78),
+    rgba(var(--scratch-secondary-rgb, 244, 185, 66), 0.18)
+  );
+  box-shadow: 0 24px 48px -28px rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.55);
+  gap: 1.15rem;
+}
+
+.scratch-classic-prize-card__rarity {
+  margin: 0;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  letter-spacing: 0.24em;
+  opacity: 0.75;
+}
+
+.scratch-classic-prize-card__title {
+  margin: 0.35rem 0 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.scratch-classic-prize-card__description {
+  margin: 0.5rem 0 0;
+  opacity: 0.8;
+  line-height: 1.5;
+  font-size: 0.95rem;
+}
+
+.scratch-classic-prize-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.22em;
+  opacity: 0.75;
+}
+
+.scratch-classic-prize-card__footer strong {
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  color: var(--scratch-primary, #f5e3c3);
+}
+
+.scratch-classic-prize-card--common {
+  border-color: rgba(var(--scratch-foreground-rgb, 255, 248, 232), 0.35);
+}
+
+.scratch-classic-prize-card--uncommon {
+  border-color: rgba(255, 195, 113, 0.45);
+  box-shadow: 0 24px 48px -26px rgba(255, 195, 113, 0.28);
+}
+
+.scratch-classic-prize-card--rare {
+  border-color: rgba(255, 137, 125, 0.45);
+  box-shadow: 0 24px 48px -26px rgba(255, 137, 125, 0.28);
+}
+
+.scratch-classic-prize-card--epic {
+  border-color: rgba(214, 168, 255, 0.45);
+  box-shadow: 0 24px 48px -26px rgba(214, 168, 255, 0.28);
+}
+
+.scratch-classic-prize-card--legendary {
+  border-color: rgba(255, 219, 102, 0.55);
+  box-shadow: 0 24px 48px -24px rgba(255, 219, 102, 0.32);
+}
+
+.scratch-classic-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+  padding: 1.5rem;
+}
+
+.scratch-classic-modal__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.75);
+}
+
+.scratch-classic-modal__panel {
+  position: relative;
+  width: min(420px, 100%);
+  border-radius: 2rem;
+  padding: 2.5rem 2rem;
+  text-align: center;
+  background: linear-gradient(
+    160deg,
+    rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.9),
+    rgba(var(--scratch-secondary-rgb, 244, 185, 66), 0.24)
+  );
+  border: 1px solid rgba(var(--scratch-foreground-rgb, 255, 248, 232), 0.24);
+  box-shadow: 0 40px 90px -30px rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.scratch-classic-modal__badge {
+  align-self: center;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(var(--scratch-secondary-rgb, 244, 185, 66), 0.35);
+  background: rgba(var(--scratch-secondary-rgb, 244, 185, 66), 0.2);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
+}
+
+.scratch-classic-modal__title {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 600;
+}
+
+.scratch-classic-modal__description {
+  margin: 0;
+  font-size: 0.95rem;
+  opacity: 0.85;
+  line-height: 1.6;
+}
+
+@media (max-width: 720px) {
+  .scratch-classic-actions {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .scratch-classic-stage,
+  .scratch-classic-prizes {
+    border-radius: 1.5rem;
+  }
+}

--- a/src/games/scratch-card-classic/scratch-card-classic.js
+++ b/src/games/scratch-card-classic/scratch-card-classic.js
@@ -1,0 +1,645 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { attemptScratchCard, fetchScratchPrizes } from '../scratch-card-game/scratch-card-api';
+import { createThemeFromConfig, derivePrizes, normalizeScratchCardConfig, rarityOrder } from './config';
+import './scratch-card-classic.css';
+
+const SCRATCH_CELL_SIZE = 32;
+const SCRATCH_RADIUS = 28;
+const REVEAL_THRESHOLD = 0.6;
+
+const toRgbComponents = (hexColor, fallback) => {
+  if (typeof hexColor !== 'string') {
+    return fallback;
+  }
+
+  const normalized = hexColor.trim();
+  if (!normalized) {
+    return fallback;
+  }
+
+  const hexMatch = normalized.match(/^#?([0-9a-f]{3}|[0-9a-f]{6})$/i);
+  if (!hexMatch) {
+    return fallback;
+  }
+
+  let hex = hexMatch[1];
+  if (hex.length === 3) {
+    hex = hex
+      .split('')
+      .map((char) => `${char}${char}`)
+      .join('');
+  }
+
+  const intVal = parseInt(hex, 16);
+  if (Number.isNaN(intVal)) {
+    return fallback;
+  }
+
+  const r = (intVal >> 16) & 255;
+  const g = (intVal >> 8) & 255;
+  const b = intVal & 255;
+  return `${r}, ${g}, ${b}`;
+};
+
+const rarityAccentClass = {
+  common: 'scratch-classic-prize-card--common',
+  uncommon: 'scratch-classic-prize-card--uncommon',
+  rare: 'scratch-classic-prize-card--rare',
+  epic: 'scratch-classic-prize-card--epic',
+  legendary: 'scratch-classic-prize-card--legendary'
+};
+
+const formatDropRate = (weight, totalWeight) => {
+  if (!totalWeight) {
+    return '—';
+  }
+
+  const percentage = (weight / totalWeight) * 100;
+  if (percentage < 0.1) {
+    return '<0.1%';
+  }
+
+  return `${percentage.toFixed(1)}%`;
+};
+
+const PrizeCard = ({ prize, dropRate }) => {
+  const rarityClass = rarityAccentClass[prize.rarity] || rarityAccentClass.common;
+  return (
+    <div className={`scratch-classic-prize-card ${rarityClass}`}>
+      <div className="scratch-classic-prize-card__body">
+        <p className="scratch-classic-prize-card__rarity">{prize.rarityLabel}</p>
+        <h3 className="scratch-classic-prize-card__title">{prize.name}</h3>
+        <p className="scratch-classic-prize-card__description">{prize.description}</p>
+      </div>
+      <div className="scratch-classic-prize-card__footer">
+        <span>Drop rate</span>
+        <strong>{dropRate}</strong>
+      </div>
+    </div>
+  );
+};
+
+const ScratchCardClassicGame = ({ config }) => {
+  const navigate = useNavigate();
+
+  const mergedConfig = useMemo(() => normalizeScratchCardConfig(config), [config]);
+  const theme = useMemo(() => createThemeFromConfig(mergedConfig.theme || mergedConfig), [mergedConfig]);
+  const [prizes, setPrizes] = useState(() => derivePrizes(mergedConfig));
+  const [loadingPrizes, setLoadingPrizes] = useState(true);
+  const [prizeError, setPrizeError] = useState(null);
+  const [isAttempting, setIsAttempting] = useState(false);
+  const [cardState, setCardState] = useState('idle');
+  const [scratchProgress, setScratchProgress] = useState(0);
+  const [isScratching, setIsScratching] = useState(false);
+  const [coverCleared, setCoverCleared] = useState(false);
+  const [result, setResult] = useState(null);
+  const [showResultModal, setShowResultModal] = useState(false);
+  const [attemptError, setAttemptError] = useState(null);
+
+  const timeoutsRef = useRef([]);
+  const isMountedRef = useRef(true);
+  const canvasRef = useRef(null);
+  const surfaceRef = useRef(null);
+  const pointerActiveRef = useRef(false);
+  const scratchedCellsRef = useRef(new Set());
+  const totalCellsRef = useRef(0);
+  const scratchCompletedRef = useRef(false);
+
+  const backgroundStyle = useMemo(() => {
+    const style = {
+      '--scratch-primary': theme.primaryColor,
+      '--scratch-primary-rgb': toRgbComponents(theme.primaryColor, '245, 227, 195'),
+      '--scratch-secondary': theme.secondaryColor,
+      '--scratch-secondary-rgb': toRgbComponents(theme.secondaryColor, '244, 185, 66'),
+      '--scratch-tertiary': theme.tertiaryColor,
+      '--scratch-tertiary-rgb': toRgbComponents(theme.tertiaryColor, '10, 10, 10'),
+      '--scratch-foreground': '#fff8e8',
+      '--scratch-foreground-rgb': '255, 248, 232',
+      '--scratch-contrast': '#1d1304',
+      '--scratch-card-back': theme.cardBackImage ? `url(${theme.cardBackImage})` : 'none',
+      '--scratch-background': theme.backgroundImage ? `url(${theme.backgroundImage})` : 'none'
+    };
+
+    return style;
+  }, [theme]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+      timeoutsRef.current.forEach(clearTimeout);
+      timeoutsRef.current = [];
+    };
+  }, []);
+
+  useEffect(() => {
+    setPrizes(derivePrizes(mergedConfig));
+    setCardState('idle');
+    setScratchProgress(0);
+    setCoverCleared(false);
+    setResult(null);
+    setShowResultModal(false);
+    setAttemptError(null);
+  }, [mergedConfig]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadingPrizes(true);
+    setPrizeError(null);
+
+    fetchScratchPrizes(mergedConfig)
+      .then((availablePrizes) => {
+        if (cancelled || !isMountedRef.current) {
+          return;
+        }
+        if (Array.isArray(availablePrizes) && availablePrizes.length) {
+          setPrizes(availablePrizes);
+        }
+      })
+      .catch(() => {
+        if (cancelled || !isMountedRef.current) {
+          return;
+        }
+        setPrizeError('We could not load the prize ledger. Please refresh to try again.');
+      })
+      .finally(() => {
+        if (cancelled || !isMountedRef.current) {
+          return;
+        }
+        setLoadingPrizes(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [mergedConfig]);
+
+  const totalWeight = useMemo(
+    () => prizes.reduce((sum, prize) => sum + (Number.isFinite(prize.weight) ? prize.weight : 0), 0),
+    [prizes]
+  );
+
+  const queueTimeout = (callback, delay) => {
+    const timeoutId = setTimeout(callback, delay);
+    timeoutsRef.current.push(timeoutId);
+    return timeoutId;
+  };
+
+  const handleAttempt = () => {
+    if (isAttempting || loadingPrizes || cardState === 'preparing' || cardState === 'ready') {
+      return;
+    }
+
+    timeoutsRef.current.forEach(clearTimeout);
+    timeoutsRef.current = [];
+
+    setIsAttempting(true);
+    setAttemptError(null);
+    setIsScratching(false);
+    pointerActiveRef.current = false;
+    setResult(null);
+    setShowResultModal(false);
+    setCardState('preparing');
+    setScratchProgress(0);
+    setCoverCleared(false);
+    scratchedCellsRef.current = new Set();
+    totalCellsRef.current = 0;
+    scratchCompletedRef.current = false;
+
+    attemptScratchCard(mergedConfig)
+      .then((outcome) => {
+        if (!isMountedRef.current) {
+          return;
+        }
+        setResult(outcome);
+        setCardState('ready');
+      })
+      .catch(() => {
+        if (!isMountedRef.current) {
+          return;
+        }
+        setAttemptError('Something interrupted the scratch card attempt. Please try again.');
+        setCardState('idle');
+      })
+      .finally(() => {
+        if (!isMountedRef.current) {
+          return;
+        }
+        setIsAttempting(false);
+      });
+  };
+
+  const closeModal = () => {
+    setShowResultModal(false);
+  };
+
+  const initializeFoil = useCallback(() => {
+    if (cardState !== 'ready') {
+      return;
+    }
+
+    const canvas = canvasRef.current;
+    const surface = surfaceRef.current;
+    if (!canvas || !surface) {
+      return;
+    }
+
+    const rect = surface.getBoundingClientRect();
+    if (!rect.width || !rect.height) {
+      return;
+    }
+
+    const dpr = window.devicePixelRatio || 1;
+
+    canvas.width = rect.width * dpr;
+    canvas.height = rect.height * dpr;
+    canvas.style.width = `${rect.width}px`;
+    canvas.style.height = `${rect.height}px`;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      return;
+    }
+
+    ctx.globalCompositeOperation = 'source-over';
+    const gradient = ctx.createLinearGradient(0, 0, canvas.width, canvas.height);
+    gradient.addColorStop(0, theme.primaryColor);
+    gradient.addColorStop(0.45, theme.secondaryColor);
+    gradient.addColorStop(1, theme.primaryColor);
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.globalAlpha = 0.22;
+    ctx.fillStyle = '#ffffff';
+    const stripeStep = 28 * dpr;
+    for (let offset = -canvas.height; offset < canvas.width * 2; offset += stripeStep) {
+      ctx.save();
+      ctx.translate(0, offset);
+      ctx.rotate((18 * Math.PI) / 180);
+      ctx.fillRect(-canvas.width, 0, canvas.width * 3, 8 * dpr);
+      ctx.restore();
+    }
+    ctx.globalAlpha = 1;
+
+    scratchedCellsRef.current = new Set();
+    const widthCells = Math.ceil(rect.width / SCRATCH_CELL_SIZE);
+    const heightCells = Math.ceil(rect.height / SCRATCH_CELL_SIZE);
+    totalCellsRef.current = widthCells * heightCells;
+    setScratchProgress(0);
+    setCoverCleared(false);
+    scratchCompletedRef.current = false;
+  }, [cardState, theme.primaryColor, theme.secondaryColor]);
+
+  useEffect(() => {
+    if (cardState !== 'ready') {
+      return;
+    }
+
+    initializeFoil();
+
+    const handleResize = () => {
+      initializeFoil();
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [cardState, initializeFoil]);
+
+  const handleScratchComplete = useCallback(() => {
+    if (cardState !== 'ready' || !result || scratchCompletedRef.current) {
+      return;
+    }
+
+    scratchCompletedRef.current = true;
+    setCardState('revealed');
+    setCoverCleared(true);
+    setScratchProgress(1);
+
+    queueTimeout(() => {
+      if (!isMountedRef.current) {
+        return;
+      }
+      setShowResultModal(true);
+    }, 650);
+  }, [cardState, result]);
+
+  const scratchAt = useCallback(
+    (clientX, clientY) => {
+      if (cardState !== 'ready') {
+        return;
+      }
+
+      const canvas = canvasRef.current;
+      if (!canvas) {
+        return;
+      }
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        return;
+      }
+
+      const rect = canvas.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+      const x = (clientX - rect.left) * dpr;
+      const y = (clientY - rect.top) * dpr;
+
+      if (Number.isNaN(x) || Number.isNaN(y)) {
+        return;
+      }
+
+      const radius = SCRATCH_RADIUS * dpr;
+      const gradient = ctx.createRadialGradient(x, y, radius * 0.3, x, y, radius);
+      gradient.addColorStop(0, 'rgba(0, 0, 0, 0.9)');
+      gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
+      ctx.globalCompositeOperation = 'destination-out';
+      ctx.fillStyle = gradient;
+      ctx.beginPath();
+      ctx.arc(x, y, radius, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.closePath();
+      ctx.globalCompositeOperation = 'source-over';
+
+      const normalizedX = clientX - rect.left;
+      const normalizedY = clientY - rect.top;
+      const cellX = Math.floor(normalizedX / SCRATCH_CELL_SIZE);
+      const cellY = Math.floor(normalizedY / SCRATCH_CELL_SIZE);
+      const cellKey = `${cellX},${cellY}`;
+
+      if (!scratchedCellsRef.current.has(cellKey)) {
+        scratchedCellsRef.current.add(cellKey);
+        if (totalCellsRef.current > 0) {
+          const ratio = scratchedCellsRef.current.size / totalCellsRef.current;
+          setScratchProgress((prev) => (ratio > prev ? ratio : prev));
+          if (ratio >= REVEAL_THRESHOLD) {
+            handleScratchComplete();
+          }
+        }
+      }
+    },
+    [cardState, handleScratchComplete]
+  );
+
+  const endScratch = useCallback(() => {
+    if (!pointerActiveRef.current) {
+      return;
+    }
+    pointerActiveRef.current = false;
+    setIsScratching(false);
+  }, []);
+
+  const handlePointerDown = useCallback(
+    (event) => {
+      if (cardState !== 'ready') {
+        return;
+      }
+      event.preventDefault();
+      pointerActiveRef.current = true;
+      setIsScratching(true);
+      if (event.target?.setPointerCapture) {
+        event.target.setPointerCapture(event.pointerId);
+      }
+      const points = event.getCoalescedEvents ? event.getCoalescedEvents() : [event];
+      points.forEach((point) => {
+        scratchAt(point.clientX, point.clientY);
+      });
+    },
+    [cardState, scratchAt]
+  );
+
+  const handlePointerMove = useCallback(
+    (event) => {
+      if (!pointerActiveRef.current || cardState !== 'ready') {
+        return;
+      }
+      event.preventDefault();
+      const points = event.getCoalescedEvents ? event.getCoalescedEvents() : [event];
+      points.forEach((point) => {
+        scratchAt(point.clientX, point.clientY);
+      });
+    },
+    [cardState, scratchAt]
+  );
+
+  const handlePointerUp = useCallback(
+    (event) => {
+      if (event?.target?.releasePointerCapture) {
+        event.target.releasePointerCapture(event.pointerId);
+      }
+      endScratch();
+    },
+    [endScratch]
+  );
+
+  const handlePointerLeave = useCallback(() => {
+    endScratch();
+  }, [endScratch]);
+
+  const buttonDisabled = isAttempting || loadingPrizes || cardState === 'preparing';
+  const buttonLabel =
+    cardState === 'idle'
+      ? 'Get a new card'
+      : cardState === 'preparing'
+      ? 'Preparing…'
+      : cardState === 'ready'
+      ? 'Scratch again'
+      : 'Play again';
+
+  const hasRevealed = cardState === 'revealed';
+  const showProgress = cardState === 'ready' || cardState === 'revealed';
+  const progressPercent = Math.min(100, Math.round(scratchProgress * 100));
+  const statusText =
+    cardState === 'preparing'
+      ? 'Preparing card'
+      : cardState === 'ready'
+      ? isScratching
+        ? 'Scratching…'
+        : 'Ready to scratch'
+      : cardState === 'revealed'
+      ? 'Prize revealed'
+      : 'Awaiting attempt';
+
+  const foilMessage =
+    cardState === 'idle'
+      ? 'Tap the button to receive your scratch card.'
+      : cardState === 'preparing'
+      ? 'Summoning foil shimmer…'
+      : cardState === 'ready'
+      ? 'Scratch to reveal your prize.'
+      : 'Prize revealed!';
+
+  const foilMessageDetail = cardState === 'ready' && !isScratching ? 'Drag or click to scratch the foil.' : '';
+
+  const canvasClassName = `scratch-classic-foil__canvas${cardState !== 'ready' ? ' scratch-classic-foil__canvas--inactive' : ''}$
+{coverCleared ? ' scratch-classic-foil__canvas--cleared' : ''}`;
+
+  const foilClassName = `scratch-classic-foil${cardState === 'ready' ? ' scratch-classic-foil--interactive' : ''}${coverCleared ? ' scratch-classic-foil--cleared' : ''}`;
+
+  const cardClassName = `scratch-classic-card scratch-classic-card--${cardState}${
+    cardState === 'ready' && isScratching ? ' scratch-classic-card--scratching' : ''
+  }${hasRevealed ? ' scratch-classic-card--revealed' : ''}`;
+
+  const prizeRarity = result?.prize?.rarity?.toLowerCase();
+  const rarityIndex = prizeRarity ? Math.max(0, rarityOrder.indexOf(prizeRarity)) : 0;
+  const glowStrength = 0.25 + rarityIndex * 0.15;
+  const glowStyle = {
+    opacity: hasRevealed ? 1 : 0,
+    background: `radial-gradient(circle at center, rgba(255,255,255,${glowStrength}) 0%, rgba(15,23,42,0) 70%)`
+  };
+
+  const rewardImageStyle = theme.cardBackImage
+    ? {
+        backgroundImage: `var(--scratch-card-back)`
+      }
+    : undefined;
+
+  const modalTitle = result?.prize?.name || 'Scratch Card Result';
+  const modalRarity = result?.prize?.rarityLabel || 'Mystery';
+  const modalFlair = result?.flairText || 'The foil peels away and the prize gleams brilliantly!';
+
+  return (
+    <div className="scratch-classic-game" style={backgroundStyle}>
+      <div className="scratch-classic-overlay" />
+      <div className="scratch-classic-content">
+        <header className="scratch-classic-header">
+          <div className="scratch-classic-branding">
+            {theme.logoImage ? <img src={theme.logoImage} alt="Game logo" className="scratch-classic-logo" /> : null}
+            <div>
+              <p className="scratch-classic-tagline">Scratch &amp; reveal</p>
+              <h1 className="scratch-classic-title">{mergedConfig.title}</h1>
+              <p className="scratch-classic-description">{mergedConfig.description}</p>
+            </div>
+          </div>
+          <div className="scratch-classic-actions">
+            <button type="button" className="scratch-classic-secondary" onClick={() => navigate(-1)}>
+              Back to store
+            </button>
+            <button
+              type="button"
+              className="scratch-classic-primary"
+              onClick={handleAttempt}
+              disabled={buttonDisabled}
+            >
+              {buttonLabel}
+            </button>
+          </div>
+        </header>
+
+        <main className="scratch-classic-layout">
+          <section className="scratch-classic-stage">
+            <div className="scratch-classic-card-wrapper">
+              <div className={cardClassName}>
+                <div className="scratch-classic-card__inner" ref={surfaceRef}>
+                  <div className="scratch-classic-reward" style={rewardImageStyle}>
+                    <div className="scratch-classic-reward__glow" style={glowStyle} />
+                    <div className="scratch-classic-reward__body">
+                      <p className="scratch-classic-reward__rarity">
+                        {hasRevealed && result ? result.prize.rarityLabel : 'Mystery Reward'}
+                      </p>
+                      <h3 className="scratch-classic-reward__title">
+                        {hasRevealed && result
+                          ? result.prize.name
+                          : cardState === 'ready'
+                          ? 'Scratch to reveal'
+                          : 'Awaiting scratch'}
+                      </h3>
+                      <p className="scratch-classic-reward__helper">
+                        {hasRevealed && result
+                          ? result.flairText || 'The prize gleams brilliantly!'
+                          : 'Drag across the foil to lift the shimmer.'}
+                      </p>
+                    </div>
+                  </div>
+                  <div className={foilClassName}>
+                    <canvas
+                      ref={canvasRef}
+                      className={canvasClassName}
+                      onPointerDown={handlePointerDown}
+                      onPointerMove={handlePointerMove}
+                      onPointerUp={handlePointerUp}
+                      onPointerCancel={handlePointerLeave}
+                      onPointerLeave={handlePointerLeave}
+                    />
+                    <div className="scratch-classic-foil__noise" />
+                    <div className="scratch-classic-foil__shine" />
+                    <div
+                      className={`scratch-classic-foil__message${
+                        cardState !== 'revealed' ? ' scratch-classic-foil__message--visible' : ''
+                      }`}
+                    >
+                      <span>{foilMessage}</span>
+                      {foilMessageDetail ? (
+                        <span className="scratch-classic-foil__detail">{foilMessageDetail}</span>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <aside className="scratch-classic-status">
+                <div className="scratch-classic-status__badge">{statusText}</div>
+                {showProgress ? (
+                  <div className="scratch-classic-progress">
+                    <div className="scratch-classic-progress__track">
+                      <div
+                        className="scratch-classic-progress__fill"
+                        style={{ width: `${progressPercent}%` }}
+                      />
+                    </div>
+                    <span className="scratch-classic-progress__label">{progressPercent}% revealed</span>
+                  </div>
+                ) : null}
+                {cardState === 'revealed' && result ? (
+                  <p className="scratch-classic-status__detail">
+                    You uncovered the <span>{result.prize.name}</span>!
+                  </p>
+                ) : null}
+                {attemptError ? <div className="scratch-classic-error">{attemptError}</div> : null}
+              </aside>
+            </div>
+          </section>
+
+          <section className="scratch-classic-prizes">
+            <div className="scratch-classic-prizes__header">
+              <h2>Prize ledger</h2>
+              <p>Review every reward hiding beneath the aurora foil.</p>
+            </div>
+            {loadingPrizes ? (
+              <p className="scratch-classic-prizes__state">Loading prizes…</p>
+            ) : prizeError ? (
+              <p className="scratch-classic-prizes__state scratch-classic-prizes__state--error">{prizeError}</p>
+            ) : (
+              <div className="scratch-classic-prizes__grid">
+                {prizes.map((prize) => (
+                  <PrizeCard
+                    key={prize.id}
+                    prize={prize}
+                    dropRate={formatDropRate(prize.weight ?? 0, totalWeight)}
+                  />
+                ))}
+              </div>
+            )}
+          </section>
+        </main>
+      </div>
+
+      {showResultModal && result ? (
+        <div className="scratch-classic-modal" role="dialog" aria-modal="true">
+          <div className="scratch-classic-modal__overlay" />
+          <div className="scratch-classic-modal__panel">
+            <div className="scratch-classic-modal__badge">{modalRarity}</div>
+            <h3 className="scratch-classic-modal__title">{modalTitle}</h3>
+            <p className="scratch-classic-modal__description">{modalFlair}</p>
+            <button type="button" className="scratch-classic-primary" onClick={closeModal}>
+              Close
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default ScratchCardClassicGame;


### PR DESCRIPTION
## Summary
- retune the scratch-card-classic defaults to a black and cream palette and expose RGB variables for custom gradients
- retune the gachapon-classic defaults to a rainbow accent palette with matching RGB style variables
- refresh both classic CSS layouts with mobile-friendly spacing and brighter gradients on cards, stages, and modals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db1d7094a8832ab9ed1f107f852ba4