### PR TITLE
Add overworld exploration prototype game

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -9,7 +9,8 @@ jest.mock(
     Route: ({ element }) => element,
     Routes: ({ children }) => <>{children}</>,
     Link: ({ children, to }) => <a href={to}>{children}</a>,
-    useNavigate: () => jest.fn()
+    useNavigate: () => jest.fn(),
+    useParams: () => ({})
 
   }),
   { virtual: true }
@@ -18,5 +19,5 @@ jest.mock(
 test("renders the game library navigation", () => {
   render(<App />);
   expect(screen.getByText(/NthLabs' Game Library/i)).toBeInTheDocument();
-  expect(screen.getByText(/Precision Timer/i)).toBeInTheDocument();
+  expect(screen.getByText(/Sprite Walkabout/i)).toBeInTheDocument();
 });

--- a/src/game_modules/overworld-module/index.js
+++ b/src/game_modules/overworld-module/index.js
@@ -1,0 +1,120 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import OverworldExplorerGame from './overworld-explorer';
+import sampleOverworldGameDocument from './sample-game-document';
+
+const mockFetchOverworldConfig = () =>
+  new Promise((resolve, reject) => {
+    try {
+      setTimeout(() => {
+        if (typeof structuredClone === 'function') {
+          resolve(structuredClone(sampleOverworldGameDocument));
+          return;
+        }
+
+        resolve(JSON.parse(JSON.stringify(sampleOverworldGameDocument)));
+      }, 250);
+    } catch (error) {
+      reject(error);
+    }
+  });
+
+const ErrorState = ({ message, onBack }) => (
+  <div className="p-6 text-center">
+    <h3 className="text-xl font-semibold text-slate-900">Game failed to load</h3>
+    <p className="mt-1 text-slate-600">{message}</p>
+    {onBack && (
+      <button
+        type="button"
+        onClick={onBack}
+        className="mt-4 rounded-lg bg-slate-900 px-4 py-2 text-white"
+      >
+        Go back
+      </button>
+    )}
+  </div>
+);
+
+const LoadingState = () => (
+  <div className="flex items-center justify-center p-10 text-slate-600">Loading…</div>
+);
+
+export default function OverworldExplorerInit({
+  config: externalConfig,
+  onBack,
+  fetchConfig = mockFetchOverworldConfig,
+}) {
+  const [config, setConfig] = useState(() => externalConfig || null);
+  const [error, setError] = useState(null);
+  const [isLoading, setIsLoading] = useState(() => !externalConfig);
+
+  const loadConfig = useMemo(
+    () => (typeof fetchConfig === 'function' ? fetchConfig : mockFetchOverworldConfig),
+    [fetchConfig],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (externalConfig) {
+      setConfig(externalConfig);
+      setError(null);
+      setIsLoading(false);
+
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setConfig(null);
+    setIsLoading(true);
+    setError(null);
+
+    loadConfig()
+      .then((data) => {
+        if (cancelled) {
+          return;
+        }
+        if (!data) {
+          throw new Error('Game configuration was not found.');
+        }
+        setConfig(data);
+        setIsLoading(false);
+      })
+      .catch((fetchError) => {
+        if (cancelled) {
+          return;
+        }
+        const message =
+          fetchError instanceof Error
+            ? fetchError.message || 'Failed to load the overworld configuration.'
+            : 'Failed to load the overworld configuration.';
+        setError(message);
+        setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [externalConfig, loadConfig]);
+
+  if (error) {
+    return <ErrorState message={error} onBack={onBack} />;
+  }
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (!config?.world?.tiles?.length) {
+    return (
+      <ErrorState
+        message="This overworld is missing its map data. Update the configuration and try again."
+        onBack={onBack}
+      />
+    );
+  }
+
+  return <OverworldExplorerGame config={config} onBack={onBack} />;
+}
+
+export { default as sampleOverworldGameDocument } from './sample-game-document';

--- a/src/game_modules/overworld-module/overworld-explorer.js
+++ b/src/game_modules/overworld-module/overworld-explorer.js
@@ -1,0 +1,518 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+const TILE_SIZE = 48;
+const MOVEMENT_MAP = {
+  ArrowUp: 'up',
+  w: 'up',
+  W: 'up',
+  ArrowDown: 'down',
+  s: 'down',
+  S: 'down',
+  ArrowLeft: 'left',
+  a: 'left',
+  A: 'left',
+  ArrowRight: 'right',
+  d: 'right',
+  D: 'right',
+};
+
+const SOLID_TILES = new Set(['tree', 'water', 'rock']);
+
+const ITEM_RENDERERS = {
+  campfire: (ctx, centerX, centerY) => {
+    ctx.save();
+    ctx.translate(centerX, centerY);
+    ctx.fillStyle = '#b45309';
+    ctx.beginPath();
+    ctx.moveTo(-12, 16);
+    ctx.lineTo(12, 16);
+    ctx.lineTo(0, -4);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.fillStyle = '#f97316';
+    ctx.beginPath();
+    ctx.moveTo(0, -18);
+    ctx.quadraticCurveTo(14, -8, 0, 18);
+    ctx.quadraticCurveTo(-14, -8, 0, -18);
+    ctx.fill();
+
+    ctx.restore();
+  },
+  board: (ctx, centerX, centerY) => {
+    ctx.save();
+    ctx.translate(centerX, centerY);
+    ctx.fillStyle = '#b45309';
+    ctx.fillRect(-14, -16, 28, 20);
+    ctx.fillStyle = '#fde68a';
+    ctx.fillRect(-10, -12, 20, 12);
+    ctx.fillStyle = '#92400e';
+    ctx.fillRect(-2, 4, 4, 14);
+    ctx.restore();
+  },
+  pond: (ctx, centerX, centerY) => {
+    ctx.save();
+    ctx.translate(centerX, centerY);
+    ctx.fillStyle = '#60a5fa';
+    ctx.beginPath();
+    ctx.ellipse(0, 0, 26, 18, 0, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.55)';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.ellipse(4, -2, 12, 6, 0.2, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.restore();
+  },
+  sprout: (ctx, centerX, centerY) => {
+    ctx.save();
+    ctx.translate(centerX, centerY);
+    ctx.fillStyle = '#166534';
+    ctx.fillRect(-2, 4, 4, 14);
+    ctx.fillStyle = '#22c55e';
+    ctx.beginPath();
+    ctx.ellipse(-6, 0, 8, 12, 0.4, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.beginPath();
+    ctx.ellipse(6, -2, 8, 12, -0.4, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+  },
+};
+
+const fallbackItemRenderer = (ctx, centerX, centerY) => {
+  ctx.save();
+  ctx.translate(centerX, centerY);
+  ctx.fillStyle = '#1f2937';
+  ctx.beginPath();
+  ctx.arc(0, 0, 12, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.fillStyle = '#f9fafb';
+  ctx.font = 'bold 12px sans-serif';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText('?', 0, 0);
+  ctx.restore();
+};
+
+const drawTile = (ctx, tile, x, y, tileSize, colors) => {
+  const color = colors[tile] || '#6ac17c';
+  ctx.fillStyle = color;
+  ctx.fillRect(x, y, tileSize, tileSize);
+
+  if (tile === 'water') {
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.35)';
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.arc(x + tileSize * 0.35, y + tileSize * 0.4, tileSize * 0.25, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+
+  if (tile === 'path' || tile === 'sand') {
+    ctx.strokeStyle = 'rgba(120, 72, 30, 0.25)';
+    ctx.strokeRect(x + 4, y + 4, tileSize - 8, tileSize - 8);
+  }
+};
+
+const isTileSolid = (tile, legend) => {
+  if (SOLID_TILES.has(tile)) {
+    return true;
+  }
+
+  const metadata = legend?.[tile];
+  return Boolean(metadata?.solid);
+};
+
+const createDefaultState = (config) => {
+  const startX = config?.player?.start?.x ?? 1;
+  const startY = config?.player?.start?.y ?? 1;
+
+  return {
+    keys: {
+      up: false,
+      down: false,
+      left: false,
+      right: false,
+    },
+    position: {
+      x: (startX + 0.5) * TILE_SIZE,
+      y: (startY + 0.5) * TILE_SIZE,
+    },
+    direction: 'down',
+    nearbyItemId: null,
+  };
+};
+
+const OverworldExplorerGame = ({ config, onBack }) => {
+  const canvasRef = useRef(null);
+  const animationFrameRef = useRef(null);
+  const stateRef = useRef(createDefaultState(config));
+  const [nearbyItem, setNearbyItem] = useState(null);
+  const [eventLog, setEventLog] = useState([]);
+
+  const world = useMemo(() => config?.world ?? { tiles: [[]], width: 1, height: 1 }, [config]);
+  const tileColors = useMemo(() => {
+    const legend = world.legend || {};
+    const entries = Object.entries(legend).map(([key, value]) => [key, value?.color]);
+    return Object.fromEntries(entries);
+  }, [world]);
+
+  const handleInteract = useCallback(() => {
+    const { nearbyItemId } = stateRef.current;
+    if (!nearbyItemId) {
+      return;
+    }
+
+    const item = world.items?.find((entry) => entry.id === nearbyItemId);
+    if (!item) {
+      return;
+    }
+
+    const message = item.interactionMessage || `You examine the ${item.name}.`;
+
+    setEventLog((previous) => {
+      const next = [
+        {
+          id: `${item.id}-${Date.now()}`,
+          text: message,
+        },
+        ...previous,
+      ];
+      return next.slice(0, 5);
+    });
+  }, [world.items]);
+
+  useEffect(() => {
+    stateRef.current = createDefaultState(config);
+  }, [config]);
+
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      const direction = MOVEMENT_MAP[event.key];
+      if (direction) {
+        event.preventDefault();
+        stateRef.current.keys[direction] = true;
+      }
+
+      if (event.key === ' ' || event.key === 'Enter') {
+        event.preventDefault();
+        handleInteract();
+      }
+    };
+
+    const handleKeyUp = (event) => {
+      const direction = MOVEMENT_MAP[event.key];
+      if (direction) {
+        event.preventDefault();
+        stateRef.current.keys[direction] = false;
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [handleInteract]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return undefined;
+    }
+
+    const ctx = canvas.getContext('2d');
+    const { width, height, tiles = [[]] } = world;
+    const canvasWidth = Math.max(1, width * TILE_SIZE);
+    const canvasHeight = Math.max(1, height * TILE_SIZE);
+    canvas.width = canvasWidth;
+    canvas.height = canvasHeight;
+
+    const solidCheckLegend = world.legend || {};
+    const items = world.items || [];
+
+    let lastTime = performance.now();
+
+    const canMoveTo = (targetX, targetY) => {
+      const radius = TILE_SIZE * 0.35;
+      const offsets = [
+        [0, 0],
+        [radius, 0],
+        [-radius, 0],
+        [0, radius],
+        [0, -radius],
+      ];
+
+      return offsets.every(([offsetX, offsetY]) => {
+        const sampleX = targetX + offsetX;
+        const sampleY = targetY + offsetY;
+        const tileX = Math.floor(sampleX / TILE_SIZE);
+        const tileY = Math.floor(sampleY / TILE_SIZE);
+
+        if (tileX < 0 || tileY < 0 || tileX >= width || tileY >= height) {
+          return false;
+        }
+
+        const tile = tiles[tileY]?.[tileX];
+        return !isTileSolid(tile, solidCheckLegend);
+      });
+    };
+
+    const drawItems = () => {
+      items.forEach((item) => {
+        const centerX = (item.position?.x + 0.5) * TILE_SIZE;
+        const centerY = (item.position?.y + 0.5) * TILE_SIZE;
+        const renderer = ITEM_RENDERERS[item.icon] || fallbackItemRenderer;
+        renderer(ctx, centerX, centerY);
+
+        if (stateRef.current.nearbyItemId === item.id) {
+          ctx.save();
+          ctx.strokeStyle = 'rgba(250, 204, 21, 0.8)';
+          ctx.lineWidth = 3;
+          ctx.setLineDash([6, 6]);
+          ctx.beginPath();
+          ctx.arc(centerX, centerY, TILE_SIZE * 0.48, 0, Math.PI * 2);
+          ctx.stroke();
+          ctx.restore();
+        }
+      });
+    };
+
+    const drawPlayer = () => {
+      const { position, direction } = stateRef.current;
+      const centerX = position.x;
+      const centerY = position.y;
+
+      ctx.save();
+      ctx.translate(centerX, centerY);
+      ctx.fillStyle = '#fbbf24';
+      ctx.strokeStyle = '#1f2937';
+      ctx.lineWidth = 3;
+
+      if (direction === 'left') {
+        ctx.beginPath();
+        ctx.moveTo(-18, 0);
+        ctx.lineTo(18, -16);
+        ctx.lineTo(18, 16);
+        ctx.closePath();
+        ctx.fill();
+        ctx.stroke();
+      } else if (direction === 'right') {
+        ctx.beginPath();
+        ctx.moveTo(18, 0);
+        ctx.lineTo(-18, -16);
+        ctx.lineTo(-18, 16);
+        ctx.closePath();
+        ctx.fill();
+        ctx.stroke();
+      } else if (direction === 'up') {
+        ctx.fillRect(-14, -24, 28, 40);
+        ctx.strokeRect(-14, -24, 28, 40);
+      } else {
+        ctx.fillStyle = '#facc15';
+        ctx.fillRect(-16, -20, 32, 40);
+        ctx.strokeRect(-16, -20, 32, 40);
+      }
+
+      ctx.fillStyle = '#1f2937';
+      ctx.beginPath();
+      ctx.arc(0, -8, 4, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.restore();
+    };
+
+    const drawWorld = () => {
+      ctx.clearRect(0, 0, canvasWidth, canvasHeight);
+
+      for (let row = 0; row < height; row += 1) {
+        for (let col = 0; col < width; col += 1) {
+          const tile = tiles[row]?.[col];
+          drawTile(ctx, tile, col * TILE_SIZE, row * TILE_SIZE, TILE_SIZE, tileColors);
+        }
+      }
+
+      drawItems();
+      drawPlayer();
+    };
+
+    const updateNearbyItem = () => {
+      if (!items.length) {
+        if (stateRef.current.nearbyItemId) {
+          stateRef.current.nearbyItemId = null;
+          setNearbyItem(null);
+        }
+        return;
+      }
+
+      const { position } = stateRef.current;
+      const threshold = TILE_SIZE * 0.8;
+      let closestItem = null;
+      let closestDistance = Infinity;
+
+      items.forEach((item) => {
+        const centerX = (item.position?.x + 0.5) * TILE_SIZE;
+        const centerY = (item.position?.y + 0.5) * TILE_SIZE;
+        const distance = Math.hypot(centerX - position.x, centerY - position.y);
+
+        if (distance < threshold && distance < closestDistance) {
+          closestItem = item;
+          closestDistance = distance;
+        }
+      });
+
+      const currentId = stateRef.current.nearbyItemId;
+      const nextId = closestItem?.id ?? null;
+
+      if (currentId !== nextId) {
+        stateRef.current.nearbyItemId = nextId;
+        setNearbyItem(closestItem || null);
+      }
+    };
+
+    const tick = (now) => {
+      const deltaMs = now - lastTime;
+      lastTime = now;
+      const deltaMultiplier = Math.min(3, deltaMs / 16.67);
+
+      const { keys, position } = stateRef.current;
+      let dx = 0;
+      let dy = 0;
+
+      if (keys.up) dy -= 1;
+      if (keys.down) dy += 1;
+      if (keys.left) dx -= 1;
+      if (keys.right) dx += 1;
+
+      if (dx !== 0 || dy !== 0) {
+        const length = Math.hypot(dx, dy) || 1;
+        dx /= length;
+        dy /= length;
+
+        const speedPerFrame = (config?.player?.speed ?? 2.5) * 3 * deltaMultiplier;
+        const proposedX = position.x + dx * speedPerFrame;
+        const proposedY = position.y + dy * speedPerFrame;
+
+        const clampedX = Math.min(Math.max(proposedX, TILE_SIZE * 0.5), canvasWidth - TILE_SIZE * 0.5);
+        const clampedY = Math.min(Math.max(proposedY, TILE_SIZE * 0.5), canvasHeight - TILE_SIZE * 0.5);
+
+        if (canMoveTo(clampedX, position.y)) {
+          position.x = clampedX;
+        }
+        if (canMoveTo(position.x, clampedY)) {
+          position.y = clampedY;
+        }
+
+        if (Math.abs(dx) > Math.abs(dy)) {
+          stateRef.current.direction = dx > 0 ? 'right' : 'left';
+        } else if (dy !== 0) {
+          stateRef.current.direction = dy > 0 ? 'down' : 'up';
+        }
+      }
+
+      updateNearbyItem();
+      drawWorld();
+      animationFrameRef.current = requestAnimationFrame(tick);
+    };
+
+    drawWorld();
+    animationFrameRef.current = requestAnimationFrame((time) => {
+      lastTime = time;
+      tick(time);
+    });
+
+    return () => {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, [config, tileColors, world]);
+
+  const interactionHint = nearbyItem
+    ? `Press Space or Enter to inspect the ${nearbyItem.name}.`
+    : 'WASD or arrow keys to move. Explore and find something curious!';
+
+  return (
+    <div className="flex min-h-screen flex-col gap-6 bg-gradient-to-br from-sky-100 via-emerald-100 to-amber-100 p-6">
+      <header className="flex flex-col gap-3 rounded-2xl bg-white/80 p-5 shadow">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold text-slate-900">{config?.title || 'Overworld Explorer'}</h1>
+            <p className="text-sm text-slate-600">{config?.subtitle}</p>
+          </div>
+          {onBack && (
+            <button
+              type="button"
+              onClick={onBack}
+              className="rounded-full bg-slate-900 px-4 py-2 text-sm font-medium text-white shadow"
+            >
+              Back to games
+            </button>
+          )}
+        </div>
+        <p className="text-sm text-slate-600">
+          Use the keyboard to roam the glade. Placeholder sprites (triangles and rectangles) show direction while
+          walking. Stand near glowing objects and interact to read flavour text.
+        </p>
+      </header>
+
+      <div className="flex flex-col gap-6 lg:flex-row">
+        <div className="flex flex-1 flex-col gap-4">
+          <div className="overflow-hidden rounded-2xl border border-emerald-200 bg-white/60 shadow-inner">
+            <canvas
+              ref={canvasRef}
+              className="h-full w-full"
+              style={{ imageRendering: 'pixelated' }}
+            />
+          </div>
+          <div className="rounded-2xl bg-white/80 p-4 text-sm text-slate-700 shadow">
+            {interactionHint}
+          </div>
+        </div>
+
+        <aside className="flex w-full flex-col gap-4 lg:w-80">
+          <div className="rounded-2xl bg-white/80 p-4 shadow">
+            <h2 className="text-lg font-semibold text-slate-900">World Guide</h2>
+            <p className="mt-1 text-sm text-slate-600">
+              You are exploring <span className="font-medium text-emerald-600">{world?.name || 'a mysterious grove'}</span>.
+              Tile colours are derived from the configuration legend to keep visuals editable.
+            </p>
+            <ul className="mt-3 space-y-1 text-sm">
+              {world?.legend &&
+                Object.entries(world.legend).map(([key, info]) => (
+                  <li key={key} className="flex items-center gap-2">
+                    <span
+                      className="inline-flex h-4 w-4 rounded border border-slate-300"
+                      style={{ backgroundColor: info?.color || '#d1d5db' }}
+                    />
+                    <span className="text-slate-600">{info?.label || key}</span>
+                    {isTileSolid(key, world.legend) && (
+                      <span className="rounded-full bg-slate-900/80 px-2 text-xs text-white">solid</span>
+                    )}
+                  </li>
+                ))}
+            </ul>
+          </div>
+
+          <div className="rounded-2xl bg-white/80 p-4 shadow">
+            <h2 className="text-lg font-semibold text-slate-900">Recent interactions</h2>
+            {eventLog.length === 0 ? (
+              <p className="mt-2 text-sm text-slate-600">Nothing logged yet. Investigate the glowing props.</p>
+            ) : (
+              <ul className="mt-2 space-y-2 text-sm text-slate-700">
+                {eventLog.map((entry) => (
+                  <li key={entry.id} className="rounded-lg bg-emerald-50/80 p-2">
+                    {entry.text}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+};
+
+export default OverworldExplorerGame;

--- a/src/game_modules/overworld-module/sample-game-document.js
+++ b/src/game_modules/overworld-module/sample-game-document.js
@@ -1,0 +1,126 @@
+const legend = {
+  G: 'grass',
+  P: 'path',
+  W: 'water',
+  T: 'tree',
+  S: 'sand',
+  R: 'rock',
+};
+
+const tilePlan = [
+  'TTTTTTTTTTTTTTTT',
+  'TGGGGGGGGGGGGGGT',
+  'TGGGPPPPPGGGGGGT',
+  'TGGGPGGGPGGGGGGT',
+  'TGGGPGWWPGGTTTGT',
+  'TGGGPGWWPGGTTTGT',
+  'TGGGPPPPPGGGTGGT',
+  'TGGGGGGGGGGGTGGT',
+  'TGGGGGSSSGGGGGGT',
+  'TGGGGGSSSGGGGGGT',
+  'TGGGGGGGGGGGGGGT',
+  'TTTTTTTTTTTTTTTT',
+];
+
+const tiles = tilePlan.map((row) =>
+  row.split('').map((symbol) => legend[symbol] || 'grass'),
+);
+
+const width = tiles[0].length;
+const height = tiles.length;
+
+const sampleThumbnailSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#80c6ff" />
+      <stop offset="100%" stop-color="#4caf82" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" fill="url(#bg)" rx="28" />
+  <rect x="16" y="86" width="128" height="36" rx="18" fill="#d4b483" opacity="0.85" />
+  <circle cx="40" cy="70" r="18" fill="#3f704d" />
+  <circle cx="116" cy="60" r="22" fill="#3f704d" />
+  <polygon points="80,54 100,92 60,92" fill="#f9f871" stroke="#1f2937" stroke-width="4" stroke-linejoin="round" />
+</svg>`;
+
+const sampleThumbnail = `data:image/svg+xml;utf8,${encodeURIComponent(sampleThumbnailSvg)}`;
+
+const sampleOverworldGameDocument = {
+  game_template_id: 'overworld-adventure',
+  game_type: 'overworld',
+  title: 'Sprite Walkabout',
+  subtitle: 'Stroll through Sunrise Glade and meet its curiosities.',
+  description:
+    'Guide the sprite around a friendly overworld. Test movement, collisions, and lightweight interactions.',
+  sample_thumbnail: sampleThumbnail,
+  world: {
+    name: 'Sunrise Glade',
+    width,
+    height,
+    tiles,
+    legend: {
+      grass: {
+        label: 'Grass',
+        color: '#6ac17c',
+      },
+      path: {
+        label: 'Path',
+        color: '#d7b894',
+      },
+      water: {
+        label: 'Water',
+        color: '#4f8fd7',
+      },
+      sand: {
+        label: 'Sand',
+        color: '#f1d59a',
+      },
+      tree: {
+        label: 'Trees',
+        color: '#3d6b47',
+        solid: true,
+      },
+      rock: {
+        label: 'Rock',
+        color: '#8d9aa9',
+        solid: true,
+      },
+    },
+    items: [
+      {
+        id: 'campfire',
+        name: 'Campfire',
+        position: { x: 6, y: 6 },
+        interactionMessage: 'The campfire crackles softly. You feel its warmth.',
+        icon: 'campfire',
+      },
+      {
+        id: 'notice-board',
+        name: 'Notice Board',
+        position: { x: 4, y: 3 },
+        interactionMessage: 'A faded note reads: "Adventurers welcome!"',
+        icon: 'board',
+      },
+      {
+        id: 'sparkling-pond',
+        name: 'Sparkling Pond',
+        position: { x: 8, y: 4 },
+        interactionMessage: 'Sunlight scatters across the pond, revealing darting fish.',
+        icon: 'pond',
+      },
+      {
+        id: 'mystery-sprout',
+        name: 'Mystery Sprout',
+        position: { x: 10, y: 8 },
+        interactionMessage: 'The sprout hums when you hover nearby, eager to grow.',
+        icon: 'sprout',
+      },
+    ],
+  },
+  player: {
+    start: { x: 3, y: 5 },
+    speed: 2.5,
+  },
+};
+
+export default sampleOverworldGameDocument;

--- a/src/game_modules/registry.js
+++ b/src/game_modules/registry.js
@@ -6,6 +6,9 @@ import GachaponGameInit, { sampleGachaponGameDocument } from "./gachapon-module"
 import ScratchCardGameInit, {
   sampleScratchCardGameDocument,
 } from "./scratch-card-module";
+import OverworldExplorerInit, {
+  sampleOverworldGameDocument,
+} from "./overworld-module";
 
 /**
  * Keys should match what's coming from backend:
@@ -27,6 +30,10 @@ export const GAME_MODULES = {
   // Scratch card module
   "scratch-card-starlight": ScratchCardGameInit,
   "scratch-card": ScratchCardGameInit,
+
+  // Overworld explorer prototype
+  "overworld-adventure": OverworldExplorerInit,
+  overworld: OverworldExplorerInit,
 
   // Example for future templates:
   // "spinthewheel-v1": SpinTheWheelInit,
@@ -72,6 +79,17 @@ export const GAME_LIBRARY = [
       game_type: sampleScratchCardGameDocument.game_type,
     },
     sampleConfig: sampleScratchCardGameDocument,
+  },
+  {
+    slug: "overworld-adventure",
+    title: sampleOverworldGameDocument.title || "Sprite Walkabout",
+    subtitle: sampleOverworldGameDocument.subtitle,
+    thumbnail: sampleOverworldGameDocument.sample_thumbnail,
+    launchPayload: {
+      game_template_id: "overworld-adventure",
+      game_type: sampleOverworldGameDocument.game_type || "overworld",
+    },
+    sampleConfig: sampleOverworldGameDocument,
   },
 ];
 


### PR DESCRIPTION
## Summary
- add a configurable overworld exploration module with placeholder sprites and interactive items
- expose the overworld game in the registry and home library metadata
- update the app test double to mock useParams and assert the new game tile

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68e49f4c6fd0832a9ed77ab35b1a3dd9