### PR TITLE
Fix scratch card overlay blocking pointer input

### DIFF
--- a/src/games/scratch-card-classic/scratch-card-classic.css
+++ b/src/games/scratch-card-classic/scratch-card-classic.css
@@ -384,6 +384,7 @@
   font-weight: 600;
   letter-spacing: 0.04em;
   transition: opacity 0.3s ease;
+  pointer-events: none;
 }
 
 .scratch-classic-foil__message--visible {


### PR DESCRIPTION
## Summary
- prevent the scratch card classic overlay message from capturing pointer events
- allow users to scratch the foil by letting pointer input reach the canvas

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68dbc5e520c4832a97f4f5824d28bac6