### PR TITLE
Add animated motion to Gachapon game module

### DIFF
--- a/src/game_modules/gachapon-module/gachapon.css
+++ b/src/game_modules/gachapon-module/gachapon.css
@@ -39,11 +39,122 @@
   align-items: center;
 }
 
+.machine-visual {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .machine-image {
   width: 100%;
   border-radius: 1.25rem;
   object-fit: cover;
   box-shadow: 0 16px 30px rgba(15, 23, 42, 0.35);
+}
+
+.machine-visual--playing .machine-image {
+  animation: machineShake 0.45s ease-in-out infinite;
+}
+
+.gachapon-ball-track {
+  position: absolute;
+  left: clamp(1rem, 6vw, 3rem);
+  right: clamp(1rem, 6vw, 3rem);
+  bottom: clamp(0.5rem, 4vw, 1.75rem);
+  height: clamp(48px, 12vw, 72px);
+  pointer-events: none;
+}
+
+.gachapon-ball {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: clamp(36px, 9vw, 64px);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  opacity: 0;
+  transform: translateX(-15%);
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.85), rgba(59, 130, 246, 0.95) 55%, rgba(30, 64, 175, 0.95));
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
+}
+
+.gachapon-ball-shadow {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: clamp(36px, 9vw, 64px);
+  height: clamp(10px, 2.5vw, 16px);
+  border-radius: 999px;
+  opacity: 0;
+  transform: translateX(-15%);
+  background: rgba(15, 23, 42, 0.35);
+  filter: blur(12px);
+  transform-origin: center;
+}
+
+.machine-visual--playing .gachapon-ball {
+  opacity: 1;
+  animation: gachaponBallRoll 1.4s ease-in-out infinite;
+}
+
+.machine-visual--playing .gachapon-ball-shadow {
+  opacity: 0.45;
+  animation: gachaponBallShadow 1.4s ease-in-out infinite;
+}
+
+@keyframes machineShake {
+  0% {
+    transform: translate3d(0, 0, 0) rotate(0deg);
+  }
+  20% {
+    transform: translate3d(-3px, 2px, 0) rotate(-1deg);
+  }
+  40% {
+    transform: translate3d(3px, -2px, 0) rotate(1.2deg);
+  }
+  60% {
+    transform: translate3d(-2px, 3px, 0) rotate(-0.8deg);
+  }
+  80% {
+    transform: translate3d(2px, -3px, 0) rotate(0.6deg);
+  }
+  100% {
+    transform: translate3d(0, 0, 0) rotate(0deg);
+  }
+}
+
+@keyframes gachaponBallRoll {
+  0% {
+    transform: translateX(-20%) rotate(0deg);
+  }
+  25% {
+    transform: translateX(30%) rotate(120deg);
+  }
+  50% {
+    transform: translateX(85%) rotate(240deg);
+  }
+  75% {
+    transform: translateX(140%) rotate(320deg);
+  }
+  100% {
+    transform: translateX(190%) rotate(400deg);
+  }
+}
+
+@keyframes gachaponBallShadow {
+  0% {
+    transform: translateX(-20%) scaleX(0.7);
+    opacity: 0.3;
+  }
+  50% {
+    transform: translateX(90%) scaleX(1);
+    opacity: 0.45;
+  }
+  100% {
+    transform: translateX(190%) scaleX(0.7);
+    opacity: 0.3;
+  }
 }
 
 .machine-panel {

--- a/src/game_modules/gachapon-module/gachapon.js
+++ b/src/game_modules/gachapon-module/gachapon.js
@@ -206,7 +206,13 @@ const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
         </header>
 
         <div className="machine-wrapper">
-          <img src={machineImage} alt="Gachapon machine" className="machine-image" />
+          <div className={`machine-visual ${isPlaying ? 'machine-visual--playing' : ''}`}>
+            <img src={machineImage} alt="Gachapon machine" className="machine-image" />
+            <div className="gachapon-ball-track" aria-hidden="true">
+              <div className="gachapon-ball" />
+              <div className="gachapon-ball-shadow" />
+            </div>
+          </div>
 
           <div
             className="machine-panel"


### PR DESCRIPTION
## Summary
- wrap the gachapon machine artwork with a visual container that exposes a capsule track and rolling ball elements
- add CSS-driven shake and rolling animations so the machine reacts while a play session is in progress

## Testing
- npm test -- --watchAll=false *(fails: existing test suite expects react-router v6 hooks and throws "useParams is not a function")*

------
https://chatgpt.com/codex/tasks/task_e_68e27bb83614832aa8168ef237582bc4