### PR TITLE
Restyle scratch card experience with newspaper-inspired theme

### DIFF
--- a/src/game_modules/scratch-card-module/scratch-card.css
+++ b/src/game_modules/scratch-card-module/scratch-card.css
@@ -1,11 +1,15 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Source+Serif+4:wght@500;600&display=swap');
 
 :root {
-  color-scheme: dark;
+  color-scheme: light;
+  background-color: #f4f1ea;
+  color: #111827;
 }
 
 body {
   font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+  background-color: #f4f1ea;
+  color: #111827;
 }
 
 .scratch-module-root {
@@ -15,9 +19,9 @@ body {
   align-items: center;
   justify-content: center;
   padding: clamp(2rem, 3vw + 1.5rem, 4rem);
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
+  background-color: #f4f1ea;
+  background-image: radial-gradient(#e5dcc7 1px, transparent 1px);
+  background-size: 18px 18px;
   position: relative;
   overflow: hidden;
 }
@@ -26,80 +30,61 @@ body {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at top, rgba(148, 163, 184, 0.12), transparent 55%),
-    radial-gradient(circle at bottom, rgba(56, 189, 248, 0.15), transparent 65%);
-  mix-blend-mode: screen;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.7), rgba(244, 241, 234, 0));
+  mix-blend-mode: normal;
   pointer-events: none;
 }
 
 .scratch-module-surface {
   position: relative;
-  width: min(1080px, 100%);
+  width: min(960px, 100%);
   display: flex;
   flex-direction: column;
-  gap: clamp(1.75rem, 3vw + 1rem, 2.5rem);
+  align-items: center;
+  gap: clamp(1.5rem, 2.5vw + 1rem, 2.5rem);
   z-index: 1;
 }
 
 .scratch-card-stage {
-  perspective: 1200px;
   position: relative;
+  width: 100%;
 }
 
 .scratch-card-container {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 28px;
+  gap: 24px;
 }
 
 .scratch-card {
   position: relative;
-  width: clamp(260px, 78vw, 320px);
-  height: clamp(180px, 52vw, 220px);
+  width: clamp(280px, 80vw, 360px);
+  min-height: clamp(200px, 55vw, 240px);
   border-radius: 28px;
-  padding: 16px;
-  background: linear-gradient(150deg, rgba(79, 70, 229, 0.32), rgba(236, 72, 153, 0.28));
-  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.6);
-  transform-style: preserve-3d;
-  transition: transform 0.35s ease, box-shadow 0.35s ease;
+  padding: 20px;
+  background: #cddffb;
+  border: 3px solid #111827;
+  box-shadow: 0 12px 0 rgba(17, 24, 39, 0.12);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .scratch-card::before {
   content: '';
   position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: linear-gradient(120deg, rgba(255, 255, 255, 0.18), rgba(125, 211, 252, 0));
-  mix-blend-mode: screen;
+  inset: 12px;
+  border-radius: 20px;
+  border: 1px dashed rgba(17, 24, 39, 0.1);
   pointer-events: none;
 }
 
 .scratch-card--scratching {
-  animation: scratch-card-wiggle 0.18s ease-in-out infinite;
+  transform: translateY(-4px);
 }
 
 .scratch-card--revealed {
-  transform: translateY(-4px) scale(1.03);
-  box-shadow: 0 36px 80px rgba(129, 140, 248, 0.5);
-}
-
-@keyframes scratch-card-wiggle {
-  0% {
-    transform: rotate(0deg) translate3d(0, 0, 0);
-  }
-  25% {
-    transform: rotate(-1.6deg) translate3d(-5px, 2px, 0);
-  }
-  50% {
-    transform: rotate(1.6deg) translate3d(4px, -3px, 0);
-  }
-  75% {
-    transform: rotate(-1.2deg) translate3d(-3px, -2px, 0);
-  }
-  100% {
-    transform: rotate(0deg) translate3d(0, 0, 0);
-  }
+  transform: translateY(-6px);
+  box-shadow: 0 16px 0 rgba(17, 24, 39, 0.16);
 }
 
 .scratch-card__inner {
@@ -108,45 +93,34 @@ body {
   height: 100%;
   border-radius: 22px;
   overflow: hidden;
-  background: linear-gradient(160deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.85));
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+  background: #fdfaf3;
+  border: 2px solid #111827;
+  box-shadow: inset 0 -8px 0 rgba(17, 24, 39, 0.06);
 }
 
 .scratch-card__reward {
   position: absolute;
-  inset: clamp(10px, 3vw, 12px);
+  inset: clamp(12px, 4vw, 18px);
   border-radius: 18px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   text-align: center;
-  color: #e2e8f0;
-  padding: clamp(18px, 6vw, 24px);
-  background: linear-gradient(135deg, rgba(148, 163, 184, 0.35), rgba(51, 65, 85, 0.92));
-  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.5);
-  opacity: 0.4;
-  transform: scale(0.96);
-  transition: opacity 0.45s ease, transform 0.45s ease, box-shadow 0.45s ease;
+  color: #111827;
+  padding: clamp(20px, 6vw, 28px);
+  background: #ffffff;
+  border: 2px solid #111827;
+  box-shadow: 0 10px 0 rgba(17, 24, 39, 0.1);
+  transition: transform 0.25s ease;
 }
 
 .scratch-card--revealed .scratch-card__reward {
-  opacity: 1;
-  transform: scale(1);
+  transform: translateY(-4px);
 }
 
 .scratch-card__reward-glow {
-  position: absolute;
-  inset: -35%;
-  border-radius: inherit;
-  background: radial-gradient(circle, rgba(129, 140, 248, 0.45) 0%, rgba(15, 23, 42, 0) 75%);
-  filter: blur(26px);
-  opacity: 0;
-  transition: opacity 0.45s ease;
-}
-
-.scratch-card--revealed .scratch-card__reward-glow {
-  opacity: 1;
+  display: none;
 }
 
 .scratch-card__reward-content {
@@ -158,41 +132,51 @@ body {
 }
 
 .scratch-card__reward-rarity {
-  font-size: clamp(0.68rem, 2.2vw, 0.74rem);
-  letter-spacing: 0.32em;
+  font-size: clamp(0.7rem, 2.2vw, 0.8rem);
+  letter-spacing: 0.26em;
   text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.7);
+  color: rgba(17, 24, 39, 0.64);
 }
 
 .scratch-card__reward-name {
-  font-size: clamp(1.05rem, 4.8vw, 1.25rem);
+  font-family: 'Source Serif 4', 'Georgia', 'Times New Roman', serif;
+  font-size: clamp(1.25rem, 5vw, 1.6rem);
   font-weight: 600;
-  letter-spacing: 0.06em;
-  color: #f8fafc;
+  letter-spacing: 0.01em;
+  color: #111827;
 }
 
 .scratch-card__reward-helper {
-  font-size: clamp(0.68rem, 2.2vw, 0.75rem);
-  letter-spacing: 0.22em;
+  font-size: clamp(0.7rem, 2.1vw, 0.78rem);
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.55);
+  color: rgba(17, 24, 39, 0.56);
 }
 
 .scratch-card__foil {
   position: absolute;
-  inset: 12px;
+  inset: 14px;
   border-radius: 18px;
   overflow: hidden;
-  transition: opacity 0.45s ease, transform 0.45s ease;
+  border: 2px dashed rgba(17, 24, 39, 0.28);
+  background: repeating-linear-gradient(
+      45deg,
+      rgba(17, 24, 39, 0.08) 0,
+      rgba(17, 24, 39, 0.08) 10px,
+      rgba(255, 255, 255, 0.4) 10px,
+      rgba(255, 255, 255, 0.4) 20px
+    ),
+    #f0efe6;
+  transition: opacity 0.35s ease, transform 0.35s ease;
 }
 
 .scratch-card__foil--interactive {
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  cursor: pointer;
 }
 
 .scratch-card__foil--cleared {
   opacity: 0;
-  transform: scale(1.03);
+  transform: scale(1.02);
   pointer-events: none;
 }
 
@@ -202,86 +186,45 @@ body {
   width: 100%;
   height: 100%;
   border-radius: inherit;
-  cursor: crosshair;
+  cursor: pointer;
   touch-action: none;
-  transition: opacity 0.4s ease;
+  transition: opacity 0.3s ease;
 }
 
-.scratch-card__foil-canvas--inactive {
-  opacity: 0;
-  pointer-events: none;
-}
-
+.scratch-card__foil-canvas--inactive,
 .scratch-card__foil-canvas--cleared {
   opacity: 0;
   pointer-events: none;
 }
 
 .scratch-card__foil-noise {
-  position: absolute;
-  inset: -25%;
-  background: conic-gradient(
-    from 0deg,
-    rgba(255, 255, 255, 0.22),
-    rgba(79, 70, 229, 0.25),
-    rgba(236, 72, 153, 0.22),
-    rgba(255, 255, 255, 0.22)
-  );
-  mix-blend-mode: screen;
-  opacity: 0.55;
-  animation: scratch-card-foil-spin 7s linear infinite;
-  pointer-events: none;
+  display: none;
 }
 
 .scratch-card__foil-shine {
-  position: absolute;
-  inset: -35%;
-  background: radial-gradient(circle at 20% -10%, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0));
-  opacity: 0.7;
-  animation: scratch-card-foil-shimmer 4.5s ease-in-out infinite;
-  pointer-events: none;
-}
-
-@keyframes scratch-card-foil-spin {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}
-
-@keyframes scratch-card-foil-shimmer {
-  0%,
-  100% {
-    transform: translateY(-6%);
-    opacity: 0.55;
-  }
-  50% {
-    transform: translateY(6%);
-    opacity: 0.85;
-  }
+  display: none;
 }
 
 .scratch-card__foil-message {
   position: absolute;
   bottom: clamp(14px, 4vw, 18px);
-  left: clamp(12px, 4vw, 18px);
-  right: clamp(12px, 4vw, 18px);
-  border-radius: 999px;
-  padding: clamp(8px, 3vw, 10px) clamp(14px, 5vw, 16px);
-  font-size: clamp(0.62rem, 2.3vw, 0.7rem);
+  left: clamp(16px, 4vw, 20px);
+  right: clamp(16px, 4vw, 20px);
+  border-radius: 16px;
+  padding: clamp(8px, 3vw, 12px) clamp(14px, 5vw, 18px);
+  font-size: clamp(0.65rem, 2.3vw, 0.75rem);
   text-transform: uppercase;
-  letter-spacing: clamp(0.22em, 2vw, 0.35em);
+  letter-spacing: clamp(0.18em, 1.8vw, 0.28em);
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 4px;
-  color: rgba(226, 232, 240, 0.85);
-  background: rgba(15, 23, 42, 0.65);
+  color: #111827;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(17, 24, 39, 0.16);
   opacity: 0;
   transform: translateY(12px);
-  transition: opacity 0.35s ease, transform 0.35s ease;
+  transition: opacity 0.3s ease, transform 0.3s ease;
   pointer-events: none;
 }
 
@@ -291,9 +234,9 @@ body {
 }
 
 .scratch-card__foil-detail {
-  font-size: clamp(0.52rem, 1.8vw, 0.6rem);
-  letter-spacing: clamp(0.12em, 1.4vw, 0.18em);
-  color: rgba(226, 232, 240, 0.6);
+  font-size: clamp(0.54rem, 1.8vw, 0.64rem);
+  letter-spacing: clamp(0.12em, 1.2vw, 0.18em);
+  color: rgba(17, 24, 39, 0.6);
 }
 
 .scratch-card__status-panel {
@@ -301,62 +244,63 @@ body {
   flex-direction: column;
   align-items: center;
   gap: 16px;
-  padding: 16px clamp(18px, 6vw, 24px);
-  border-radius: 20px;
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(99, 102, 241, 0.35);
-  box-shadow: inset 0 0 0 1px rgba(79, 70, 229, 0.18);
+  padding: 18px clamp(20px, 6vw, 28px);
+  border-radius: 24px;
+  background: #ffffff;
+  border: 2px solid #111827;
+  box-shadow: 0 12px 0 rgba(17, 24, 39, 0.12);
 }
 
 .scratch-card__status-badge {
-  padding: 6px clamp(14px, 4vw, 18px);
+  padding: 6px clamp(16px, 4vw, 22px);
   border-radius: 999px;
-  font-size: clamp(0.58rem, 2vw, 0.65rem);
-  letter-spacing: clamp(0.2em, 2vw, 0.32em);
+  font-size: clamp(0.62rem, 2.2vw, 0.72rem);
+  letter-spacing: clamp(0.18em, 1.8vw, 0.28em);
   text-transform: uppercase;
-  background: rgba(30, 64, 175, 0.35);
-  color: rgba(191, 219, 254, 0.9);
+  background: #fee79b;
+  border: 1px solid #111827;
+  color: #111827;
 }
 
 .scratch-card__progress {
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 
 .scratch-card__progress-track {
   width: 100%;
-  height: 6px;
+  height: 8px;
   border-radius: 999px;
-  background: rgba(30, 64, 175, 0.35);
+  background: rgba(17, 24, 39, 0.08);
+  border: 1px solid rgba(17, 24, 39, 0.12);
   overflow: hidden;
 }
 
 .scratch-card__progress-fill {
   height: 100%;
   border-radius: inherit;
-  background: linear-gradient(90deg, rgba(94, 234, 212, 0.9), rgba(129, 140, 248, 0.9));
-  box-shadow: 0 8px 18px rgba(14, 165, 233, 0.45);
+  background: #111827;
 }
 
 .scratch-card__progress-label {
-  font-size: clamp(0.62rem, 2.4vw, 0.7rem);
-  letter-spacing: clamp(0.22em, 2vw, 0.32em);
+  font-size: clamp(0.66rem, 2.4vw, 0.78rem);
+  letter-spacing: clamp(0.16em, 1.6vw, 0.26em);
   text-transform: uppercase;
-  color: rgba(191, 219, 254, 0.7);
+  color: rgba(17, 24, 39, 0.7);
   text-align: center;
 }
 
 .scratch-card__status-detail {
-  font-size: clamp(0.75rem, 3vw, 0.82rem);
+  font-size: clamp(0.78rem, 3vw, 0.88rem);
   text-align: center;
-  color: rgba(224, 231, 255, 0.85);
+  color: rgba(17, 24, 39, 0.82);
 }
 
 .scratch-card__status-detail span {
-  color: rgba(129, 140, 248, 0.95);
-  font-weight: 600;
+  color: #111827;
+  font-weight: 700;
 }
 
 @media (max-width: 640px) {

--- a/src/game_modules/scratch-card-module/scratch-card.js
+++ b/src/game_modules/scratch-card-module/scratch-card.js
@@ -12,19 +12,27 @@ const SCRATCH_RADIUS = 28;
 const DEFAULT_REVEAL_THRESHOLD = 0.6;
 
 const rarityAccentClasses = {
-  common: 'border-slate-500/70 text-slate-100',
-  uncommon: 'border-emerald-400/70 text-emerald-100',
-  rare: 'border-sky-400/70 text-sky-100',
-  epic: 'border-violet-400/70 text-violet-100',
-  legendary: 'border-amber-300/80 text-amber-100',
+  common: 'border-[#1e3a8a]',
+  uncommon: 'border-[#166534]',
+  rare: 'border-[#1d4ed8]',
+  epic: 'border-[#6d28d9]',
+  legendary: 'border-[#b45309]',
 };
 
 const rarityBackground = {
-  common: 'bg-slate-900/60',
-  uncommon: 'bg-emerald-500/15',
-  rare: 'bg-sky-500/15',
-  epic: 'bg-violet-500/15',
-  legendary: 'bg-amber-500/20',
+  common: 'bg-[#e7f0ff]',
+  uncommon: 'bg-[#e4f5ec]',
+  rare: 'bg-[#e6edff]',
+  epic: 'bg-[#f1e9ff]',
+  legendary: 'bg-[#fff4d6]',
+};
+
+const rarityLabelColors = {
+  common: 'text-[#1e3a8a]',
+  uncommon: 'text-[#166534]',
+  rare: 'text-[#1d4ed8]',
+  epic: 'text-[#6d28d9]',
+  legendary: 'text-[#b45309]',
 };
 
 const defaultRarityLabels = {
@@ -349,21 +357,22 @@ const attemptScratchCard = (config) =>
   });
 
 const PrizeCard = ({ prize, dropRate }) => {
-  const accentClass = rarityAccentClasses[prize.rarity] ?? 'border-slate-500/60 text-slate-200';
-  const backgroundClass = rarityBackground[prize.rarity] ?? 'bg-slate-900/60';
+  const accentClass = rarityAccentClasses[prize.rarity] ?? 'border-neutral-900';
+  const backgroundClass = rarityBackground[prize.rarity] ?? 'bg-[#f4f1ea]';
+  const labelColor = rarityLabelColors[prize.rarity] ?? 'text-neutral-700';
 
   return (
     <div
-      className={`flex h-full flex-col justify-between rounded-2xl border ${accentClass} ${backgroundClass} p-5 shadow-lg shadow-slate-950/40 backdrop-blur`}
+      className={`flex h-full flex-col justify-between rounded-[28px] border-[3px] ${accentClass} ${backgroundClass} p-5 shadow-[0_10px_0_rgba(17,24,39,0.12)]`}
     >
       <div>
-        <p className="text-xs uppercase tracking-[0.3em] text-slate-400">{prize.rarityLabel}</p>
-        <h3 className="mt-2 text-lg font-semibold text-white">{prize.name}</h3>
-        <p className="mt-3 text-sm text-slate-300">{prize.description}</p>
+        <p className={`text-xs uppercase tracking-[0.22em] text-neutral-600 ${labelColor}`}>{prize.rarityLabel}</p>
+        <h3 className="mt-2 text-lg font-semibold text-neutral-900">{prize.name}</h3>
+        <p className="mt-3 text-sm text-neutral-700">{prize.description}</p>
       </div>
-      <div className="mt-5 flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-400">
+      <div className="mt-5 flex items-center justify-between text-xs uppercase tracking-[0.18em] text-neutral-600">
         <span>Drop Rate</span>
-        <span className="text-sm font-semibold text-slate-100 normal-case tracking-normal">{dropRate}</span>
+        <span className={`text-sm font-semibold tracking-normal ${labelColor}`}>{dropRate}</span>
       </div>
     </div>
   );
@@ -971,25 +980,25 @@ const ScratchCardGame = ({ config = {}, onBack }) => {
 
   const statusText =
     cardState === 'idle'
-      ? 'Awaiting attempt'
+      ? 'Awaiting your turn'
       : cardState === 'preparing'
-      ? 'Forging foil card'
+      ? 'Shuffling prizes'
       : cardState === 'ready'
-      ? 'Foil armed & ready'
-      : 'Reward unveiled';
+      ? 'Ready to scratch'
+      : 'Prize revealed';
 
   const foilMessage =
     cardState === 'ready'
       ? normalisedConfig.scratchActionLabel
       : cardState === 'revealed'
-      ? 'Foil fully lifted'
-      : 'Claim a card to begin';
+      ? 'Foil cleared'
+      : 'Pick a card to begin';
 
   const foilMessageDetail =
     cardState === 'ready'
-      ? 'Drag to reveal the hidden reward.'
+      ? "Swipe to see what's underneath."
       : cardState === 'revealed'
-      ? 'Your prize awaits in full splendor.'
+      ? 'Your reward is ready.'
       : null;
 
   const showButtonProgress = cardState === 'preparing';
@@ -1000,7 +1009,7 @@ const ScratchCardGame = ({ config = {}, onBack }) => {
     }
 
     return {
-      backgroundImage: `linear-gradient(160deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.85)), url(${normalisedConfig.cardBackgroundImage})`,
+      backgroundImage: `linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(244, 241, 234, 0.85)), url(${normalisedConfig.cardBackgroundImage})`,
       backgroundSize: 'cover, 100% 100%',
       backgroundPosition: 'center, center',
     };
@@ -1050,8 +1059,8 @@ const ScratchCardGame = ({ config = {}, onBack }) => {
     }
 
     const gradient = result
-      ? `linear-gradient(135deg, ${result.prize.foilColor}, rgba(15, 23, 42, 0.92))`
-      : 'linear-gradient(135deg, rgba(148, 163, 184, 0.35), rgba(51, 65, 85, 0.92))';
+      ? `linear-gradient(135deg, ${result.prize.foilColor}, rgba(255, 255, 255, 0.9))`
+      : 'linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(244, 241, 234, 0.9))';
 
     backgrounds.push(gradient);
     sizes.push('100% 100%');
@@ -1079,36 +1088,43 @@ const ScratchCardGame = ({ config = {}, onBack }) => {
     <div
       className="scratch-module-root"
       style={{
-        backgroundImage: `linear-gradient(120deg, rgba(15, 23, 42, 0.82), rgba(30, 41, 59, 0.88)), url(${normalisedConfig.backgroundImage})`,
+        backgroundImage: normalisedConfig.backgroundImage
+          ? `linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(244, 241, 234, 0.85)), url(${normalisedConfig.backgroundImage})`
+          : undefined,
       }}
     >
       <div className="scratch-module-surface">
-        <div className="rounded-3xl border border-slate-800/60 bg-slate-950/60 p-6 shadow-[0_30px_70px_rgba(15,23,42,0.45)] backdrop-blur sm:p-7">
-          <div className="flex flex-col gap-5 sm:gap-6">
+        <div className="rounded-[32px] border-[3px] border-neutral-900 bg-[#fceecf] p-6 shadow-[0_12px_0_rgba(17,24,39,0.12)] sm:p-8">
+          <div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
             <div>
-              <p className="text-[0.68rem] uppercase tracking-[0.35em] text-indigo-200/70 sm:text-xs">{normalisedConfig.tagline}</p>
-              <h1 className="mt-3 text-3xl font-semibold text-white sm:text-4xl">{normalisedConfig.title}</h1>
-              <p className="mt-4 text-sm text-slate-300 sm:text-base">{normalisedConfig.description}</p>
+              <p className="text-[0.68rem] uppercase tracking-[0.28em] text-neutral-600 sm:text-xs">{normalisedConfig.tagline}</p>
+              <h1
+                className="mt-2 text-3xl font-semibold text-neutral-900 sm:text-4xl"
+                style={{ fontFamily: '"Source Serif 4", "Georgia", "Times New Roman", serif' }}
+              >
+                {normalisedConfig.title}
+              </h1>
+              <p className="mt-4 max-w-xl text-sm text-neutral-700 sm:text-base">{normalisedConfig.description}</p>
             </div>
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex w-full flex-col gap-3 sm:w-auto sm:items-end">
               <button
                 type="button"
                 onClick={handleAttempt}
                 disabled={buttonDisabled}
-                className="flex w-full items-center justify-center rounded-full bg-gradient-to-r from-fuchsia-500 via-indigo-500 to-sky-500 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-indigo-900/40 transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto sm:px-6"
+                className="flex w-full items-center justify-center rounded-full border-[3px] border-neutral-900 bg-[#fee79b] px-6 py-2.5 text-sm font-semibold text-neutral-900 shadow-[0_6px_0_rgba(17,24,39,0.2)] transition hover:-translate-y-0.5 hover:shadow-[0_9px_0_rgba(17,24,39,0.2)] disabled:translate-y-0 disabled:opacity-60 disabled:shadow-[0_6px_0_rgba(17,24,39,0.12)] sm:w-auto"
               >
                 {buttonLabel}
               </button>
               {showButtonProgress ? (
-                <span className="text-xs uppercase tracking-[0.3em] text-indigo-200/70">Forging your foil…</span>
+                <span className="text-xs uppercase tracking-[0.26em] text-neutral-600">Preparing your card…</span>
               ) : cardState === 'ready' ? (
-                <span className="text-xs uppercase tracking-[0.3em] text-indigo-200/70">Foil armed &amp; ready</span>
+                <span className="text-xs uppercase tracking-[0.26em] text-neutral-600">Ready to scratch</span>
               ) : null}
             </div>
           </div>
         </div>
 
-        <div className="scratch-card-stage rounded-3xl border border-indigo-500/30 bg-gradient-to-br from-indigo-950/70 via-slate-950/60 to-fuchsia-900/40 p-5 shadow-[0_35px_80px_rgba(59,7,100,0.45)] sm:p-8">
+        <div className="scratch-card-stage rounded-[32px] border-[3px] border-neutral-900 bg-[#f6f1e1] p-5 shadow-[0_14px_0_rgba(17,24,39,0.12)] sm:p-8">
           <div className="scratch-card-container w-full">
             <div className={cardClassName}>
               <div className="scratch-card__inner" ref={surfaceRef} style={innerStyle}>
@@ -1175,24 +1191,24 @@ const ScratchCardGame = ({ config = {}, onBack }) => {
           </div>
         </div>
 
-        <div className="rounded-3xl border border-slate-800/60 bg-slate-950/60 p-6 shadow-[0_30px_70px_rgba(15,23,42,0.45)] backdrop-blur sm:p-7">
+        <div className="rounded-[32px] border-[3px] border-neutral-900 bg-white p-6 shadow-[0_12px_0_rgba(17,24,39,0.12)] sm:p-8">
           <div className="flex flex-col items-start justify-between gap-3 text-center sm:flex-row sm:items-center sm:text-left">
             <div>
-              <h2 className="text-lg font-semibold text-white sm:text-xl">{normalisedConfig.prizeLedgerTitle}</h2>
+              <h2 className="text-lg font-semibold text-neutral-900 sm:text-xl">{normalisedConfig.prizeLedgerTitle}</h2>
               {normalisedConfig.prizeLedgerSubtitle ? (
-                <p className="mt-1 text-sm text-slate-400">{normalisedConfig.prizeLedgerSubtitle}</p>
+                <p className="mt-1 text-sm text-neutral-600">{normalisedConfig.prizeLedgerSubtitle}</p>
               ) : null}
             </div>
             {normalisedConfig.prizeLedgerBadgeLabel ? (
-              <span className="rounded-full border border-indigo-400/30 px-3 py-1 text-xs uppercase tracking-[0.3em] text-indigo-200/70">
+              <span className="rounded-full border-[3px] border-neutral-900 bg-[#dbe6ff] px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-neutral-900">
                 {normalisedConfig.prizeLedgerBadgeLabel}
               </span>
             ) : null}
           </div>
           {loadingPrizes ? (
-            <p className="mt-4 text-sm text-slate-400">{normalisedConfig.prizeListLoadingText}</p>
+            <p className="mt-4 text-sm text-neutral-600">{normalisedConfig.prizeListLoadingText}</p>
           ) : prizeError ? (
-            <p className="mt-4 text-sm text-rose-300">{prizeError}</p>
+            <p className="mt-4 text-sm text-rose-600">{prizeError}</p>
           ) : (
             <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
               {prizes.map((prize) => (
@@ -1206,14 +1222,14 @@ const ScratchCardGame = ({ config = {}, onBack }) => {
           <button
             type="button"
             onClick={onBack}
-            className="w-full rounded-full border border-slate-600 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-400 hover:text-white sm:w-auto"
+            className="w-full rounded-full border-[3px] border-neutral-900 bg-white px-5 py-2.5 text-sm font-semibold text-neutral-900 shadow-[0_6px_0_rgba(17,24,39,0.12)] transition hover:-translate-y-0.5 hover:shadow-[0_9px_0_rgba(17,24,39,0.12)] sm:w-auto"
           >
             Back to Store
           </button>
           {cardState === 'revealed' ? (
             <button
               type="button"
-              className="w-full rounded-full bg-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400 sm:w-auto"
+              className="w-full rounded-full border-[3px] border-neutral-900 bg-[#a5d8ff] px-6 py-2.5 text-sm font-semibold text-neutral-900 shadow-[0_6px_0_rgba(17,24,39,0.12)] transition hover:-translate-y-0.5 hover:shadow-[0_9px_0_rgba(17,24,39,0.12)] sm:w-auto"
               onClick={handleAttempt}
             >
               {normalisedConfig.playAgainLabel}
@@ -1223,30 +1239,34 @@ const ScratchCardGame = ({ config = {}, onBack }) => {
       </div>
 
       {showResultModal && result ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4 py-10 backdrop-blur">
-          <div className="w-full max-w-lg rounded-3xl border border-indigo-400/40 bg-slate-900/90 p-6 text-center shadow-2xl shadow-indigo-900/50 sm:p-8">
-            <p className="text-xs uppercase tracking-[0.25em] text-indigo-300 sm:text-sm">{normalisedConfig.resultModalTitle}</p>
-            <h3 className="mt-2 text-2xl font-semibold text-white sm:text-3xl">{result.prize.name}</h3>
-            <p className="mt-1 text-sm text-slate-400">{result.prize.rarityLabel}</p>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-10">
+          <div className="w-full max-w-lg rounded-[32px] border-[3px] border-neutral-900 bg-white p-6 text-center shadow-[0_20px_0_rgba(17,24,39,0.18)] sm:p-8">
+            <p className="text-xs uppercase tracking-[0.22em] text-neutral-600 sm:text-sm">{normalisedConfig.resultModalTitle}</p>
+            <h3
+              className="mt-2 text-2xl font-semibold text-neutral-900 sm:text-3xl"
+              style={{ fontFamily: '"Source Serif 4", "Georgia", "Times New Roman", serif' }}
+            >
+              {result.prize.name}
+            </h3>
+            <p className="mt-1 text-sm font-semibold uppercase tracking-[0.22em] text-neutral-600">{result.prize.rarityLabel}</p>
             <div className="mt-5 flex items-center justify-center">
-              <div
-                className="h-28 w-44 rounded-2xl border border-indigo-400/30 bg-gradient-to-br from-slate-700 via-indigo-500/60 to-slate-900 shadow-[0_18px_40px_rgba(79,70,229,0.35)]"
-                style={{ boxShadow: `0 18px 40px ${result.prize.glowColor}` }}
-              >
+              <div className="h-28 w-44 rounded-[24px] border-[3px] border-neutral-900 bg-[#f6f1e1] shadow-[0_10px_0_rgba(17,24,39,0.12)]">
                 <div
-                  className="h-full w-full rounded-2xl"
+                  className="h-full w-full rounded-[20px]"
                   style={{
-                    background: `linear-gradient(135deg, ${result.prize.foilColor}, rgba(15, 23, 42, 0.92))`,
+                    background: result.prize.foilColor
+                      ? `linear-gradient(135deg, ${result.prize.foilColor}, rgba(255, 255, 255, 0.85))`
+                      : 'linear-gradient(135deg, #ffffff, #f4f1ea)',
                   }}
                 />
               </div>
             </div>
-            <p className="mt-6 text-sm text-slate-300">{result.prize.description}</p>
-            <p className="mt-4 text-sm text-indigo-200">{result.flairText ?? normalisedConfig.defaultFlairText}</p>
+            <p className="mt-6 text-sm text-neutral-700">{result.prize.description}</p>
+            <p className="mt-4 text-sm font-semibold text-neutral-900">{result.flairText ?? normalisedConfig.defaultFlairText}</p>
             <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-end">
               <button
                 type="button"
-                className="w-full rounded-full border border-slate-600 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-400 hover:text-white sm:w-auto"
+                className="w-full rounded-full border-[3px] border-neutral-900 bg-white px-5 py-2.5 text-sm font-semibold text-neutral-900 shadow-[0_6px_0_rgba(17,24,39,0.12)] transition hover:-translate-y-0.5 hover:shadow-[0_9px_0_rgba(17,24,39,0.12)] sm:w-auto"
                 onClick={() => {
                   closeModal();
                   handleAttempt();
@@ -1256,7 +1276,7 @@ const ScratchCardGame = ({ config = {}, onBack }) => {
               </button>
               <button
                 type="button"
-                className="w-full rounded-full bg-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400 sm:w-auto"
+                className="w-full rounded-full border-[3px] border-neutral-900 bg-[#fee79b] px-6 py-2.5 text-sm font-semibold text-neutral-900 shadow-[0_6px_0_rgba(17,24,39,0.12)] transition hover:-translate-y-0.5 hover:shadow-[0_9px_0_rgba(17,24,39,0.12)] sm:w-auto"
                 onClick={() => {
                   closeModal();
                   onBack?.();

--- a/src/games/scratch-card-game/scratch-card-game.css
+++ b/src/games/scratch-card-game/scratch-card-game.css
@@ -1,63 +1,45 @@
+@import url('https://fonts.googleapis.com/css2?family=Source+Serif+4:wght@500;600&display=swap');
 
 .scratch-card-stage {
-  perspective: 1200px;
   position: relative;
+  width: 100%;
 }
 
 .scratch-card-container {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 28px;
+  gap: 24px;
 }
 
 .scratch-card {
   position: relative;
-  width: 320px;
-  height: 220px;
+  width: clamp(280px, 80vw, 360px);
+  min-height: 240px;
   border-radius: 28px;
-  padding: 16px;
-  background: linear-gradient(150deg, rgba(79, 70, 229, 0.32), rgba(236, 72, 153, 0.28));
-  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.6);
-  transform-style: preserve-3d;
-  transition: transform 0.35s ease, box-shadow 0.35s ease;
+  padding: 20px;
+  background: #cddffb;
+  border: 3px solid #111827;
+  box-shadow: 0 12px 0 rgba(17, 24, 39, 0.12);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .scratch-card::before {
   content: '';
   position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: linear-gradient(120deg, rgba(255, 255, 255, 0.18), rgba(125, 211, 252, 0));
-  mix-blend-mode: screen;
+  inset: 12px;
+  border-radius: 20px;
+  border: 1px dashed rgba(17, 24, 39, 0.1);
   pointer-events: none;
 }
 
 .scratch-card--scratching {
-  animation: scratch-card-wiggle 0.18s ease-in-out infinite;
+  transform: translateY(-4px);
 }
 
 .scratch-card--revealed {
-  transform: translateY(-4px) scale(1.03);
-  box-shadow: 0 36px 80px rgba(129, 140, 248, 0.5);
-}
-
-@keyframes scratch-card-wiggle {
-  0% {
-    transform: rotate(0deg) translate3d(0, 0, 0);
-  }
-  25% {
-    transform: rotate(-1.6deg) translate3d(-5px, 2px, 0);
-  }
-  50% {
-    transform: rotate(1.6deg) translate3d(4px, -3px, 0);
-  }
-  75% {
-    transform: rotate(-1.2deg) translate3d(-3px, -2px, 0);
-  }
-  100% {
-    transform: rotate(0deg) translate3d(0, 0, 0);
-  }
+  transform: translateY(-6px);
+  box-shadow: 0 16px 0 rgba(17, 24, 39, 0.16);
 }
 
 .scratch-card__inner {
@@ -66,45 +48,34 @@
   height: 100%;
   border-radius: 22px;
   overflow: hidden;
-  background: linear-gradient(160deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.85));
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+  background: #fdfaf3;
+  border: 2px solid #111827;
+  box-shadow: inset 0 -8px 0 rgba(17, 24, 39, 0.06);
 }
 
 .scratch-card__reward {
   position: absolute;
-  inset: 12px;
+  inset: 14px;
   border-radius: 18px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   text-align: center;
-  color: #e2e8f0;
-  padding: 24px;
-  background: linear-gradient(135deg, rgba(148, 163, 184, 0.35), rgba(51, 65, 85, 0.92));
-  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.5);
-  opacity: 0.4;
-  transform: scale(0.96);
-  transition: opacity 0.45s ease, transform 0.45s ease, box-shadow 0.45s ease;
+  color: #111827;
+  padding: 28px;
+  background: #ffffff;
+  border: 2px solid #111827;
+  box-shadow: 0 10px 0 rgba(17, 24, 39, 0.1);
+  transition: transform 0.25s ease;
 }
 
 .scratch-card--revealed .scratch-card__reward {
-  opacity: 1;
-  transform: scale(1);
+  transform: translateY(-4px);
 }
 
 .scratch-card__reward-glow {
-  position: absolute;
-  inset: -35%;
-  border-radius: inherit;
-  background: radial-gradient(circle, rgba(129, 140, 248, 0.45) 0%, rgba(15, 23, 42, 0) 75%);
-  filter: blur(26px);
-  opacity: 0;
-  transition: opacity 0.45s ease;
-}
-
-.scratch-card--revealed .scratch-card__reward-glow {
-  opacity: 1;
+  display: none;
 }
 
 .scratch-card__reward-content {
@@ -116,41 +87,51 @@
 }
 
 .scratch-card__reward-rarity {
-  font-size: 0.74rem;
-  letter-spacing: 0.32em;
+  font-size: 0.8rem;
+  letter-spacing: 0.26em;
   text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.7);
+  color: rgba(17, 24, 39, 0.64);
 }
 
 .scratch-card__reward-name {
-  font-size: 1.25rem;
+  font-family: 'Source Serif 4', 'Georgia', 'Times New Roman', serif;
+  font-size: 1.5rem;
   font-weight: 600;
-  letter-spacing: 0.06em;
-  color: #f8fafc;
+  letter-spacing: 0.01em;
+  color: #111827;
 }
 
 .scratch-card__reward-helper {
-  font-size: 0.75rem;
-  letter-spacing: 0.22em;
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.55);
+  color: rgba(17, 24, 39, 0.56);
 }
 
 .scratch-card__foil {
   position: absolute;
-  inset: 12px;
+  inset: 16px;
   border-radius: 18px;
   overflow: hidden;
-  transition: opacity 0.45s ease, transform 0.45s ease;
+  border: 2px dashed rgba(17, 24, 39, 0.28);
+  background: repeating-linear-gradient(
+      45deg,
+      rgba(17, 24, 39, 0.08) 0,
+      rgba(17, 24, 39, 0.08) 10px,
+      rgba(255, 255, 255, 0.4) 10px,
+      rgba(255, 255, 255, 0.4) 20px
+    ),
+    #f0efe6;
+  transition: opacity 0.35s ease, transform 0.35s ease;
 }
 
 .scratch-card__foil--interactive {
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  cursor: pointer;
 }
 
 .scratch-card__foil--cleared {
   opacity: 0;
-  transform: scale(1.03);
+  transform: scale(1.02);
   pointer-events: none;
 }
 
@@ -160,64 +141,45 @@
   width: 100%;
   height: 100%;
   border-radius: inherit;
-  cursor: crosshair;
+  cursor: pointer;
   touch-action: none;
-  transition: opacity 0.4s ease;
+  transition: opacity 0.3s ease;
 }
 
-.scratch-card__foil-canvas--inactive {
-  opacity: 0;
-  pointer-events: none;
-}
-
+.scratch-card__foil-canvas--inactive,
 .scratch-card__foil-canvas--cleared {
   opacity: 0;
   pointer-events: none;
 }
 
 .scratch-card__foil-noise {
-  position: absolute;
-  inset: -25%;
-  background: conic-gradient(
-    from 0deg,
-    rgba(255, 255, 255, 0.22),
-    rgba(79, 70, 229, 0.25),
-    rgba(236, 72, 153, 0.22),
-    rgba(255, 255, 255, 0.22)
-  );
-  mix-blend-mode: screen;
-  opacity: 0.55;
-  animation: scratch-card-foil-spin 7s linear infinite;
-  pointer-events: none;
+  display: none;
 }
 
 .scratch-card__foil-shine {
-  position: absolute;
-  inset: -35%;
-  background: radial-gradient(circle at 20% -10%, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0));
-  opacity: 0.7;
-  animation: scratch-card-foil-shimmer 4.5s ease-in-out infinite;
-  pointer-events: none;
+  display: none;
 }
 
 .scratch-card__foil-message {
   position: absolute;
-  inset: 0;
+  bottom: 18px;
+  left: 20px;
+  right: 20px;
+  border-radius: 16px;
+  padding: 10px 18px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.26em;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 0 24px;
-  text-align: center;
-  text-transform: uppercase;
-  letter-spacing: 0.32em;
-  font-size: 0.7rem;
-  color: rgba(226, 232, 240, 0.85);
-  backdrop-filter: blur(0px);
+  gap: 4px;
+  color: #111827;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(17, 24, 39, 0.16);
   opacity: 0;
-  transform: translateY(8px);
-  transition: opacity 0.4s ease, transform 0.4s ease;
+  transform: translateY(12px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
   pointer-events: none;
 }
 
@@ -227,30 +189,9 @@
 }
 
 .scratch-card__foil-detail {
-  font-size: 0.66rem;
-  letter-spacing: 0.25em;
-  color: rgba(226, 232, 240, 0.6);
-}
-
-@keyframes scratch-card-foil-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@keyframes scratch-card-foil-shimmer {
-  0%,
-  100% {
-    opacity: 0.65;
-    transform: translateX(-10%);
-  }
-  50% {
-    opacity: 0.85;
-    transform: translateX(10%);
-  }
+  font-size: 0.64rem;
+  letter-spacing: 0.16em;
+  color: rgba(17, 24, 39, 0.6);
 }
 
 .scratch-card__status-panel {
@@ -259,26 +200,30 @@
   align-items: center;
   gap: 16px;
   text-align: center;
+  padding: 18px 28px;
+  border-radius: 24px;
+  background: #ffffff;
+  border: 2px solid #111827;
+  box-shadow: 0 12px 0 rgba(17, 24, 39, 0.12);
 }
 
 .scratch-card__status-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 10px 22px;
+  padding: 6px 22px;
   border-radius: 999px;
-  border: 1px solid rgba(129, 140, 248, 0.45);
-  background: linear-gradient(120deg, rgba(30, 41, 59, 0.9), rgba(99, 102, 241, 0.2));
-  font-size: 0.7rem;
-  letter-spacing: 0.28em;
+  border: 1px solid #111827;
+  background: #fee79b;
+  font-size: 0.72rem;
+  letter-spacing: 0.26em;
   text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.78);
-  backdrop-filter: blur(10px);
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.35);
+  color: #111827;
 }
 
 .scratch-card__progress {
-  width: 220px;
+  width: 100%;
+  max-width: 280px;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -289,53 +234,60 @@
   width: 100%;
   height: 8px;
   border-radius: 999px;
-  background: rgba(30, 41, 59, 0.9);
-  border: 1px solid rgba(129, 140, 248, 0.3);
+  background: rgba(17, 24, 39, 0.08);
+  border: 1px solid rgba(17, 24, 39, 0.12);
   overflow: hidden;
 }
 
 .scratch-card__progress-fill {
   height: 100%;
-  background: linear-gradient(90deg, #ec4899, #6366f1, #38bdf8);
+  background: #111827;
   border-radius: inherit;
   transition: width 0.3s ease;
 }
 
 .scratch-card__progress-label {
-  font-size: 0.65rem;
+  font-size: 0.78rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.65);
+  color: rgba(17, 24, 39, 0.7);
 }
 
 .scratch-card__status-detail {
-  font-size: 0.85rem;
-  color: rgba(244, 211, 255, 0.8);
-  letter-spacing: 0.05em;
+  font-size: 0.88rem;
+  color: rgba(17, 24, 39, 0.82);
+  letter-spacing: 0.03em;
 }
 
 .scratch-card__status-detail span {
-  color: #f472b6;
-  font-weight: 600;
+  color: #111827;
+  font-weight: 700;
 }
 
 .scratch-card-error {
   padding: 10px 16px;
   border-radius: 14px;
-  border: 1px solid rgba(248, 113, 113, 0.5);
+  border: 1px solid rgba(248, 113, 113, 0.35);
   background: rgba(248, 113, 113, 0.12);
-  color: #fecdd3;
+  color: #b91c1c;
   font-size: 0.85rem;
   line-height: 1.4;
+  text-align: center;
 }
 
 @media (max-width: 640px) {
-  .scratch-card {
+  .scratch-card-container {
     width: 100%;
-    max-width: 320px;
+    gap: 22px;
   }
 
-  .scratch-card__progress {
+  .scratch-card {
     width: 100%;
+    max-width: 360px;
+  }
+
+  .scratch-card__status-panel {
+    width: 100%;
+    max-width: 360px;
   }
 }


### PR DESCRIPTION
## Summary
- restyle the scratch card module with a light newspaper-inspired palette, new typography, and simplified foil cues
- refresh prize ledger cards, status badges, and result modal to match the updated aesthetic
- align the standalone scratch card game styles with the new visual language

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e4cfc174f4832ab37cb4a3d161490c