### PR TITLE
Mock dev APIs for gachapon and scratch card

### DIFF
--- a/src/game_modules/gachapon-module/gachapon.js
+++ b/src/game_modules/gachapon-module/gachapon.js
@@ -4,9 +4,10 @@ import { buildConfig } from './config';
 import { buildTheme } from './theme';
 import './gachapon.css';
 
-const mockPlay = (config) => {
+const buildMockResult = (config) => {
   const prizes = config.prizes || [];
   const prize = prizes[Math.floor(Math.random() * prizes.length)];
+
   return {
     resultId: `mock-${Date.now()}`,
     outcome: prize ? `You won ${prize.name}` : 'Better luck next time',
@@ -23,8 +24,17 @@ const mockPlay = (config) => {
   };
 };
 
+const mockPlay = (config) =>
+  new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(buildMockResult(config));
+    }, 450);
+  });
+
 const playGachapon = async ({ config }) => {
-  if (!config?.play_endpoint) {
+  const shouldMock = !config?.play_endpoint || process.env.NODE_ENV !== 'production';
+
+  if (shouldMock) {
     return mockPlay(config);
   }
 
@@ -47,7 +57,7 @@ const playGachapon = async ({ config }) => {
 
   const data = await response.json();
   return {
-    ...mockPlay(config),
+    ...buildMockResult(config),
     ...data,
   };
 };

--- a/src/game_modules/scratch-card-module/scratch-card.css
+++ b/src/game_modules/scratch-card-module/scratch-card.css
@@ -44,14 +44,29 @@
 .scratch-overlay {
   position: absolute;
   inset: 0;
-  mix-blend-mode: screen;
-  opacity: 0.8;
+  background-size: cover;
+  background-position: center;
+  display: flex;
 }
 
-.scratch-overlay img {
+.scratch-canvas {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  flex: 1;
+  cursor: grab;
+  touch-action: none;
+  transition: opacity 200ms ease;
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.8), rgba(226, 232, 240, 0.85));
+  border: none;
+}
+
+.scratch-canvas.is-scratching {
+  cursor: grabbing;
+}
+
+.scratch-canvas.is-complete {
+  opacity: 0;
+  pointer-events: none;
 }
 
 .scratch-content {


### PR DESCRIPTION
## Summary
- serve mocked play/results data for the gachapon game when not in production
- switch the scratch card game to a canvas-based scratching interaction and mocked reveal/results data
- refresh scratch card styling to support the interactive overlay

## Testing
- npm test -- --watchAll=false *(fails: TypeError: (0 , _reactRouterDom.useParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68e2733fa9ac832a95ef04da8fc91704