### PR TITLE
Revamp gachapon module with modern experience

### DIFF
--- a/src/game_modules/gachapon-module/config.js
+++ b/src/game_modules/gachapon-module/config.js
@@ -1,42 +1,297 @@
 const rarityOrder = ['legendary', 'epic', 'rare', 'uncommon', 'common'];
 
-const toArray = (value) => (Array.isArray(value) ? value : []);
-
-const normaliseRarity = (value) => {
-  if (typeof value !== 'string') {
-    return 'common';
-  }
-  const cleaned = value.trim().toLowerCase();
-  return rarityOrder.includes(cleaned) ? cleaned : 'common';
+const defaultRarityLabels = {
+  common: 'Common',
+  uncommon: 'Uncommon',
+  rare: 'Rare',
+  epic: 'Epic',
+  legendary: 'Legendary',
 };
 
-export const normalisePrizes = (prizes = []) => {
-  const items = toArray(prizes).map((prize, index) => ({
+const defaultRarityCapsuleColors = {
+  common: '#E5E7EB',
+  uncommon: '#86EFAC',
+  rare: '#93C5FD',
+  epic: '#C4B5FD',
+  legendary: '#FDE68A',
+};
+
+const baseFallbackImage =
+  'https://images.unsplash.com/photo-1479064555552-3ef4979f8908?auto=format&fit=crop&w=900&q=80';
+
+const toArray = (value) => (Array.isArray(value) ? value : []);
+
+const readString = (value, fallback = '') => {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : fallback;
+};
+
+const toPositiveNumber = (value, fallback) => {
+  const parsed = Number(value);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+  return fallback;
+};
+
+const toNonNegativeInteger = (value, fallback) => {
+  const parsed = Math.floor(Number(value));
+  if (Number.isFinite(parsed) && parsed >= 0) {
+    return parsed;
+  }
+  return fallback;
+};
+
+const normaliseRarity = (value, fallback = 'common') => {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+  const cleaned = value.trim().toLowerCase();
+  return rarityOrder.includes(cleaned) ? cleaned : fallback;
+};
+
+const resolveRarityLabel = (rarity, provided) => {
+  if (provided) {
+    return provided;
+  }
+  const fallback = defaultRarityLabels[rarity];
+  if (fallback) {
+    return fallback;
+  }
+  return rarity.charAt(0).toUpperCase() + rarity.slice(1);
+};
+
+const buildPrize = (prize, index, defaultFlairText, defaultCapsuleColor) => {
+  const rarity = normaliseRarity(prize?.rarity);
+  const weight = toPositiveNumber(prize?.weight, 1);
+  const flairText = readString(prize?.flairText ?? prize?.flair_text, defaultFlairText);
+  const capsuleColor =
+    readString(prize?.capsuleColor ?? prize?.capsule_color, '') ||
+    defaultRarityCapsuleColors[rarity] ||
+    defaultCapsuleColor;
+
+  return {
     id: prize?.id || `prize-${index + 1}`,
-    name: prize?.name || `Prize ${index + 1}`,
-    description: prize?.description || 'Configure prize copy in the template.',
-    rarity: normaliseRarity(prize?.rarity),
-    image: prize?.image ||
-      'https://images.unsplash.com/photo-1479064555552-3ef4979f8908?auto=format&fit=crop&w=900&q=80',
-  }));
+    name: readString(prize?.name, `Prize ${index + 1}`),
+    description: readString(
+      prize?.description,
+      'Configure prize copy in the template.',
+    ),
+    rarity,
+    rarityLabel: resolveRarityLabel(rarity, prize?.rarityLabel ?? prize?.rarity_label),
+    image:
+      readString(prize?.image, '') ||
+      readString(prize?.image_url, '') ||
+      baseFallbackImage,
+    weight,
+    flairText,
+    capsuleColor,
+    probabilityLabel: readString(prize?.probability ?? prize?.odds ?? prize?.chance, ''),
+  };
+};
+
+const normalisePrizes = (prizes = [], defaultFlairText, defaultCapsuleColor) => {
+  const items = toArray(prizes)
+    .map((prize, index) => buildPrize(prize, index, defaultFlairText, defaultCapsuleColor))
+    .filter(Boolean);
 
   if (!items.length) {
     return [
-      {
-        id: 'gachapon-placeholder',
-        name: 'Mystery Capsule',
-        description: 'Update the template with your actual prizes.',
-        rarity: 'common',
-        image:
-          'https://images.unsplash.com/photo-1479064555552-3ef4979f8908?auto=format&fit=crop&w=900&q=80',
-      },
+      buildPrize(
+        {
+          id: 'gachapon-placeholder',
+          name: 'Mystery Capsule',
+          description: 'Update the template with your actual prizes.',
+          rarity: 'common',
+          capsuleColor: defaultCapsuleColor,
+          flairText: defaultFlairText,
+        },
+        0,
+        defaultFlairText,
+        defaultCapsuleColor,
+      ),
     ];
   }
 
   return items.sort((a, b) => rarityOrder.indexOf(a.rarity) - rarityOrder.indexOf(b.rarity));
 };
 
-export const buildConfig = (data = {}) => ({
-  ...data,
-  prizes: normalisePrizes(data.prizes),
-});
+const createPrizeDictionary = (prizes) =>
+  prizes.reduce((accumulator, prize) => {
+    accumulator[prize.id] = prize;
+    return accumulator;
+  }, {});
+
+const baseDefaultFlairText = 'The capsule cracks open in a burst of light! 🎉';
+const baseDefaultCapsuleColor = '#38bdf8';
+
+export const buildConfig = (data = {}) => {
+  const defaultFlairText = readString(
+    data.default_flair_text ?? data.defaultFlairText,
+    baseDefaultFlairText,
+  );
+  const defaultCapsuleColor =
+    readString(data.default_capsule_color ?? data.defaultCapsuleColor, '') ||
+    readString(data.secondary_color ?? data.secondaryColor, '') ||
+    baseDefaultCapsuleColor;
+
+  const prizes = normalisePrizes(data.prizes, defaultFlairText, defaultCapsuleColor);
+
+  return {
+    ...data,
+    title: readString(data.title, readString(data.name, 'Gachapon Game')),
+    tagline: readString(data.subtitle ?? data.tagline),
+    description: readString(data.instructions ?? data.description),
+    ctaLabel: readString(data.cta_label ?? data.ctaLabel, 'Start Gachapon'),
+    preparingLabel: readString(data.preparing_label ?? data.preparingLabel, 'Dispensing…'),
+    resultModalTitle: readString(data.result_modal_title ?? data.resultModalTitle, 'Gachapon Result'),
+    capsuleMachineLabel: readString(
+      data.capsule_machine_label ?? data.capsuleMachineLabel,
+      'Capsule Machine',
+    ),
+    capsuleStatusIdleLabel: readString(
+      data.capsule_status_idle_label ?? data.capsuleStatusIdleLabel,
+      'Ready',
+    ),
+    capsuleStatusPreparingLabel: readString(
+      data.capsule_status_preparing_label ?? data.capsuleStatusPreparingLabel,
+      'Preparing…',
+    ),
+    capsuleStatusShakingLabel: readString(
+      data.capsule_status_shaking_label ?? data.capsuleStatusShakingLabel,
+      'Shaking…',
+    ),
+    capsuleStatusOpeningLabel: readString(
+      data.capsule_status_opening_label ?? data.capsuleStatusOpeningLabel,
+      'Opening…',
+    ),
+    capsuleStatusResultLabel: readString(
+      data.capsule_status_result_label ?? data.capsuleStatusResultLabel,
+      'Capsule opened!',
+    ),
+    capsuleDescription: readString(
+      data.capsule_description ?? data.capsuleDescription,
+      'Every shake builds anticipation before the capsule bursts open to reveal your prize.',
+    ),
+    prizeShowcaseTitle: readString(
+      data.prize_showcase_title ?? data.prizeShowcaseTitle,
+      'Prize Showcase',
+    ),
+    prizeShowcaseDescription: readString(
+      data.prize_showcase_description ?? data.prizeShowcaseDescription,
+      'Browse every prize currently loaded into the capsule.',
+    ),
+    prizeListLoadingText: readString(
+      data.prize_list_loading_text ?? data.prizeListLoadingText,
+      'Loading prize lineup…',
+    ),
+    prizeListErrorText: readString(
+      data.prize_list_error_text ?? data.prizeListErrorText,
+      'We could not load the prize list. Please refresh to try again.',
+    ),
+    attemptErrorText: readString(
+      data.attempt_error_text ?? data.attemptErrorText,
+      'Something interrupted the gachapon attempt. Please try again.',
+    ),
+    defaultFlairText,
+    defaultCapsuleColor,
+    shakeDurationMs: toNonNegativeInteger(data.shake_duration_ms ?? data.shakeDurationMs, 1200),
+    explosionDurationMs: toNonNegativeInteger(
+      data.explosion_duration_ms ?? data.explosionDurationMs,
+      650,
+    ),
+    prizes,
+    prizeDictionary: createPrizeDictionary(prizes),
+  };
+};
+
+export const mergeDisplayPrizes = (displayPrizes, config) => {
+  const basePrizes = config.prizes || [];
+  const byId = config.prizeDictionary || {};
+  const merged = [];
+  const seen = new Set();
+
+  toArray(displayPrizes).forEach((item, index) => {
+    const fallback = byId[item?.id] || basePrizes[index] || basePrizes[0];
+    if (!fallback) {
+      return;
+    }
+
+    const mergedPrize = {
+      ...fallback,
+      id: item?.id || fallback.id || `display-${index}`,
+      name: readString(item?.title, fallback.name),
+      description: readString(item?.description, fallback.description),
+      image: readString(item?.image, fallback.image),
+      probabilityLabel: readString(item?.probability, fallback.probabilityLabel),
+    };
+
+    merged.push(mergedPrize);
+    seen.add(mergedPrize.id);
+  });
+
+  basePrizes.forEach((prize) => {
+    if (!seen.has(prize.id)) {
+      merged.push(prize);
+    }
+  });
+
+  return merged;
+};
+
+export const normaliseResult = (payload = {}, config = {}) => {
+  const byId = config.prizeDictionary || {};
+  const basePrize = payload?.prize?.id ? byId[payload.prize.id] : null;
+  const fallbackPrize = basePrize || config.prizes?.[0];
+
+  const resolvedFallback =
+    fallbackPrize ||
+    buildPrize(
+      {
+        id: 'gachapon-result-placeholder',
+        name: 'Mystery Capsule',
+        description: 'Configure prize copy in the template.',
+        rarity: 'common',
+      },
+      0,
+      config.defaultFlairText || baseDefaultFlairText,
+      config.defaultCapsuleColor || baseDefaultCapsuleColor,
+    );
+
+  const mergedPrize = {
+    ...resolvedFallback,
+    ...(payload?.prize || {}),
+  };
+
+  const rarity = normaliseRarity(mergedPrize.rarity, resolvedFallback.rarity);
+
+  const finalPrize = {
+    ...resolvedFallback,
+    ...mergedPrize,
+    rarity,
+    rarityLabel: resolveRarityLabel(rarity, mergedPrize.rarityLabel ?? mergedPrize.rarity_label),
+    capsuleColor:
+      readString(mergedPrize.capsuleColor ?? mergedPrize.capsule_color, '') ||
+      resolvedFallback.capsuleColor ||
+      config.defaultCapsuleColor ||
+      baseDefaultCapsuleColor,
+    flairText: readString(mergedPrize.flairText ?? mergedPrize.flair_text, resolvedFallback.flairText),
+    weight: toPositiveNumber(mergedPrize.weight, resolvedFallback.weight ?? 1),
+  };
+
+  return {
+    ...payload,
+    resultId: payload?.resultId ?? `result-${Date.now()}`,
+    outcome: payload?.outcome ?? `You won ${finalPrize.name}`,
+    message: payload?.message ?? 'Collect your rewards below.',
+    flairText:
+      readString(payload?.flairText ?? payload?.flair_text, '') ||
+      finalPrize.flairText ||
+      config.defaultFlairText ||
+      baseDefaultFlairText,
+    prize: finalPrize,
+  };
+};

--- a/src/game_modules/gachapon-module/gachapon.css
+++ b/src/game_modules/gachapon-module/gachapon.css
@@ -1,486 +1,207 @@
-.gachapon-root {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem 1.5rem;
-  background-size: cover;
-  background-position: center;
+.gachapon-stage {
+  perspective: 1200px;
 }
 
-.gachapon-card {
-  width: min(720px, 100%);
-  border-radius: 1.5rem;
-  padding: clamp(1.75rem, 2.5vw + 1rem, 2.75rem);
-  backdrop-filter: blur(14px);
-  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.45);
-  overflow: hidden;
-}
-
-.gachapon-header {
-  text-align: center;
-  margin-bottom: 2rem;
-}
-
-.gachapon-header h1 {
-  font-size: clamp(2rem, 3vw, 2.75rem);
-  margin-bottom: 0.5rem;
-}
-
-.gachapon-header p {
-  margin: 0.35rem 0;
-}
-
-.machine-wrapper {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1.5rem;
-  align-items: center;
-}
-
-.machine-visual {
+.gachapon-box {
   position: relative;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  width: 240px;
+  height: 260px;
+  border-radius: 24px;
+  background: linear-gradient(160deg, #312e81, #1f2937);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.45);
+  overflow: hidden;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  transform-style: preserve-3d;
 }
 
-.machine-image {
-  width: 100%;
-  border-radius: 1.25rem;
-  object-fit: cover;
-  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.35);
-}
-
-.machine-visual--playing .machine-image {
-  animation: machineShake 0.45s ease-in-out infinite;
-}
-
-.gachapon-ball-track {
+.gachapon-box::before,
+.gachapon-box::after {
+  content: '';
   position: absolute;
-  left: clamp(1rem, 6vw, 3rem);
-  right: clamp(1rem, 6vw, 3rem);
-  bottom: clamp(0.5rem, 4vw, 1.75rem);
-  height: clamp(48px, 12vw, 72px);
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0));
+  mix-blend-mode: screen;
   pointer-events: none;
 }
 
-.gachapon-ball {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: clamp(36px, 9vw, 64px);
-  aspect-ratio: 1;
-  border-radius: 50%;
+.gachapon-box::after {
+  inset: 12px;
+  border-radius: 20px;
+  background: linear-gradient(225deg, rgba(59, 130, 246, 0.15), rgba(14, 116, 144, 0));
+}
+
+.gachapon-box--shake {
+  animation: gachapon-shake 0.12s ease-in-out infinite;
+}
+
+.gachapon-box--hidden {
   opacity: 0;
-  transform: translateX(-15%);
-  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.85), rgba(59, 130, 246, 0.95) 55%, rgba(30, 64, 175, 0.95));
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
+  transform: scale(0.85) rotateX(12deg);
 }
 
-.gachapon-ball-shadow {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: clamp(36px, 9vw, 64px);
-  height: clamp(10px, 2.5vw, 16px);
-  border-radius: 999px;
-  opacity: 0;
-  transform: translateX(-15%);
-  background: rgba(15, 23, 42, 0.35);
-  filter: blur(12px);
-  transform-origin: center;
-}
-
-.machine-visual--playing .gachapon-ball {
-  opacity: 1;
-  animation: gachaponBallRoll 1.4s ease-in-out infinite;
-}
-
-.machine-visual--playing .gachapon-ball-shadow {
-  opacity: 0.45;
-  animation: gachaponBallShadow 1.4s ease-in-out infinite;
-}
-
-@keyframes machineShake {
+@keyframes gachapon-shake {
   0% {
     transform: translate3d(0, 0, 0) rotate(0deg);
-  }
-  20% {
-    transform: translate3d(-3px, 2px, 0) rotate(-1deg);
-  }
-  40% {
-    transform: translate3d(3px, -2px, 0) rotate(1.2deg);
-  }
-  60% {
-    transform: translate3d(-2px, 3px, 0) rotate(-0.8deg);
-  }
-  80% {
-    transform: translate3d(2px, -3px, 0) rotate(0.6deg);
-  }
-  100% {
-    transform: translate3d(0, 0, 0) rotate(0deg);
-  }
-}
-
-@keyframes gachaponBallRoll {
-  0% {
-    transform: translateX(-20%) rotate(0deg);
   }
   25% {
-    transform: translateX(30%) rotate(120deg);
+    transform: translate3d(-5px, 3px, 0) rotate(-1.6deg);
   }
   50% {
-    transform: translateX(85%) rotate(240deg);
+    transform: translate3d(4px, -4px, 0) rotate(1.4deg);
   }
   75% {
-    transform: translateX(140%) rotate(320deg);
+    transform: translate3d(-4px, -2px, 0) rotate(-1deg);
   }
   100% {
-    transform: translateX(190%) rotate(400deg);
+    transform: translate3d(0, 0, 0) rotate(0deg);
   }
 }
 
-@keyframes gachaponBallShadow {
+.gachapon-explosion {
+  position: absolute;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(250, 204, 21, 0.9) 0%, rgba(249, 115, 22, 0.6) 55%, rgba(0, 0, 0, 0) 70%);
+  animation: gachapon-explosion-burst 0.6s forwards ease-out;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+@keyframes gachapon-explosion-burst {
   0% {
-    transform: translateX(-20%) scaleX(0.7);
-    opacity: 0.3;
+    transform: scale(0.35);
+    opacity: 0.9;
   }
   50% {
-    transform: translateX(90%) scaleX(1);
-    opacity: 0.45;
+    transform: scale(1.9);
+    opacity: 1;
   }
   100% {
-    transform: translateX(190%) scaleX(0.7);
-    opacity: 0.3;
+    transform: scale(3.8);
+    opacity: 0;
   }
 }
 
-.machine-panel {
-  border-radius: 1.25rem;
-  padding: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
+.gachapon-capsule {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 120px;
+  height: 120px;
+  border-radius: 50% 50% 60% 60%;
+  box-shadow: 0 12px 20px rgba(15, 23, 42, 0.35);
+  transition: transform 0.4s ease, opacity 0.4s ease;
 }
 
-.machine-panel h3 {
-  font-size: 1.25rem;
-  margin: 0;
+.gachapon-capsule::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0) 55%);
+  mix-blend-mode: screen;
 }
 
-.machine-panel p {
-  margin: 0;
-  line-height: 1.6;
+.gachapon-capsule--hidden {
+  transform: translate(-50%, -50%) scale(0.6) rotateX(22deg);
+  opacity: 0;
 }
 
-.gachapon-button {
-  padding: 0.85rem 1.25rem;
-  border: none;
-  border-radius: 999px;
-  font-size: 1rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 120ms ease, box-shadow 120ms ease;
-}
-
-.gachapon-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
-}
-
-.gachapon-button:not(:disabled):hover {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 30px rgba(56, 189, 248, 0.35);
-}
-
-.gachapon-error {
-  margin: 0;
-  font-size: 0.95rem;
-  opacity: 0.85;
-}
-
-.prizes-section {
-  margin-top: 2.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
-
-.prizes-section__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.prizes-section__header h2 {
-  margin: 0;
-  font-size: clamp(1.35rem, 2vw, 1.75rem);
-}
-
-.prizes-section__status {
-  font-size: 0.95rem;
-  opacity: 0.85;
-}
-
-.prizes-section__status--error {
-  color: #fecaca;
-}
-
-.prize-gallery {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: 1rem;
-}
-
-.prize-card {
-  padding: 1rem;
-  border-radius: 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(10px);
-}
-
-.prize-card__media {
-  width: 100%;
-  aspect-ratio: 4 / 3;
-  border-radius: 0.85rem;
+.gachapon-capsule-display {
+  position: relative;
+  width: 112px;
+  height: 112px;
+  border-radius: 50% 50% 60% 60%;
+  box-shadow: 0 14px 26px rgba(15, 23, 42, 0.35);
   overflow: hidden;
 }
 
-.prize-card__media img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+.gachapon-capsule-display::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0) 55%);
+  mix-blend-mode: screen;
 }
 
-.prize-card__content {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.prize-card__content h4 {
-  margin: 0;
-  font-size: 1.1rem;
-}
-
-.prize-card__content p {
-  margin: 0;
-  line-height: 1.5;
-  font-size: 0.95rem;
-}
-
-.prize-card__meta {
-  font-size: 0.8rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  opacity: 0.75;
-}
-
-.prizes-section__footnote {
-  margin: 0;
-  font-size: 0.85rem;
-  opacity: 0.75;
-}
-
-.gachapon-results {
-  min-height: 100vh;
-  display: flex;
+.gachapon-start-button {
+  position: relative;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 2.5rem 1.5rem;
-}
-
-.results-card {
-  width: min(680px, 100%);
-  border-radius: 1.5rem;
-  padding: clamp(1.75rem, 2.5vw + 1rem, 2.5rem);
-  background: rgba(15, 23, 42, 0.65);
-  backdrop-filter: blur(16px);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.results-title {
-  font-size: clamp(2rem, 3vw, 2.75rem);
-  margin: 0.35rem 0;
-}
-
-.results-subtitle,
-.results-message,
-.results-error {
-  margin: 0;
-  opacity: 0.85;
-}
-
-.results-error {
-  color: #fca5a5;
-}
-
-.prize-preview {
-  display: grid;
-  grid-template-columns: minmax(120px, 150px) 1fr;
-  gap: 1.25rem;
-  padding: 1.25rem;
-  border-radius: 1.25rem;
-  background: rgba(15, 23, 42, 0.55);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-}
-
-.prize-image {
-  width: 100%;
-  height: 120px;
-  object-fit: cover;
-  border-radius: 1rem;
-}
-
-.prize-rarity {
-  margin: 0;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.75rem;
-  opacity: 0.75;
-}
-
-.prize-name {
-  margin: 0.35rem 0;
-  font-size: 1.35rem;
-}
-
-.prize-description {
-  margin: 0;
-  font-size: 0.95rem;
-  line-height: 1.6;
-}
-
-.section-title {
-  margin: 0 0 0.75rem;
-  font-size: 1.2rem;
-}
-
-.voucher-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.85rem;
-}
-
-.voucher-item {
-  border-radius: 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  padding: 1rem 1.25rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.voucher-name {
-  margin: 0;
-  font-weight: 600;
-}
-
-.voucher-code,
-.voucher-expiry {
-  margin: 0;
-  font-size: 0.9rem;
-  opacity: 0.85;
-}
-
-.results-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  justify-content: flex-end;
-}
-
-.results-button {
+  padding: 1.1rem 3.5rem;
   border: none;
-  border-radius: 999px;
-  padding: 0.8rem 1.5rem;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.results-link {
-  border: none;
+  border-radius: 9999px;
   background: transparent;
-  color: inherit;
+  color: #fff7ed;
+  font-size: 1.25rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  line-height: 1;
   cursor: pointer;
-  text-decoration: underline;
-  font-weight: 500;
+  box-shadow: 0 18px 0 #9a3412, 0 28px 45px rgba(249, 115, 22, 0.55);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
 }
 
-.loading-text {
-  margin: 0;
-  opacity: 0.8;
+.gachapon-start-button::before {
+  content: '';
+  position: absolute;
+  inset: -18px -28px -40px;
+  border-radius: inherit;
+  background: radial-gradient(circle, rgba(249, 115, 22, 0.35), rgba(249, 115, 22, 0));
+  z-index: 0;
 }
 
-@media (max-width: 768px) {
-  .gachapon-root {
-    justify-content: flex-start;
-    padding: 1.5rem 1rem;
-  }
-
-  .gachapon-card {
-    border-radius: 1.25rem;
-    padding: clamp(1.5rem, 3vw + 1rem, 2rem);
-  }
-
-  .machine-wrapper {
-    grid-template-columns: 1fr;
-  }
-
-  .prize-gallery {
-    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-  }
-
-  .prize-preview {
-    grid-template-columns: 1fr;
-    text-align: center;
-  }
-
-  .prize-image {
-    height: 160px;
-    margin: 0 auto;
-  }
-
-  .voucher-item {
-    flex-direction: column;
-    align-items: flex-start;
-  }
+.gachapon-start-button::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at 50% 20%, #fde68a 0%, #fb923c 45%, #f97316 70%, #ea580c 100%);
+  box-shadow: inset 0 -10px 0 rgba(124, 45, 18, 0.6), inset 0 8px 18px rgba(255, 255, 255, 0.25);
+  z-index: 1;
+  transition: inherit;
 }
 
-@media (max-width: 480px) {
-  .gachapon-card {
-    padding: 1.5rem;
-  }
+.gachapon-start-button span {
+  position: relative;
+  z-index: 2;
+  text-shadow: 0 4px 12px rgba(120, 53, 15, 0.6);
+}
 
-  .machine-panel {
-    padding: 1.25rem;
-  }
+.gachapon-start-button:hover:not(:disabled) {
+  transform: translateY(-3px);
+  box-shadow: 0 20px 0 #b45309, 0 34px 55px rgba(249, 115, 22, 0.6);
+}
 
-  .prizes-section__header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
+.gachapon-start-button:hover:not(:disabled)::after {
+  filter: brightness(1.05);
+}
 
-  .prize-gallery {
-    grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
-  }
+.gachapon-start-button:active:not(:disabled) {
+  transform: translateY(6px);
+  box-shadow: 0 10px 0 #9a3412, 0 18px 32px rgba(153, 27, 27, 0.45);
+}
 
-  .results-card {
-    padding: 1.75rem;
-  }
+.gachapon-start-button:active:not(:disabled)::after {
+  box-shadow: inset 0 -4px 0 rgba(124, 45, 18, 0.6), inset 0 4px 12px rgba(255, 255, 255, 0.25);
+}
+
+.gachapon-start-button:disabled {
+  cursor: not-allowed;
+  filter: grayscale(0.3) brightness(0.92);
+  box-shadow: 0 14px 0 #9a3412, 0 20px 32px rgba(15, 23, 42, 0.45);
+}
+
+.gachapon-start-button:disabled::after {
+  background: radial-gradient(circle at 50% 30%, #fcd34d 0%, #fb923c 55%, #f97316 90%);
+}
+
+.gachapon-start-button:focus-visible {
+  outline: 4px solid rgba(253, 224, 71, 0.7);
+  outline-offset: 6px;
 }

--- a/src/game_modules/gachapon-module/gachapon.js
+++ b/src/game_modules/gachapon-module/gachapon.js
@@ -1,38 +1,43 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import GachaponResultsScreen from './gachapon-results-screen';
-import { buildConfig } from './config';
-import { buildDisplayPrizes, retrieveLuckdrawPrizes } from '../luckdraw-prizes';
-import { buildTheme } from './theme';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { buildConfig, mergeDisplayPrizes, normaliseResult } from './config';
+import { retrieveLuckdrawPrizes } from '../luckdraw-prizes';
 import './gachapon.css';
 
-const buildMockResult = (config) => {
-  const prizes = config.prizes || [];
-  const prize = prizes[Math.floor(Math.random() * prizes.length)];
+const rarityAccentClasses = {
+  common: 'border-slate-500 text-slate-200',
+  uncommon: 'border-emerald-300 text-emerald-200',
+  rare: 'border-sky-300 text-sky-200',
+  epic: 'border-violet-300 text-violet-200',
+  legendary: 'border-amber-200 text-amber-100',
+};
 
-  return {
-    resultId: `mock-${Date.now()}`,
-    outcome: prize ? `You won ${prize.name}` : 'Better luck next time',
-    message: 'This is a mocked result. Connect to the backend to receive live data.',
-    prize,
-    voucherItems: [
-      {
-        id: 'voucher-fallback',
-        label: 'Launch Voucher',
-        code: 'DEMO-12345',
-        expiresAt: '2024-12-31T23:59:59.000Z',
-      },
-    ],
-  };
+const rarityBackground = {
+  common: 'bg-slate-800/40',
+  uncommon: 'bg-emerald-500/10',
+  rare: 'bg-sky-500/10',
+  epic: 'bg-violet-500/10',
+  legendary: 'bg-amber-500/10',
 };
 
 const mockPlay = (config) =>
   new Promise((resolve) => {
     setTimeout(() => {
-      resolve(buildMockResult(config));
+      const randomPrize = config.prizes[Math.floor(Math.random() * config.prizes.length)];
+      resolve(
+        normaliseResult(
+          {
+            resultId: `mock-${Date.now()}`,
+            outcome: randomPrize ? `You won ${randomPrize.name}` : 'Better luck next time',
+            message: 'This is a mocked result. Connect to the backend to receive live data.',
+            prize: randomPrize,
+          },
+          config,
+        ),
+      );
     }, 450);
   });
 
-const playGachapon = async ({ config }) => {
+const playGachapon = async (config) => {
   const shouldMock = !config?.play_endpoint || process.env.NODE_ENV !== 'production';
 
   if (shouldMock) {
@@ -57,222 +62,335 @@ const playGachapon = async ({ config }) => {
   }
 
   const data = await response.json();
-  return {
-    ...buildMockResult(config),
-    ...data,
-  };
+  return normaliseResult(data, config);
 };
 
-const PrizeCard = ({ prize, theme }) => (
-  <article
-    className="prize-card"
-    style={{
-      background: `${theme.primaryColor}cc`,
-      borderColor: `${theme.tertiaryColor}33`,
-    }}
-  >
-    <div className="prize-card__media">
-      <img src={prize.image} alt={prize.title} />
-    </div>
-    <div className="prize-card__content">
-      <h4>{prize.title}</h4>
-      <p>{prize.description}</p>
-      {prize.voucherBatchId && (
-        <p className="prize-card__meta">Batch: {prize.voucherBatchId}</p>
-      )}
-      {prize.probability && <p className="prize-card__meta">{prize.probability}</p>}
-    </div>
-  </article>
-);
-
-const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
-  const config = useMemo(() => buildConfig(rawConfig), [rawConfig]);
-  const theme = useMemo(() => buildTheme(config), [config]);
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [error, setError] = useState(null);
-  const [result, setResult] = useState(null);
-  const [prizesState, setPrizesState] = useState(() => ({
-    items: buildDisplayPrizes(config.prizes),
-    includeProbability: false,
-    isLoading: true,
-    error: null,
-  }));
-
-  useEffect(() => {
-    let isActive = true;
-
-    const loadPrizes = async () => {
-      setPrizesState((previous) => ({
-        ...previous,
-        isLoading: true,
-        error: null,
-      }));
-
-      try {
-        const prizesResponse = await retrieveLuckdrawPrizes({
-          config,
-          endpoint: config.prizes_endpoint,
-          fallbackPrizes: config.prizes,
-        });
-
-        if (!isActive) {
-          return;
-        }
-
-        setPrizesState({
-          items: prizesResponse.prizes,
-          includeProbability: prizesResponse.includeProbability,
-          isLoading: false,
-          error: null,
-        });
-      } catch (prizeError) {
-        if (!isActive) {
-          return;
-        }
-
-        console.error('[Gachapon] Failed to load luck draw prizes', prizeError);
-        setPrizesState((previous) => ({
-          ...previous,
-          isLoading: false,
-          error: prizeError.message || 'Unable to load the prize list.',
-        }));
-      }
-    };
-
-    loadPrizes();
-
-    return () => {
-      isActive = false;
-    };
-  }, [config]);
-
-  const handlePlay = async () => {
-    if (isPlaying) {
-      return;
-    }
-    setIsPlaying(true);
-    setError(null);
-
-    try {
-      const payload = await playGachapon({ config });
-      setResult(payload);
-    } catch (playError) {
-      console.error('[Gachapon] Failed to play', playError);
-      setError(playError.message || 'Something went wrong. Please try again.');
-    } finally {
-      setIsPlaying(false);
-    }
-  };
-
-  const machineImage =
-    config.machine_image ||
-    'https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=900&q=80';
-  const backgroundImage =
-    config.background_image ||
-    'https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3?auto=format&fit=crop&w=1600&q=80';
-
-  if (result) {
-    return (
-      <GachaponResultsScreen
-        config={config}
-        result={{ ...result, gameId: config.game_id }}
-        onPlayAgain={() => setResult(null)}
-        onBack={onBack}
-      />
-    );
+const formatDropRate = (weight, totalWeight) => {
+  if (!totalWeight) {
+    return '—';
   }
+
+  const percentage = (weight / totalWeight) * 100;
+  if (percentage < 0.1) {
+    return '<0.1%';
+  }
+
+  return `${percentage.toFixed(1)}%`;
+};
+
+const PrizeCard = ({ prize, totalWeight }) => {
+  const accentClass = rarityAccentClasses[prize.rarity] ?? 'border-slate-500 text-slate-200';
+  const backgroundClass = rarityBackground[prize.rarity] ?? 'bg-slate-800/40';
+  const dropRate = prize.probabilityLabel || formatDropRate(prize.weight ?? 0, totalWeight);
 
   return (
     <div
-      className="gachapon-root"
-      style={{
-        backgroundImage: `linear-gradient(135deg, ${theme.primaryColor}cc, ${theme.secondaryColor}aa), url(${backgroundImage})`,
-        color: theme.textColor,
-      }}
+      className={`flex h-full flex-col justify-between rounded-xl border ${accentClass} ${backgroundClass} p-4 shadow-lg shadow-slate-900/30`}
     >
-      <div
-        className="gachapon-card"
-        style={{
-          background: `${theme.primaryColor}cc`,
-          border: `1px solid ${theme.borderColor}`,
-        }}
-      >
-        <header className="gachapon-header">
-          <p style={{ color: theme.tertiaryColor, letterSpacing: '0.08em', textTransform: 'uppercase' }}>
-            {config.subtitle || 'Instant Prize Capsule'}
-          </p>
-          <h1>{config.title || config.name}</h1>
-          <p style={{ color: theme.mutedTextColor }}>{config.instructions}</p>
-        </header>
+      <div>
+        <p className="text-sm uppercase tracking-wide text-slate-400">{prize.rarityLabel}</p>
+        <h3 className="mt-1 text-xl font-semibold text-white">{prize.name}</h3>
+        <p className="mt-2 text-sm text-slate-300">{prize.description}</p>
+      </div>
+      <div className="mt-4 flex items-center justify-between text-sm text-slate-400">
+        <span>Drop Rate</span>
+        <span className="font-semibold text-slate-100">{dropRate}</span>
+      </div>
+    </div>
+  );
+};
 
-        <div className="machine-wrapper">
-          <div className={`machine-visual ${isPlaying ? 'machine-visual--playing' : ''}`}>
-            <img src={machineImage} alt="Gachapon machine" className="machine-image" />
-            <div className="gachapon-ball-track" aria-hidden="true">
-              <div className="gachapon-ball" />
-              <div className="gachapon-ball-shadow" />
+const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
+  const config = useMemo(() => buildConfig(rawConfig), [rawConfig]);
+  const [prizes, setPrizes] = useState(config.prizes);
+  const [loadingPrizes, setLoadingPrizes] = useState(true);
+  const [prizeError, setPrizeError] = useState(null);
+  const [includeProbability, setIncludeProbability] = useState(false);
+  const [isAttempting, setIsAttempting] = useState(false);
+  const [animationPhase, setAnimationPhase] = useState('idle');
+  const [result, setResult] = useState(null);
+  const [showResultModal, setShowResultModal] = useState(false);
+  const [attemptError, setAttemptError] = useState(null);
+  const [animationKey, setAnimationKey] = useState(0);
+
+  const timeoutsRef = useRef([]);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+      timeoutsRef.current.forEach(clearTimeout);
+      timeoutsRef.current = [];
+    };
+  }, []);
+
+  useEffect(() => {
+    setPrizes(config.prizes);
+    setAnimationPhase('idle');
+    setResult(null);
+    setShowResultModal(false);
+    setAttemptError(null);
+    setIncludeProbability(false);
+  }, [config]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadingPrizes(true);
+    setPrizeError(null);
+
+    retrieveLuckdrawPrizes({
+      config,
+      endpoint: config.prizes_endpoint,
+      fallbackPrizes: config.prizes,
+    })
+      .then((prizesResponse) => {
+        if (cancelled || !isMountedRef.current) {
+          return;
+        }
+        setPrizes(mergeDisplayPrizes(prizesResponse.prizes, config));
+        setIncludeProbability(Boolean(prizesResponse.includeProbability));
+      })
+      .catch(() => {
+        if (cancelled || !isMountedRef.current) {
+          return;
+        }
+        setPrizeError(config.prizeListErrorText);
+      })
+      .finally(() => {
+        if (cancelled || !isMountedRef.current) {
+          return;
+        }
+        setLoadingPrizes(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [config]);
+
+  const totalWeight = useMemo(() => prizes.reduce((sum, prize) => sum + (prize.weight ?? 0), 0), [prizes]);
+
+  const queueTimeout = (callback, delay) => {
+    const timeoutId = setTimeout(callback, delay);
+    timeoutsRef.current.push(timeoutId);
+    return timeoutId;
+  };
+
+  const handleAttempt = () => {
+    if (isAttempting || loadingPrizes) {
+      return;
+    }
+
+    timeoutsRef.current.forEach(clearTimeout);
+    timeoutsRef.current = [];
+
+    setIsAttempting(true);
+    setAttemptError(null);
+    setResult(null);
+    setShowResultModal(false);
+    setAnimationKey((prev) => prev + 1);
+    setAnimationPhase('preparing');
+
+    playGachapon(config)
+      .then((outcome) => {
+        if (!isMountedRef.current) {
+          return;
+        }
+
+        setResult(outcome);
+        setAnimationPhase('shaking');
+
+        queueTimeout(() => {
+          if (!isMountedRef.current) {
+            return;
+          }
+
+          setAnimationPhase('explosion');
+
+          queueTimeout(() => {
+            if (!isMountedRef.current) {
+              return;
+            }
+
+            setAnimationPhase('result');
+            setShowResultModal(true);
+            setIsAttempting(false);
+          }, config.explosionDurationMs);
+        }, config.shakeDurationMs);
+      })
+      .catch(() => {
+        if (!isMountedRef.current) {
+          return;
+        }
+        setAttemptError(config.attemptErrorText);
+        setAnimationPhase('idle');
+        setIsAttempting(false);
+      });
+  };
+
+  const closeModal = () => {
+    setShowResultModal(false);
+    setAnimationPhase('idle');
+  };
+
+  const capsuleStatusLabel = (() => {
+    switch (animationPhase) {
+      case 'preparing':
+        return config.capsuleStatusPreparingLabel;
+      case 'shaking':
+        return config.capsuleStatusShakingLabel;
+      case 'explosion':
+        return config.capsuleStatusOpeningLabel;
+      case 'result':
+        return config.capsuleStatusResultLabel;
+      default:
+        return config.capsuleStatusIdleLabel;
+    }
+  })();
+
+  const buttonLabel = isAttempting ? config.preparingLabel : config.ctaLabel;
+  const capsuleColor = result?.prize?.capsuleColor ?? config.defaultCapsuleColor;
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 py-12 text-white">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-16 left-16 h-60 w-60 rounded-full bg-indigo-500/25 blur-3xl" />
+        <div className="absolute top-1/3 right-12 h-72 w-72 rounded-full bg-violet-500/20 blur-3xl" />
+        <div className="absolute bottom-0 left-1/4 h-72 w-72 rounded-full bg-fuchsia-500/15 blur-3xl" />
+      </div>
+
+      <div className="relative mx-auto flex w-full max-w-5xl flex-col items-center px-4">
+        <div className="text-center">
+          {config.tagline ? (
+            <p className="text-sm uppercase tracking-[0.35em] text-indigo-300">{config.tagline}</p>
+          ) : null}
+          <h1 className="mt-2 text-4xl font-semibold text-white sm:text-5xl">
+            {config.title ?? 'Gachapon Game'}
+          </h1>
+          {config.description ? (
+            <p className="mt-4 max-w-2xl text-sm text-slate-300 sm:text-base">{config.description}</p>
+          ) : null}
+        </div>
+
+        <div className="mt-10 w-full max-w-3xl overflow-hidden rounded-[2.5rem] border border-indigo-400/30 bg-slate-900/80 p-10 text-center shadow-2xl shadow-indigo-900/40 backdrop-blur">
+          <div className="flex flex-col items-center gap-8">
+            {config.capsuleMachineLabel ? (
+              <p className="text-xs uppercase tracking-[0.35em] text-indigo-300">{config.capsuleMachineLabel}</p>
+            ) : null}
+            <div className="gachapon-stage relative flex h-80 w-full max-w-md items-center justify-center rounded-[2rem] border border-indigo-400/30 bg-slate-950/70 p-8 shadow-[0_24px_45px_rgba(15,23,42,0.55)]">
+              <div className="relative flex h-full w-full flex-col items-center justify-center">
+                <div
+                  className={`gachapon-box ${animationPhase === 'shaking' ? 'gachapon-box--shake' : ''} ${animationPhase === 'explosion' ? 'gachapon-box--hidden' : ''}`}
+                >
+                  <div
+                    className={`gachapon-capsule ${
+                      animationPhase === 'explosion' || animationPhase === 'result' ? 'gachapon-capsule--hidden' : ''
+                    }`}
+                    style={{ background: capsuleColor }}
+                  />
+                  <div className="absolute inset-x-8 bottom-6 rounded-full bg-slate-800/80 py-3 text-xs uppercase tracking-[0.3em] text-slate-400">
+                    {capsuleStatusLabel}
+                  </div>
+                </div>
+                {animationPhase === 'explosion' ? <div key={animationKey} className="gachapon-explosion" /> : null}
+              </div>
             </div>
-          </div>
-
-          <div
-            className="machine-panel"
-            style={{
-              background: `${theme.primaryColor}88`,
-              border: `1px solid ${theme.borderColor}`,
-            }}
-          >
-            <h3>Launch a capsule</h3>
-            <p>Each play dispenses a capsule containing one of the featured rewards below.</p>
-            <button
-              type="button"
-              onClick={handlePlay}
-              disabled={isPlaying}
-              className="gachapon-button"
-              style={{
-                background: theme.secondaryColor,
-                color: theme.primaryColor,
-              }}
-            >
-              {isPlaying ? 'Rolling…' : 'Play now'}
-            </button>
-            {error && <p className="gachapon-error">{error}</p>}
-            <button
-              type="button"
-              onClick={onBack}
-              className="gachapon-button"
-              style={{
-                background: 'transparent',
-                border: `1px solid ${theme.borderColor}`,
-                color: theme.textColor,
-                boxShadow: 'none',
-              }}
-            >
-              Back
-            </button>
+            {config.capsuleDescription ? (
+              <p className="max-w-lg text-sm text-indigo-100/80">{config.capsuleDescription}</p>
+            ) : null}
+            {attemptError ? (
+              <p className="w-full rounded-2xl border border-rose-500/40 bg-rose-500/10 px-5 py-3 text-sm text-rose-200" role="status">
+                {attemptError}
+              </p>
+            ) : null}
           </div>
         </div>
 
-        <section className="prizes-section">
-          <div className="prizes-section__header">
-            <h2>Available prizes</h2>
-            {prizesState.isLoading && <span className="prizes-section__status">Loading…</span>}
-          </div>
-          {prizesState.error ? (
-            <p className="prizes-section__status prizes-section__status--error">
-              {prizesState.error}
-            </p>
-          ) : (
-            <div className="prize-gallery">
-              {prizesState.items.map((prize) => (
-                <PrizeCard key={prize.id} prize={prize} theme={theme} />
-              ))}
+        <div className="mt-10 flex flex-col items-center gap-4">
+          <button
+            type="button"
+            onClick={handleAttempt}
+            disabled={isAttempting || loadingPrizes}
+            className="gachapon-start-button"
+          >
+            <span>{buttonLabel}</span>
+          </button>
+          {onBack ? (
+            <button
+              type="button"
+              className="rounded-full border border-slate-700/70 px-6 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:text-white"
+              onClick={onBack}
+            >
+              Back
+            </button>
+          ) : null}
+        </div>
+
+        <div className="mt-12 w-full overflow-hidden rounded-[2.5rem] border border-slate-800/70 bg-slate-900/80 p-8 shadow-2xl shadow-indigo-900/30 backdrop-blur">
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-col items-center justify-between gap-3 text-center sm:flex-row sm:text-left">
+              <div>
+                <h2 className="text-lg font-semibold text-white sm:text-xl">{config.prizeShowcaseTitle}</h2>
+                {config.prizeShowcaseDescription ? (
+                  <p className="mt-1 text-sm text-slate-400">{config.prizeShowcaseDescription}</p>
+                ) : null}
+              </div>
+              <span className="rounded-full border border-slate-700/60 bg-slate-950/60 px-4 py-1 text-xs uppercase tracking-[0.3em] text-slate-300">
+                {prizes.length} Rewards
+              </span>
             </div>
-          )}
-          {prizesState.includeProbability && !prizesState.error && !prizesState.isLoading && (
-            <p className="prizes-section__footnote">Probabilities shown are provided by the backend.</p>
-          )}
-        </section>
+            {loadingPrizes ? (
+              <p className="text-sm text-slate-400">{config.prizeListLoadingText}</p>
+            ) : prizeError ? (
+              <p className="text-sm text-rose-300">{prizeError}</p>
+            ) : (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {prizes.map((prize) => (
+                  <PrizeCard key={prize.id} prize={prize} totalWeight={totalWeight} />
+                ))}
+              </div>
+            )}
+            {includeProbability && !loadingPrizes && !prizeError ? (
+              <p className="text-xs text-slate-500">Probabilities shown are provided by the backend.</p>
+            ) : null}
+          </div>
+        </div>
       </div>
+
+      {showResultModal && result ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4 py-10 backdrop-blur">
+          <div className="w-full max-w-lg rounded-3xl border border-indigo-400/40 bg-slate-900/90 p-8 shadow-2xl shadow-indigo-900/50">
+            <p className="text-sm uppercase tracking-[0.25em] text-indigo-300">{config.resultModalTitle}</p>
+            <h3 className="mt-2 text-3xl font-semibold text-white">{result.prize.name}</h3>
+            <p className="mt-1 text-sm text-slate-400">{result.prize.rarityLabel}</p>
+            <div className="mt-5 flex items-center justify-center">
+              <div className="gachapon-capsule-display" style={{ background: result.prize.capsuleColor }} />
+            </div>
+            <p className="mt-6 text-sm text-slate-300">{result.prize.description}</p>
+            <p className="mt-4 text-sm text-indigo-200">{result.flairText ?? config.defaultFlairText}</p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                className="rounded-full border border-slate-600 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-400 hover:text-white"
+                onClick={closeModal}
+              >
+                {config.ctaLabel}
+              </button>
+              {onBack ? (
+                <button
+                  type="button"
+                  className="rounded-full bg-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400"
+                  onClick={onBack}
+                >
+                  Back
+                </button>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- rebuild the gachapon module UI to match the modern gachapon game with animated capsule flow and modal reveal
- expand the module configuration utilities to normalise prizes, timing, and textual copy used by the new interface
- replace the legacy stylesheet with the animation and button styling used by the modern gachapon experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e27e371048832abc86ee2f3095ec70