### PR TITLE
Refresh scratch card module aesthetics

### DIFF
--- a/src/game_modules/scratch-card-module/scratch-card.css
+++ b/src/game_modules/scratch-card-module/scratch-card.css
@@ -1,34 +1,78 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600;700&display=swap');
+
 .scratch-root {
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2rem 1.5rem;
+  padding: clamp(1.5rem, 2vw + 1rem, 3rem);
   background-size: cover;
   background-position: center;
+  font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+  background-blend-mode: luminosity;
 }
 
 .scratch-card {
   width: min(660px, 100%);
   border-radius: 1.5rem;
-  padding: clamp(1.75rem, 2.5vw + 1rem, 2.5rem);
-  backdrop-filter: blur(12px);
-  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.45);
+  padding: clamp(1.75rem, 2.5vw + 1rem, 2.65rem);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 40px 90px rgba(15, 23, 42, 0.38);
   overflow: hidden;
+  position: relative;
+  animation: scratch-card-float 12s ease-in-out infinite;
+}
+
+.scratch-card::before {
+  content: '';
+  position: absolute;
+  inset: 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  pointer-events: none;
+}
+
+.scratch-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.08), transparent 55%);
+  mix-blend-mode: screen;
+  pointer-events: none;
 }
 
 .scratch-header {
   text-align: center;
   margin-bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
 }
 
 .scratch-header h1 {
-  margin-bottom: 0.75rem;
   font-size: clamp(2rem, 3vw, 2.75rem);
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  letter-spacing: -0.01em;
+  margin: 0;
 }
 
 .scratch-header p {
   margin: 0.25rem 0;
+}
+
+.scratch-header__eyebrow {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-weight: 600;
+  opacity: 0.85;
+}
+
+.scratch-header__description {
+  font-size: 1.05rem;
+  letter-spacing: 0.01em;
+  max-width: 32ch;
+  margin: 0 auto;
 }
 
 .scratch-area {
@@ -41,6 +85,9 @@
   justify-content: center;
   text-align: center;
   padding: clamp(1.5rem, 3vw + 1rem, 2.25rem);
+  isolation: isolate;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2), 0 25px 45px rgba(15, 23, 42, 0.35);
+  animation: scratch-area-float 8s ease-in-out infinite;
 }
 
 .scratch-overlay {
@@ -49,6 +96,17 @@
   background-size: cover;
   background-position: center;
   display: flex;
+  filter: saturate(0.6);
+  mix-blend-mode: multiply;
+}
+
+.scratch-overlay::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.35), transparent 55%, rgba(255, 255, 255, 0.45));
+  mix-blend-mode: screen;
+  pointer-events: none;
 }
 
 .scratch-canvas {
@@ -57,13 +115,14 @@
   flex: 1;
   cursor: grab;
   touch-action: none;
-  transition: opacity 200ms ease;
+  transition: opacity 220ms ease, transform 220ms ease;
   background: linear-gradient(135deg, rgba(148, 163, 184, 0.8), rgba(226, 232, 240, 0.85));
   border: none;
 }
 
 .scratch-canvas.is-scratching {
   cursor: grabbing;
+  transform: scale(1.02);
 }
 
 .scratch-canvas.is-complete {
@@ -81,14 +140,59 @@
   pointer-events: none;
 }
 
+.scratch-content__badge {
+  align-self: center;
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  color: rgba(15, 23, 42, 0.82);
+}
+
 .scratch-content h2 {
   margin: 0;
   font-size: 1.75rem;
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  letter-spacing: -0.01em;
 }
 
 .scratch-content p {
   margin: 0;
   line-height: 1.6;
+  font-size: 1rem;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+.scratch-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  pointer-events: none;
+}
+
+.scratch-progress__track {
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.35);
+  overflow: hidden;
+  position: relative;
+}
+
+.scratch-progress__fill {
+  height: 100%;
+  border-radius: inherit;
+  transition: width 300ms ease;
+}
+
+.scratch-progress__label {
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: rgba(15, 23, 42, 0.74);
+  align-self: center;
 }
 
 .scratch-actions {
@@ -105,7 +209,7 @@
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 120ms ease, box-shadow 120ms ease;
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
 }
 
 .scratch-button:disabled {
@@ -116,6 +220,11 @@
 .scratch-button:not(:disabled):hover {
   transform: translateY(-1px);
   box-shadow: 0 12px 30px rgba(244, 114, 182, 0.35);
+}
+
+.scratch-button:not(:disabled):focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
 }
 
 .scratch-prizes {
@@ -160,6 +269,13 @@
   flex-direction: column;
   gap: 0.75rem;
   backdrop-filter: blur(10px);
+  background: rgba(255, 255, 255, 0.15);
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.scratch-prize-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.25);
 }
 
 .scratch-prize-card__media {
@@ -197,6 +313,50 @@
   text-transform: uppercase;
   letter-spacing: 0.04em;
   opacity: 0.75;
+}
+
+@keyframes scratch-card-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-10px);
+  }
+}
+
+@keyframes scratch-area-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
+@media (max-width: 640px) {
+  .scratch-card {
+    border-radius: 1.25rem;
+    padding: 1.75rem 1.5rem;
+  }
+
+  .scratch-card::before {
+    inset: 0.75rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scratch-card,
+  .scratch-area,
+  .scratch-canvas,
+  .scratch-prize-card,
+  .scratch-button,
+  .scratch-progress__fill {
+    animation: none !important;
+    transition: none !important;
+    transform: none !important;
+  }
 }
 
 .scratch-prizes__footnote {

--- a/src/game_modules/scratch-card-module/scratch-card.js
+++ b/src/game_modules/scratch-card-module/scratch-card.js
@@ -327,6 +327,8 @@ const ScratchCardGame = ({ config = {}, onBack }) => {
     );
   }
 
+  const progressPercent = Math.round(scratchProgress);
+
   return (
     <div
       className="scratch-root"
@@ -343,11 +345,13 @@ const ScratchCardGame = ({ config = {}, onBack }) => {
         }}
       >
         <header className="scratch-header">
-          <p style={{ color: theme.tertiaryColor, letterSpacing: '0.08em', textTransform: 'uppercase' }}>
+          <p className="scratch-header__eyebrow" style={{ color: theme.tertiaryColor }}>
             {config.subtitle || 'Digital scratch experience'}
           </p>
           <h1>{config.title || config.name}</h1>
-          <p style={{ color: theme.mutedTextColor }}>{config.prize}</p>
+          <p className="scratch-header__description" style={{ color: theme.mutedTextColor }}>
+            {config.prize}
+          </p>
         </header>
 
         <div
@@ -387,11 +391,22 @@ const ScratchCardGame = ({ config = {}, onBack }) => {
             />
           </div>
           <div className="scratch-content">
-            <h2>Scratch here</h2>
-            <p>
-              Reveal progress: {Math.round(scratchProgress)}%. Keep scratching to uncover your
-              reward.
-            </p>
+            <span className="scratch-content__badge">Interactive reveal</span>
+            <h2>Scratch to discover</h2>
+            <p>Drag across the foil to unveil the surprise we have lined up for you.</p>
+            <div className="scratch-progress" aria-label={`Reveal progress ${progressPercent} percent`}>
+              <div className="scratch-progress__track">
+                <div
+                  className="scratch-progress__fill"
+                  style={{
+                    width: `${progressPercent}%`,
+                    background: theme.tertiaryColor,
+                    boxShadow: `0 6px 16px ${theme.tertiaryColor}45`,
+                  }}
+                />
+              </div>
+              <span className="scratch-progress__label">{progressPercent}% revealed</span>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add a floating animation loop and updated progress messaging to the scratch card game
- restyle the scratch card module with NYT-inspired typography, badges, and prize card hover treatments for a modern feel

## Testing
- npm test -- --watch=false *(fails: existing App.test.js expectation)*

------
https://chatgpt.com/codex/tasks/task_e_68e27cd65fa4832a889c34e67ac4ff42