### PR TITLE
Improve mobile layout for scratch card and gachapon modules

### DIFF
--- a/src/game_modules/gachapon-module/gachapon.css
+++ b/src/game_modules/gachapon-module/gachapon.css
@@ -4,8 +4,8 @@
 
 .gachapon-box {
   position: relative;
-  width: 240px;
-  height: 260px;
+  width: clamp(210px, 70vw, 240px);
+  height: clamp(220px, 76vw, 260px);
   border-radius: 24px;
   background: linear-gradient(160deg, #312e81, #1f2937);
   box-shadow: 0 20px 40px rgba(15, 23, 42, 0.45);
@@ -59,8 +59,8 @@
 
 .gachapon-explosion {
   position: absolute;
-  width: 120px;
-  height: 120px;
+  width: clamp(96px, 38vw, 120px);
+  height: clamp(96px, 38vw, 120px);
   border-radius: 50%;
   background: radial-gradient(circle, rgba(250, 204, 21, 0.9) 0%, rgba(249, 115, 22, 0.6) 55%, rgba(0, 0, 0, 0) 70%);
   animation: gachapon-explosion-burst 0.6s forwards ease-out;
@@ -88,8 +88,8 @@
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
-  width: 120px;
-  height: 120px;
+  width: clamp(96px, 36vw, 120px);
+  height: clamp(96px, 36vw, 120px);
   border-radius: 50% 50% 60% 60%;
   box-shadow: 0 12px 20px rgba(15, 23, 42, 0.35);
   transition: transform 0.4s ease, opacity 0.4s ease;
@@ -111,8 +111,8 @@
 
 .gachapon-capsule-display {
   position: relative;
-  width: 112px;
-  height: 112px;
+  width: clamp(92px, 35vw, 112px);
+  height: clamp(92px, 35vw, 112px);
   border-radius: 50% 50% 60% 60%;
   box-shadow: 0 14px 26px rgba(15, 23, 42, 0.35);
   overflow: hidden;
@@ -132,18 +132,18 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 1.1rem 3.5rem;
+  padding: clamp(0.85rem, 2.8vw, 1.1rem) clamp(2.25rem, 8vw, 3.5rem);
   border: none;
   border-radius: 9999px;
   background: transparent;
   color: #fff7ed;
-  font-size: 1.25rem;
+  font-size: clamp(1.05rem, 4vw, 1.25rem);
   font-weight: 800;
-  letter-spacing: 0.12em;
+  letter-spacing: clamp(0.08em, 1.8vw, 0.12em);
   text-transform: uppercase;
   line-height: 1;
   cursor: pointer;
-  box-shadow: 0 18px 0 #9a3412, 0 28px 45px rgba(249, 115, 22, 0.55);
+  box-shadow: 0 16px 0 #9a3412, 0 24px 40px rgba(249, 115, 22, 0.55);
   transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
 }
 

--- a/src/game_modules/gachapon-module/gachapon.js
+++ b/src/game_modules/gachapon-module/gachapon.js
@@ -254,7 +254,7 @@ const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
   const capsuleColor = result?.prize?.capsuleColor ?? config.defaultCapsuleColor;
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-slate-950 py-12 text-white">
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 py-10 text-white sm:py-12">
       <div className="pointer-events-none absolute inset-0">
         <div className="absolute -top-16 left-16 h-60 w-60 rounded-full bg-indigo-500/25 blur-3xl" />
         <div className="absolute top-1/3 right-12 h-72 w-72 rounded-full bg-violet-500/20 blur-3xl" />
@@ -264,9 +264,9 @@ const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
       <div className="relative mx-auto flex w-full max-w-5xl flex-col items-center px-4">
         <div className="text-center">
           {config.tagline ? (
-            <p className="text-sm uppercase tracking-[0.35em] text-indigo-300">{config.tagline}</p>
+            <p className="text-xs uppercase tracking-[0.35em] text-indigo-300 sm:text-sm">{config.tagline}</p>
           ) : null}
-          <h1 className="mt-2 text-4xl font-semibold text-white sm:text-5xl">
+          <h1 className="mt-2 text-3xl font-semibold text-white sm:text-5xl">
             {config.title ?? 'Gachapon Game'}
           </h1>
           {config.description ? (
@@ -274,12 +274,12 @@ const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
           ) : null}
         </div>
 
-        <div className="mt-10 w-full max-w-3xl overflow-hidden rounded-[2.5rem] border border-indigo-400/30 bg-slate-900/80 p-10 text-center shadow-2xl shadow-indigo-900/40 backdrop-blur">
-          <div className="flex flex-col items-center gap-8">
+        <div className="mt-10 w-full max-w-3xl overflow-hidden rounded-[2.5rem] border border-indigo-400/30 bg-slate-900/80 p-6 text-center shadow-2xl shadow-indigo-900/40 backdrop-blur sm:p-10">
+          <div className="flex flex-col items-center gap-6 sm:gap-8">
             {config.capsuleMachineLabel ? (
-              <p className="text-xs uppercase tracking-[0.35em] text-indigo-300">{config.capsuleMachineLabel}</p>
+              <p className="text-xs uppercase tracking-[0.35em] text-indigo-300 sm:text-sm">{config.capsuleMachineLabel}</p>
             ) : null}
-            <div className="gachapon-stage relative flex h-80 w-full max-w-md items-center justify-center rounded-[2rem] border border-indigo-400/30 bg-slate-950/70 p-8 shadow-[0_24px_45px_rgba(15,23,42,0.55)]">
+            <div className="gachapon-stage relative flex h-[19rem] w-full max-w-md items-center justify-center rounded-[2rem] border border-indigo-400/30 bg-slate-950/70 p-6 shadow-[0_24px_45px_rgba(15,23,42,0.55)] sm:h-80 sm:p-8">
               <div className="relative flex h-full w-full flex-col items-center justify-center">
                 <div
                   className={`gachapon-box ${animationPhase === 'shaking' ? 'gachapon-box--shake' : ''} ${animationPhase === 'explosion' ? 'gachapon-box--hidden' : ''}`}
@@ -290,7 +290,7 @@ const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
                     }`}
                     style={{ background: capsuleColor }}
                   />
-                  <div className="absolute inset-x-8 bottom-6 rounded-full bg-slate-800/80 py-3 text-xs uppercase tracking-[0.3em] text-slate-400">
+                  <div className="absolute inset-x-5 bottom-5 rounded-full bg-slate-800/80 py-2.5 text-[0.65rem] uppercase tracking-[0.25em] text-slate-400 sm:inset-x-8 sm:bottom-6 sm:py-3 sm:text-xs sm:tracking-[0.3em]">
                     {capsuleStatusLabel}
                   </div>
                 </div>
@@ -308,19 +308,19 @@ const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
           </div>
         </div>
 
-        <div className="mt-10 flex flex-col items-center gap-4">
+        <div className="mt-10 flex w-full flex-col items-center gap-4 sm:w-auto">
           <button
             type="button"
             onClick={handleAttempt}
             disabled={isAttempting || loadingPrizes}
-            className="gachapon-start-button"
+            className="gachapon-start-button w-full sm:w-auto"
           >
             <span>{buttonLabel}</span>
           </button>
           {onBack ? (
             <button
               type="button"
-              className="rounded-full border border-slate-700/70 px-6 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:text-white"
+              className="w-full rounded-full border border-slate-700/70 px-6 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:text-white sm:w-auto"
               onClick={onBack}
             >
               Back
@@ -328,8 +328,8 @@ const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
           ) : null}
         </div>
 
-        <div className="mt-12 w-full overflow-hidden rounded-[2.5rem] border border-slate-800/70 bg-slate-900/80 p-8 shadow-2xl shadow-indigo-900/30 backdrop-blur">
-          <div className="flex flex-col gap-6">
+        <div className="mt-12 w-full overflow-hidden rounded-[2.5rem] border border-slate-800/70 bg-slate-900/80 p-6 shadow-2xl shadow-indigo-900/30 backdrop-blur sm:p-8">
+          <div className="flex flex-col gap-5 sm:gap-6">
             <div className="flex flex-col items-center justify-between gap-3 text-center sm:flex-row sm:text-left">
               <div>
                 <h2 className="text-lg font-semibold text-white sm:text-xl">{config.prizeShowcaseTitle}</h2>
@@ -337,7 +337,7 @@ const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
                   <p className="mt-1 text-sm text-slate-400">{config.prizeShowcaseDescription}</p>
                 ) : null}
               </div>
-              <span className="rounded-full border border-slate-700/60 bg-slate-950/60 px-4 py-1 text-xs uppercase tracking-[0.3em] text-slate-300">
+              <span className="rounded-full border border-slate-700/60 bg-slate-950/60 px-3 py-1 text-xs uppercase tracking-[0.3em] text-slate-300 sm:px-4">
                 {prizes.length} Rewards
               </span>
             </div>
@@ -361,9 +361,9 @@ const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
 
       {showResultModal && result ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4 py-10 backdrop-blur">
-          <div className="w-full max-w-lg rounded-3xl border border-indigo-400/40 bg-slate-900/90 p-8 shadow-2xl shadow-indigo-900/50">
-            <p className="text-sm uppercase tracking-[0.25em] text-indigo-300">{config.resultModalTitle}</p>
-            <h3 className="mt-2 text-3xl font-semibold text-white">{result.prize.name}</h3>
+          <div className="w-full max-w-lg rounded-3xl border border-indigo-400/40 bg-slate-900/90 p-6 text-center shadow-2xl shadow-indigo-900/50 sm:p-8">
+            <p className="text-xs uppercase tracking-[0.25em] text-indigo-300 sm:text-sm">{config.resultModalTitle}</p>
+            <h3 className="mt-2 text-2xl font-semibold text-white sm:text-3xl">{result.prize.name}</h3>
             <p className="mt-1 text-sm text-slate-400">{result.prize.rarityLabel}</p>
             <div className="mt-5 flex items-center justify-center">
               <div className="gachapon-capsule-display" style={{ background: result.prize.capsuleColor }} />
@@ -373,7 +373,7 @@ const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
             <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-end">
               <button
                 type="button"
-                className="rounded-full border border-slate-600 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-400 hover:text-white"
+                className="w-full rounded-full border border-slate-600 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-400 hover:text-white sm:w-auto"
                 onClick={closeModal}
               >
                 {config.ctaLabel}
@@ -381,7 +381,7 @@ const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
               {onBack ? (
                 <button
                   type="button"
-                  className="rounded-full bg-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400"
+                  className="w-full rounded-full bg-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400 sm:w-auto"
                   onClick={onBack}
                 >
                   Back

--- a/src/game_modules/scratch-card-module/scratch-card.css
+++ b/src/game_modules/scratch-card-module/scratch-card.css
@@ -55,8 +55,8 @@ body {
 
 .scratch-card {
   position: relative;
-  width: 320px;
-  height: 220px;
+  width: clamp(260px, 78vw, 320px);
+  height: clamp(180px, 52vw, 220px);
   border-radius: 28px;
   padding: 16px;
   background: linear-gradient(150deg, rgba(79, 70, 229, 0.32), rgba(236, 72, 153, 0.28));
@@ -114,7 +114,7 @@ body {
 
 .scratch-card__reward {
   position: absolute;
-  inset: 12px;
+  inset: clamp(10px, 3vw, 12px);
   border-radius: 18px;
   display: flex;
   flex-direction: column;
@@ -122,7 +122,7 @@ body {
   justify-content: center;
   text-align: center;
   color: #e2e8f0;
-  padding: 24px;
+  padding: clamp(18px, 6vw, 24px);
   background: linear-gradient(135deg, rgba(148, 163, 184, 0.35), rgba(51, 65, 85, 0.92));
   box-shadow: 0 16px 36px rgba(15, 23, 42, 0.5);
   opacity: 0.4;
@@ -158,21 +158,21 @@ body {
 }
 
 .scratch-card__reward-rarity {
-  font-size: 0.74rem;
+  font-size: clamp(0.68rem, 2.2vw, 0.74rem);
   letter-spacing: 0.32em;
   text-transform: uppercase;
   color: rgba(226, 232, 240, 0.7);
 }
 
 .scratch-card__reward-name {
-  font-size: 1.25rem;
+  font-size: clamp(1.05rem, 4.8vw, 1.25rem);
   font-weight: 600;
   letter-spacing: 0.06em;
   color: #f8fafc;
 }
 
 .scratch-card__reward-helper {
-  font-size: 0.75rem;
+  font-size: clamp(0.68rem, 2.2vw, 0.75rem);
   letter-spacing: 0.22em;
   text-transform: uppercase;
   color: rgba(226, 232, 240, 0.55);
@@ -265,14 +265,14 @@ body {
 
 .scratch-card__foil-message {
   position: absolute;
-  bottom: 18px;
-  left: 18px;
-  right: 18px;
+  bottom: clamp(14px, 4vw, 18px);
+  left: clamp(12px, 4vw, 18px);
+  right: clamp(12px, 4vw, 18px);
   border-radius: 999px;
-  padding: 10px 16px;
-  font-size: 0.7rem;
+  padding: clamp(8px, 3vw, 10px) clamp(14px, 5vw, 16px);
+  font-size: clamp(0.62rem, 2.3vw, 0.7rem);
   text-transform: uppercase;
-  letter-spacing: 0.35em;
+  letter-spacing: clamp(0.22em, 2vw, 0.35em);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -291,8 +291,8 @@ body {
 }
 
 .scratch-card__foil-detail {
-  font-size: 0.6rem;
-  letter-spacing: 0.18em;
+  font-size: clamp(0.52rem, 1.8vw, 0.6rem);
+  letter-spacing: clamp(0.12em, 1.4vw, 0.18em);
   color: rgba(226, 232, 240, 0.6);
 }
 
@@ -301,7 +301,7 @@ body {
   flex-direction: column;
   align-items: center;
   gap: 16px;
-  padding: 16px 24px;
+  padding: 16px clamp(18px, 6vw, 24px);
   border-radius: 20px;
   background: rgba(15, 23, 42, 0.6);
   border: 1px solid rgba(99, 102, 241, 0.35);
@@ -309,10 +309,10 @@ body {
 }
 
 .scratch-card__status-badge {
-  padding: 6px 18px;
+  padding: 6px clamp(14px, 4vw, 18px);
   border-radius: 999px;
-  font-size: 0.65rem;
-  letter-spacing: 0.32em;
+  font-size: clamp(0.58rem, 2vw, 0.65rem);
+  letter-spacing: clamp(0.2em, 2vw, 0.32em);
   text-transform: uppercase;
   background: rgba(30, 64, 175, 0.35);
   color: rgba(191, 219, 254, 0.9);
@@ -341,15 +341,15 @@ body {
 }
 
 .scratch-card__progress-label {
-  font-size: 0.7rem;
-  letter-spacing: 0.32em;
+  font-size: clamp(0.62rem, 2.4vw, 0.7rem);
+  letter-spacing: clamp(0.22em, 2vw, 0.32em);
   text-transform: uppercase;
   color: rgba(191, 219, 254, 0.7);
   text-align: center;
 }
 
 .scratch-card__status-detail {
-  font-size: 0.82rem;
+  font-size: clamp(0.75rem, 3vw, 0.82rem);
   text-align: center;
   color: rgba(224, 231, 255, 0.85);
 }
@@ -357,6 +357,27 @@ body {
 .scratch-card__status-detail span {
   color: rgba(129, 140, 248, 0.95);
   font-weight: 600;
+}
+
+@media (max-width: 640px) {
+  .scratch-module-root {
+    align-items: flex-start;
+    padding: clamp(1.5rem, 6vw + 1rem, 2.5rem);
+  }
+
+  .scratch-module-surface {
+    gap: clamp(1.25rem, 4vw, 1.75rem);
+  }
+
+  .scratch-card-container {
+    width: 100%;
+    gap: 22px;
+  }
+
+  .scratch-card__status-panel {
+    width: 100%;
+    max-width: 360px;
+  }
 }
 
 .scratch-card-error {

--- a/src/game_modules/scratch-card-module/scratch-card.js
+++ b/src/game_modules/scratch-card-module/scratch-card.js
@@ -859,19 +859,19 @@ const ScratchCardGame = ({ config = {}, onBack }) => {
       }}
     >
       <div className="scratch-module-surface">
-        <div className="rounded-3xl border border-slate-800/60 bg-slate-950/60 p-7 shadow-[0_30px_70px_rgba(15,23,42,0.45)] backdrop-blur">
-          <div className="flex flex-col gap-6">
+        <div className="rounded-3xl border border-slate-800/60 bg-slate-950/60 p-6 shadow-[0_30px_70px_rgba(15,23,42,0.45)] backdrop-blur sm:p-7">
+          <div className="flex flex-col gap-5 sm:gap-6">
             <div>
-              <p className="text-xs uppercase tracking-[0.4em] text-indigo-200/70">{normalisedConfig.tagline}</p>
-              <h1 className="mt-3 text-4xl font-semibold text-white">{normalisedConfig.title}</h1>
-              <p className="mt-4 text-base text-slate-300">{normalisedConfig.description}</p>
+              <p className="text-[0.68rem] uppercase tracking-[0.35em] text-indigo-200/70 sm:text-xs">{normalisedConfig.tagline}</p>
+              <h1 className="mt-3 text-3xl font-semibold text-white sm:text-4xl">{normalisedConfig.title}</h1>
+              <p className="mt-4 text-sm text-slate-300 sm:text-base">{normalisedConfig.description}</p>
             </div>
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <button
                 type="button"
                 onClick={handleAttempt}
                 disabled={buttonDisabled}
-                className="flex items-center justify-center rounded-full bg-gradient-to-r from-fuchsia-500 via-indigo-500 to-sky-500 px-6 py-2 text-sm font-semibold text-white shadow-lg shadow-indigo-900/40 transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+                className="flex w-full items-center justify-center rounded-full bg-gradient-to-r from-fuchsia-500 via-indigo-500 to-sky-500 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-indigo-900/40 transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto sm:px-6"
               >
                 {buttonLabel}
               </button>
@@ -884,8 +884,8 @@ const ScratchCardGame = ({ config = {}, onBack }) => {
           </div>
         </div>
 
-        <div className="scratch-card-stage rounded-3xl border border-indigo-500/30 bg-gradient-to-br from-indigo-950/70 via-slate-950/60 to-fuchsia-900/40 p-8 shadow-[0_35px_80px_rgba(59,7,100,0.45)]">
-          <div className="scratch-card-container">
+        <div className="scratch-card-stage rounded-3xl border border-indigo-500/30 bg-gradient-to-br from-indigo-950/70 via-slate-950/60 to-fuchsia-900/40 p-5 shadow-[0_35px_80px_rgba(59,7,100,0.45)] sm:p-8">
+          <div className="scratch-card-container w-full">
             <div className={cardClassName}>
               <div className="scratch-card__inner" ref={surfaceRef}>
                 <div className="scratch-card__reward" style={rewardStyle}>
@@ -951,10 +951,10 @@ const ScratchCardGame = ({ config = {}, onBack }) => {
           </div>
         </div>
 
-        <div className="rounded-3xl border border-slate-800/60 bg-slate-950/60 p-7 shadow-[0_30px_70px_rgba(15,23,42,0.45)] backdrop-blur">
-          <div className="flex items-center justify-between gap-3">
+        <div className="rounded-3xl border border-slate-800/60 bg-slate-950/60 p-6 shadow-[0_30px_70px_rgba(15,23,42,0.45)] backdrop-blur sm:p-7">
+          <div className="flex flex-col items-start justify-between gap-3 text-center sm:flex-row sm:items-center sm:text-left">
             <div>
-              <h2 className="text-lg font-semibold text-white">{normalisedConfig.prizeLedgerTitle}</h2>
+              <h2 className="text-lg font-semibold text-white sm:text-xl">{normalisedConfig.prizeLedgerTitle}</h2>
               {normalisedConfig.prizeLedgerSubtitle ? (
                 <p className="mt-1 text-sm text-slate-400">{normalisedConfig.prizeLedgerSubtitle}</p>
               ) : null}
@@ -978,18 +978,18 @@ const ScratchCardGame = ({ config = {}, onBack }) => {
           )}
         </div>
 
-        <div className="flex flex-wrap justify-center gap-3">
+        <div className="flex w-full flex-col flex-wrap gap-3 sm:flex-row sm:justify-center">
           <button
             type="button"
             onClick={onBack}
-            className="rounded-full border border-slate-600 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-400 hover:text-white"
+            className="w-full rounded-full border border-slate-600 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-400 hover:text-white sm:w-auto"
           >
             Back to Store
           </button>
           {cardState === 'revealed' ? (
             <button
               type="button"
-              className="rounded-full bg-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400"
+              className="w-full rounded-full bg-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400 sm:w-auto"
               onClick={handleAttempt}
             >
               {normalisedConfig.playAgainLabel}
@@ -1000,9 +1000,9 @@ const ScratchCardGame = ({ config = {}, onBack }) => {
 
       {showResultModal && result ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4 py-10 backdrop-blur">
-          <div className="w-full max-w-lg rounded-3xl border border-indigo-400/40 bg-slate-900/90 p-8 shadow-2xl shadow-indigo-900/50">
-            <p className="text-sm uppercase tracking-[0.25em] text-indigo-300">{normalisedConfig.resultModalTitle}</p>
-            <h3 className="mt-2 text-3xl font-semibold text-white">{result.prize.name}</h3>
+          <div className="w-full max-w-lg rounded-3xl border border-indigo-400/40 bg-slate-900/90 p-6 text-center shadow-2xl shadow-indigo-900/50 sm:p-8">
+            <p className="text-xs uppercase tracking-[0.25em] text-indigo-300 sm:text-sm">{normalisedConfig.resultModalTitle}</p>
+            <h3 className="mt-2 text-2xl font-semibold text-white sm:text-3xl">{result.prize.name}</h3>
             <p className="mt-1 text-sm text-slate-400">{result.prize.rarityLabel}</p>
             <div className="mt-5 flex items-center justify-center">
               <div
@@ -1022,7 +1022,7 @@ const ScratchCardGame = ({ config = {}, onBack }) => {
             <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-end">
               <button
                 type="button"
-                className="rounded-full border border-slate-600 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-400 hover:text-white"
+                className="w-full rounded-full border border-slate-600 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-400 hover:text-white sm:w-auto"
                 onClick={() => {
                   closeModal();
                   handleAttempt();
@@ -1032,7 +1032,7 @@ const ScratchCardGame = ({ config = {}, onBack }) => {
               </button>
               <button
                 type="button"
-                className="rounded-full bg-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400"
+                className="w-full rounded-full bg-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400 sm:w-auto"
                 onClick={() => {
                   closeModal();
                   onBack?.();


### PR DESCRIPTION
## Summary
- refine the scratch card surface, modals, and actions to better stack on small screens
- adjust gachapon headings, capsule panel, and controls for handheld viewports
- tune module-specific styling with clamp-based sizing to prevent overflow on mobile

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e316b1b8dc832aa58351cbbc768e7d