### PR TITLE
Refresh gachapon UI with modern pastel styling

### DIFF
--- a/src/game_modules/gachapon-module/gachapon.css
+++ b/src/game_modules/gachapon-module/gachapon.css
@@ -1,24 +1,46 @@
 .gachapon-stage {
-  perspective: none;
-  background: repeating-linear-gradient(135deg, #66d86f 0 12px, #5fc965 12px 24px);
-  border: 4px solid #2f6b3a;
-  border-radius: 18px;
-  box-shadow: inset 0 0 0 3px #b7f4b8, 0 18px 0 rgba(35, 92, 49, 0.45);
-  padding: clamp(1.5rem, 4vw, 2rem);
-  image-rendering: pixelated;
+  position: relative;
+  perspective: 1400px;
+  background: linear-gradient(155deg, rgba(252, 250, 255, 0.95) 0%, rgba(239, 246, 255, 0.95) 55%, rgba(255, 239, 250, 0.95) 100%);
+  border: 1px solid rgba(129, 124, 255, 0.32);
+  border-radius: 2.75rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.75), 0 32px 60px rgba(127, 114, 255, 0.22);
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  overflow: hidden;
+}
+
+.gachapon-stage::before,
+.gachapon-stage::after {
+  content: '';
+  position: absolute;
+  border-radius: 9999px;
+  pointer-events: none;
+  filter: blur(0);
+}
+
+.gachapon-stage::before {
+  inset: auto 8% -35% -18%;
+  height: clamp(9rem, 32vw, 12rem);
+  background: radial-gradient(circle at center, rgba(124, 193, 255, 0.45) 0%, rgba(124, 193, 255, 0.05) 70%, transparent 100%);
+}
+
+.gachapon-stage::after {
+  inset: -25% -18% auto auto;
+  width: clamp(8rem, 30vw, 11rem);
+  height: clamp(8rem, 30vw, 11rem);
+  background: radial-gradient(circle at center, rgba(255, 159, 213, 0.4) 0%, rgba(255, 159, 213, 0.08) 68%, transparent 100%);
 }
 
 .gachapon-box {
   position: relative;
-  width: clamp(210px, 70vw, 240px);
-  height: clamp(220px, 76vw, 260px);
-  border-radius: 14px;
-  background: linear-gradient(180deg, #f9b05f 0 58%, #eb5b8b 58% 100%);
-  border: 4px solid #35153d;
-  box-shadow: 0 12px 0 #1f0b25, 0 20px 32px rgba(31, 11, 37, 0.45);
+  width: clamp(210px, 70vw, 250px);
+  height: clamp(220px, 76vw, 270px);
+  border-radius: 2.25rem;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(246, 240, 255, 0.95) 55%, rgba(255, 226, 246, 0.95) 100%);
+  border: 2px solid rgba(136, 124, 255, 0.35);
+  box-shadow: 0 24px 45px rgba(124, 105, 255, 0.2), 0 8px 18px rgba(255, 255, 255, 0.8) inset;
   overflow: hidden;
   transition: transform 0.2s ease, opacity 0.2s ease;
-  image-rendering: pixelated;
 }
 
 .gachapon-box::before,
@@ -30,14 +52,15 @@
 }
 
 .gachapon-box::before {
-  background: repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.12) 0 6px, transparent 6px 12px);
-  mix-blend-mode: lighten;
+  background: linear-gradient(130deg, rgba(255, 255, 255, 0.75) 0%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0) 80%);
+  opacity: 0.9;
 }
 
 .gachapon-box::after {
-  inset: 14px;
-  border-radius: 6px;
-  border: 2px solid rgba(255, 236, 214, 0.7);
+  inset: 18px;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  box-shadow: 0 1px 12px rgba(124, 105, 255, 0.12) inset;
 }
 
 .gachapon-box--shake {
@@ -69,27 +92,26 @@
 
 .gachapon-explosion {
   position: absolute;
-  width: clamp(96px, 38vw, 120px);
-  height: clamp(96px, 38vw, 120px);
-  border-radius: 4px;
-  background: radial-gradient(circle, #ffe066 0 38%, #ff9b4b 38% 68%, rgba(0, 0, 0, 0) 70%);
-  animation: gachapon-explosion-burst 0.5s steps(6) forwards;
+  width: clamp(96px, 38vw, 128px);
+  height: clamp(96px, 38vw, 128px);
+  border-radius: 32% 68% 52% 48%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.85) 0%, rgba(255, 226, 246, 0.7) 40%, rgba(127, 114, 255, 0.45) 70%, transparent 100%);
+  animation: gachapon-explosion-burst 0.55s ease-out forwards;
   pointer-events: none;
-  filter: contrast(1.1) saturate(1.15);
-  image-rendering: pixelated;
+  filter: drop-shadow(0 18px 25px rgba(124, 105, 255, 0.35));
 }
 
 @keyframes gachapon-explosion-burst {
   0% {
     transform: scale(0.4);
-    opacity: 0.9;
+    opacity: 0.8;
   }
   60% {
-    transform: scale(1.8);
+    transform: scale(1.9);
     opacity: 1;
   }
   100% {
-    transform: scale(3.2);
+    transform: scale(3.1);
     opacity: 0;
   }
 }
@@ -99,26 +121,25 @@
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
-  width: clamp(96px, 36vw, 120px);
-  height: clamp(96px, 36vw, 120px);
+  width: clamp(96px, 36vw, 128px);
+  height: clamp(96px, 36vw, 128px);
   border-radius: 48% 48% 60% 60%;
-  border: 4px solid #35153d;
-  background: linear-gradient(180deg, #56d0c5 0 48%, #fbe8a6 48% 100%);
-  box-shadow: 0 8px 0 #1f0b25, 0 14px 22px rgba(31, 11, 37, 0.35);
+  border: 2px solid rgba(136, 124, 255, 0.35);
+  background: linear-gradient(185deg, rgba(132, 214, 255, 0.95) 0%, rgba(255, 225, 246, 0.95) 60%, rgba(255, 246, 255, 0.95) 100%);
+  box-shadow: 0 18px 40px rgba(124, 105, 255, 0.28);
   transition: transform 0.4s ease, opacity 0.4s ease;
-  image-rendering: pixelated;
 }
 
 .gachapon-capsule::before {
   content: '';
   position: absolute;
-  top: 16%;
-  left: 16%;
+  top: 18%;
+  left: 18%;
   width: 28%;
   height: 24%;
-  background: rgba(255, 255, 255, 0.65);
-  border-radius: 3px;
-  box-shadow: 6px 6px 0 rgba(255, 255, 255, 0.25);
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.45));
+  border-radius: 10px;
+  box-shadow: 10px 10px 18px rgba(255, 255, 255, 0.45);
 }
 
 .gachapon-capsule--hidden {
@@ -128,25 +149,24 @@
 
 .gachapon-capsule-display {
   position: relative;
-  width: clamp(92px, 35vw, 112px);
-  height: clamp(92px, 35vw, 112px);
+  width: clamp(92px, 35vw, 120px);
+  height: clamp(92px, 35vw, 120px);
   border-radius: 48% 48% 60% 60%;
-  border: 4px solid #35153d;
-  box-shadow: 0 8px 0 #1f0b25, 0 12px 24px rgba(31, 11, 37, 0.35);
+  border: 2px solid rgba(136, 124, 255, 0.35);
+  box-shadow: 0 18px 38px rgba(124, 105, 255, 0.22);
   overflow: hidden;
-  image-rendering: pixelated;
 }
 
 .gachapon-capsule-display::before {
   content: '';
   position: absolute;
-  top: 16%;
-  left: 16%;
+  top: 18%;
+  left: 18%;
   width: 28%;
   height: 24%;
-  background: rgba(255, 255, 255, 0.65);
-  border-radius: 3px;
-  box-shadow: 6px 6px 0 rgba(255, 255, 255, 0.25);
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.45));
+  border-radius: 10px;
+  box-shadow: 10px 10px 18px rgba(255, 255, 255, 0.45);
 }
 
 .gachapon-start-button {
@@ -154,28 +174,29 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: clamp(0.85rem, 3vw, 1.1rem) clamp(2rem, 6vw, 3rem);
-  border: 4px solid #35153d;
-  border-radius: 10px;
-  background: repeating-linear-gradient(180deg, #ffe066 0 6px, #ffd54f 6px 12px);
-  color: #35153d;
-  font-size: clamp(0.95rem, 3.6vw, 1.15rem);
+  padding: clamp(0.85rem, 3vw, 1.1rem) clamp(2.1rem, 6vw, 3.25rem);
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(120deg, #7e5bff 0%, #ff7fc8 50%, #ffc27d 100%);
+  color: #ffffff;
+  font-size: clamp(1rem, 3.6vw, 1.15rem);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   line-height: 1.1;
   cursor: pointer;
-  box-shadow: 0 8px 0 #1f0b25, 0 16px 24px rgba(31, 11, 37, 0.35);
-  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
-  image-rendering: pixelated;
+  box-shadow: 0 22px 36px rgba(130, 112, 255, 0.35);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
 }
 
 .gachapon-start-button::before {
   content: '';
   position: absolute;
-  inset: 4px;
-  border: 2px solid rgba(255, 236, 214, 0.7);
+  inset: 6px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.28), rgba(255, 255, 255, 0));
   pointer-events: none;
+  transition: opacity 0.18s ease;
 }
 
 .gachapon-start-button span {
@@ -184,27 +205,27 @@
 }
 
 .gachapon-start-button:hover:not(:disabled) {
-  transform: translateY(-2px);
-  box-shadow: 0 10px 0 #1f0b25, 0 18px 26px rgba(31, 11, 37, 0.4);
+  transform: translateY(-3px) scale(1.01);
+  box-shadow: 0 26px 44px rgba(124, 105, 255, 0.4);
   filter: brightness(1.05);
 }
 
 .gachapon-start-button:active:not(:disabled) {
-  transform: translateY(4px);
-  box-shadow: 0 4px 0 #1f0b25, 0 8px 16px rgba(31, 11, 37, 0.35);
+  transform: translateY(3px) scale(0.99);
+  box-shadow: 0 14px 28px rgba(124, 105, 255, 0.32);
 }
 
 .gachapon-start-button:disabled {
   cursor: not-allowed;
-  filter: saturate(0.6) brightness(0.9);
-  box-shadow: 0 6px 0 #1f0b25, 0 12px 18px rgba(31, 11, 37, 0.25);
+  filter: saturate(0.7) brightness(0.95);
+  box-shadow: 0 12px 22px rgba(148, 163, 184, 0.28);
 }
 
 .gachapon-start-button:disabled::before {
-  background: repeating-linear-gradient(180deg, rgba(255, 236, 214, 0.5) 0 6px, rgba(255, 236, 214, 0.2) 6px 12px);
+  opacity: 0.4;
 }
 
 .gachapon-start-button:focus-visible {
-  outline: 4px solid rgba(253, 224, 71, 0.7);
+  outline: 4px solid rgba(129, 124, 255, 0.35);
   outline-offset: 6px;
 }

--- a/src/game_modules/gachapon-module/gachapon.js
+++ b/src/game_modules/gachapon-module/gachapon.js
@@ -3,20 +3,60 @@ import { buildConfig, mergeDisplayPrizes, normaliseResult } from './config';
 import { retrieveLuckdrawPrizes } from '../luckdraw-prizes';
 import './gachapon.css';
 
-const rarityAccentClasses = {
-  common: 'border-slate-500 text-slate-200',
-  uncommon: 'border-emerald-300 text-emerald-200',
-  rare: 'border-sky-300 text-sky-200',
-  epic: 'border-violet-300 text-violet-200',
-  legendary: 'border-amber-200 text-amber-100',
+const defaultCardStyle = {
+  card: 'border-slate-200/80 bg-gradient-to-br from-white via-slate-50 to-white/70 text-slate-600 shadow-[0_20px_45px_rgba(148,163,184,0.2)]',
+  accentBlob: 'from-slate-200/60 via-white/50 to-transparent',
+  rarityBadge: 'bg-slate-200 text-slate-700',
+  dropBadge: 'bg-slate-100 text-slate-700',
+  title: 'text-slate-900',
+  body: 'text-slate-600',
+  accent: 'text-slate-500',
 };
 
-const rarityBackground = {
-  common: 'bg-slate-800/40',
-  uncommon: 'bg-emerald-500/10',
-  rare: 'bg-sky-500/10',
-  epic: 'bg-violet-500/10',
-  legendary: 'bg-amber-500/10',
+const rarityStyles = {
+  common: {
+    ...defaultCardStyle,
+  },
+  uncommon: {
+    ...defaultCardStyle,
+    card: 'border-emerald-200/70 bg-gradient-to-br from-white via-emerald-50 to-teal-50/70 text-emerald-700 shadow-[0_22px_45px_rgba(45,212,191,0.16)]',
+    accentBlob: 'from-emerald-200/60 via-teal-100/40 to-transparent',
+    rarityBadge: 'bg-emerald-200 text-emerald-800',
+    dropBadge: 'bg-emerald-100 text-emerald-700',
+    title: 'text-emerald-900',
+    body: 'text-emerald-600',
+    accent: 'text-emerald-500',
+  },
+  rare: {
+    ...defaultCardStyle,
+    card: 'border-sky-200/70 bg-gradient-to-br from-white via-sky-50 to-cyan-50/70 text-sky-700 shadow-[0_22px_45px_rgba(56,189,248,0.18)]',
+    accentBlob: 'from-sky-200/60 via-cyan-100/40 to-transparent',
+    rarityBadge: 'bg-sky-200 text-sky-800',
+    dropBadge: 'bg-sky-100 text-sky-700',
+    title: 'text-sky-900',
+    body: 'text-sky-600',
+    accent: 'text-sky-500',
+  },
+  epic: {
+    ...defaultCardStyle,
+    card: 'border-violet-200/70 bg-gradient-to-br from-white via-violet-50 to-fuchsia-50/70 text-violet-700 shadow-[0_22px_48px_rgba(167,139,250,0.22)]',
+    accentBlob: 'from-violet-200/60 via-fuchsia-100/40 to-transparent',
+    rarityBadge: 'bg-violet-200 text-violet-800',
+    dropBadge: 'bg-violet-100 text-violet-700',
+    title: 'text-violet-900',
+    body: 'text-violet-600',
+    accent: 'text-violet-500',
+  },
+  legendary: {
+    ...defaultCardStyle,
+    card: 'border-amber-200/70 bg-gradient-to-br from-white via-amber-50 to-orange-50/70 text-amber-700 shadow-[0_22px_48px_rgba(251,191,36,0.22)]',
+    accentBlob: 'from-amber-200/60 via-orange-100/40 to-transparent',
+    rarityBadge: 'bg-amber-200 text-amber-800',
+    dropBadge: 'bg-amber-100 text-amber-700',
+    title: 'text-amber-900',
+    body: 'text-amber-600',
+    accent: 'text-amber-500',
+  },
 };
 
 const mockPlay = (config) =>
@@ -79,22 +119,27 @@ const formatDropRate = (weight, totalWeight) => {
 };
 
 const PrizeCard = ({ prize, totalWeight }) => {
-  const accentClass = rarityAccentClasses[prize.rarity] ?? 'border-slate-500 text-slate-200';
-  const backgroundClass = rarityBackground[prize.rarity] ?? 'bg-slate-800/40';
+  const style = rarityStyles[prize.rarity] ?? defaultCardStyle;
   const dropRate = prize.probabilityLabel || formatDropRate(prize.weight ?? 0, totalWeight);
 
   return (
     <div
-      className={`flex h-full flex-col justify-between rounded-xl border ${accentClass} ${backgroundClass} p-4 shadow-lg shadow-slate-900/30`}
+      className={`relative flex h-full flex-col justify-between overflow-hidden rounded-3xl border p-6 transition-shadow duration-150 hover:shadow-[0_28px_48px_rgba(129,140,248,0.18)] ${style.card}`}
     >
-      <div>
-        <p className="text-sm uppercase tracking-wide text-slate-400">{prize.rarityLabel}</p>
-        <h3 className="mt-1 text-xl font-semibold text-white">{prize.name}</h3>
-        <p className="mt-2 text-sm text-slate-300">{prize.description}</p>
+      <div
+        className={`pointer-events-none absolute -right-14 top-12 h-28 w-28 rounded-full bg-gradient-to-br blur-3xl ${style.accentBlob}`}
+      />
+      <div className="pointer-events-none absolute -left-12 top-16 h-20 w-20 rounded-full bg-white/60 blur-3xl" />
+      <div className="flex flex-col gap-3">
+        <span className={`inline-flex w-max items-center rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${style.rarityBadge}`}>
+          {prize.rarityLabel}
+        </span>
+        <h3 className={`text-2xl font-semibold ${style.title}`}>{prize.name}</h3>
+        <p className={`text-sm leading-relaxed ${style.body}`}>{prize.description}</p>
       </div>
-      <div className="mt-4 flex items-center justify-between text-sm text-slate-400">
+      <div className={`mt-6 flex items-center justify-between text-[0.7rem] font-semibold uppercase tracking-[0.2em] ${style.accent}`}>
         <span>Drop Rate</span>
-        <span className="font-semibold text-slate-100">{dropRate}</span>
+        <span className={`rounded-full px-3 py-1 text-sm font-semibold tracking-normal ${style.dropBadge}`}>{dropRate}</span>
       </div>
     </div>
   );
@@ -254,32 +299,32 @@ const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
   const capsuleColor = result?.prize?.capsuleColor ?? config.defaultCapsuleColor;
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-slate-950 py-10 text-white sm:py-12">
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-[#f6f5ff] via-[#fff5f8] to-[#f1fbff] py-10 text-slate-700 sm:py-12">
       <div className="pointer-events-none absolute inset-0">
-        <div className="absolute -top-16 left-16 h-60 w-60 rounded-full bg-indigo-500/25 blur-3xl" />
-        <div className="absolute top-1/3 right-12 h-72 w-72 rounded-full bg-violet-500/20 blur-3xl" />
-        <div className="absolute bottom-0 left-1/4 h-72 w-72 rounded-full bg-fuchsia-500/15 blur-3xl" />
+        <div className="absolute -top-32 left-8 h-72 w-72 rounded-full bg-[radial-gradient(circle_at_center,_rgba(129,140,248,0.35),_rgba(129,140,248,0))] blur-3xl" />
+        <div className="absolute top-1/3 right-0 h-80 w-80 rounded-full bg-[radial-gradient(circle_at_center,_rgba(236,72,153,0.18),_rgba(236,72,153,0))] blur-3xl" />
+        <div className="absolute bottom-[-6rem] left-1/4 h-96 w-96 rounded-full bg-[radial-gradient(circle_at_center,_rgba(56,189,248,0.18),_rgba(56,189,248,0))] blur-3xl" />
       </div>
 
       <div className="relative mx-auto flex w-full max-w-5xl flex-col items-center px-4">
         <div className="text-center">
           {config.tagline ? (
-            <p className="text-xs uppercase tracking-[0.35em] text-indigo-300 sm:text-sm">{config.tagline}</p>
+            <p className="text-xs uppercase tracking-[0.35em] text-sky-500 sm:text-sm">{config.tagline}</p>
           ) : null}
-          <h1 className="mt-2 text-3xl font-semibold text-white sm:text-5xl">
+          <h1 className="mt-2 text-3xl font-semibold text-slate-900 sm:text-5xl">
             {config.title ?? 'Gachapon Game'}
           </h1>
           {config.description ? (
-            <p className="mt-4 max-w-2xl text-sm text-slate-300 sm:text-base">{config.description}</p>
+            <p className="mt-4 max-w-2xl text-sm text-slate-600 sm:text-base">{config.description}</p>
           ) : null}
         </div>
 
-        <div className="mt-10 w-full max-w-3xl overflow-hidden rounded-[2.5rem] border border-indigo-400/30 bg-slate-900/80 p-6 text-center shadow-2xl shadow-indigo-900/40 backdrop-blur sm:p-10">
+        <div className="mt-10 w-full max-w-3xl overflow-hidden rounded-[2.75rem] border border-white/70 bg-white/80 p-6 text-center shadow-[0_30px_70px_rgba(99,102,241,0.12)] backdrop-blur sm:p-10">
           <div className="flex flex-col items-center gap-6 sm:gap-8">
             {config.capsuleMachineLabel ? (
-              <p className="text-xs uppercase tracking-[0.35em] text-indigo-300 sm:text-sm">{config.capsuleMachineLabel}</p>
+              <p className="text-xs uppercase tracking-[0.35em] text-sky-500 sm:text-sm">{config.capsuleMachineLabel}</p>
             ) : null}
-            <div className="gachapon-stage relative flex h-[19rem] w-full max-w-md items-center justify-center rounded-[2rem] border border-indigo-400/30 bg-slate-950/70 p-6 shadow-[0_24px_45px_rgba(15,23,42,0.55)] sm:h-80 sm:p-8">
+            <div className="gachapon-stage relative flex h-[19rem] w-full max-w-md items-center justify-center rounded-[2.25rem] border border-transparent bg-white/80 p-6 shadow-[0_35px_60px_rgba(129,140,248,0.18)] sm:h-80 sm:p-8">
               <div className="relative flex h-full w-full flex-col items-center justify-center">
                 <div
                   className={`gachapon-box ${animationPhase === 'shaking' ? 'gachapon-box--shake' : ''} ${animationPhase === 'explosion' ? 'gachapon-box--hidden' : ''}`}
@@ -290,7 +335,7 @@ const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
                     }`}
                     style={{ background: capsuleColor }}
                   />
-                  <div className="absolute inset-x-5 bottom-5 rounded-full bg-slate-800/80 py-2.5 text-[0.65rem] uppercase tracking-[0.25em] text-slate-400 sm:inset-x-8 sm:bottom-6 sm:py-3 sm:text-xs sm:tracking-[0.3em]">
+                  <div className="absolute inset-x-5 bottom-5 rounded-full bg-white/80 py-2.5 text-[0.65rem] uppercase tracking-[0.25em] text-slate-500 sm:inset-x-8 sm:bottom-6 sm:py-3 sm:text-xs sm:tracking-[0.3em]">
                     {capsuleStatusLabel}
                   </div>
                 </div>
@@ -298,10 +343,10 @@ const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
               </div>
             </div>
             {config.capsuleDescription ? (
-              <p className="max-w-lg text-sm text-indigo-100/80">{config.capsuleDescription}</p>
+              <p className="max-w-lg text-sm text-slate-500">{config.capsuleDescription}</p>
             ) : null}
             {attemptError ? (
-              <p className="w-full rounded-2xl border border-rose-500/40 bg-rose-500/10 px-5 py-3 text-sm text-rose-200" role="status">
+              <p className="w-full rounded-2xl border border-rose-200 bg-rose-50 px-5 py-3 text-sm text-rose-700" role="status">
                 {attemptError}
               </p>
             ) : null}
@@ -320,7 +365,7 @@ const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
           {onBack ? (
             <button
               type="button"
-              className="w-full rounded-full border border-slate-700/70 px-6 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:text-white sm:w-auto"
+              className="w-full rounded-full border border-slate-300/80 px-6 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-800 sm:w-auto"
               onClick={onBack}
             >
               Back
@@ -328,23 +373,23 @@ const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
           ) : null}
         </div>
 
-        <div className="mt-12 w-full overflow-hidden rounded-[2.5rem] border border-slate-800/70 bg-slate-900/80 p-6 shadow-2xl shadow-indigo-900/30 backdrop-blur sm:p-8">
+        <div className="mt-12 w-full overflow-hidden rounded-[2.75rem] border border-white/70 bg-white/80 p-6 shadow-[0_30px_70px_rgba(148,163,184,0.18)] backdrop-blur sm:p-8">
           <div className="flex flex-col gap-5 sm:gap-6">
             <div className="flex flex-col items-center justify-between gap-3 text-center sm:flex-row sm:text-left">
               <div>
-                <h2 className="text-lg font-semibold text-white sm:text-xl">{config.prizeShowcaseTitle}</h2>
+                <h2 className="text-lg font-semibold text-slate-900 sm:text-xl">{config.prizeShowcaseTitle}</h2>
                 {config.prizeShowcaseDescription ? (
-                  <p className="mt-1 text-sm text-slate-400">{config.prizeShowcaseDescription}</p>
+                  <p className="mt-1 text-sm text-slate-500">{config.prizeShowcaseDescription}</p>
                 ) : null}
               </div>
-              <span className="rounded-full border border-slate-700/60 bg-slate-950/60 px-3 py-1 text-xs uppercase tracking-[0.3em] text-slate-300 sm:px-4">
+              <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs uppercase tracking-[0.3em] text-slate-500 sm:px-4">
                 {prizes.length} Rewards
               </span>
             </div>
             {loadingPrizes ? (
-              <p className="text-sm text-slate-400">{config.prizeListLoadingText}</p>
+              <p className="text-sm text-slate-500">{config.prizeListLoadingText}</p>
             ) : prizeError ? (
-              <p className="text-sm text-rose-300">{prizeError}</p>
+              <p className="text-sm text-rose-500">{prizeError}</p>
             ) : (
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 {prizes.map((prize) => (
@@ -353,27 +398,27 @@ const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
               </div>
             )}
             {includeProbability && !loadingPrizes && !prizeError ? (
-              <p className="text-xs text-slate-500">Probabilities shown are provided by the backend.</p>
+              <p className="text-xs text-slate-400">Probabilities shown are provided by the backend.</p>
             ) : null}
           </div>
         </div>
       </div>
 
       {showResultModal && result ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4 py-10 backdrop-blur">
-          <div className="w-full max-w-lg rounded-3xl border border-indigo-400/40 bg-slate-900/90 p-6 text-center shadow-2xl shadow-indigo-900/50 sm:p-8">
-            <p className="text-xs uppercase tracking-[0.25em] text-indigo-300 sm:text-sm">{config.resultModalTitle}</p>
-            <h3 className="mt-2 text-2xl font-semibold text-white sm:text-3xl">{result.prize.name}</h3>
-            <p className="mt-1 text-sm text-slate-400">{result.prize.rarityLabel}</p>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/20 px-4 py-10 backdrop-blur-md">
+          <div className="w-full max-w-lg rounded-3xl border border-white/70 bg-white/90 p-6 text-center shadow-[0_35px_70px_rgba(129,140,248,0.25)] sm:p-8">
+            <p className="text-xs uppercase tracking-[0.25em] text-sky-500 sm:text-sm">{config.resultModalTitle}</p>
+            <h3 className="mt-2 text-2xl font-semibold text-slate-900 sm:text-3xl">{result.prize.name}</h3>
+            <p className="mt-1 text-sm text-slate-500">{result.prize.rarityLabel}</p>
             <div className="mt-5 flex items-center justify-center">
               <div className="gachapon-capsule-display" style={{ background: result.prize.capsuleColor }} />
             </div>
-            <p className="mt-6 text-sm text-slate-300">{result.prize.description}</p>
-            <p className="mt-4 text-sm text-indigo-200">{result.flairText ?? config.defaultFlairText}</p>
+            <p className="mt-6 text-sm text-slate-600">{result.prize.description}</p>
+            <p className="mt-4 text-sm text-sky-600">{result.flairText ?? config.defaultFlairText}</p>
             <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-end">
               <button
                 type="button"
-                className="w-full rounded-full border border-slate-600 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-400 hover:text-white sm:w-auto"
+                className="w-full rounded-full border border-slate-300 px-5 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-800 sm:w-auto"
                 onClick={closeModal}
               >
                 {config.ctaLabel}
@@ -381,7 +426,7 @@ const GachaponGame = ({ config: rawConfig = {}, onBack }) => {
               {onBack ? (
                 <button
                   type="button"
-                  className="w-full rounded-full bg-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400 sm:w-auto"
+                  className="w-full rounded-full bg-gradient-to-r from-sky-500 to-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:brightness-110 sm:w-auto"
                   onClick={onBack}
                 >
                   Back

--- a/src/games/gachapon-game/gachapon-game.css
+++ b/src/games/gachapon-game/gachapon-game.css
@@ -1,24 +1,46 @@
 .gachapon-stage {
-  perspective: none;
-  background: repeating-linear-gradient(135deg, #66d86f 0 12px, #5fc965 12px 24px);
-  border: 4px solid #2f6b3a;
-  border-radius: 18px;
-  box-shadow: inset 0 0 0 3px #b7f4b8, 0 18px 0 rgba(35, 92, 49, 0.45);
-  padding: 1.75rem;
-  image-rendering: pixelated;
+  position: relative;
+  perspective: 1400px;
+  background: linear-gradient(155deg, rgba(252, 250, 255, 0.95) 0%, rgba(239, 246, 255, 0.95) 55%, rgba(255, 239, 250, 0.95) 100%);
+  border: 1px solid rgba(129, 124, 255, 0.32);
+  border-radius: 2.75rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.75), 0 32px 60px rgba(127, 114, 255, 0.22);
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  overflow: hidden;
+}
+
+.gachapon-stage::before,
+.gachapon-stage::after {
+  content: '';
+  position: absolute;
+  border-radius: 9999px;
+  pointer-events: none;
+  filter: blur(0);
+}
+
+.gachapon-stage::before {
+  inset: auto 8% -35% -18%;
+  height: clamp(9rem, 32vw, 12rem);
+  background: radial-gradient(circle at center, rgba(124, 193, 255, 0.45) 0%, rgba(124, 193, 255, 0.05) 70%, transparent 100%);
+}
+
+.gachapon-stage::after {
+  inset: -25% -18% auto auto;
+  width: clamp(8rem, 30vw, 11rem);
+  height: clamp(8rem, 30vw, 11rem);
+  background: radial-gradient(circle at center, rgba(255, 159, 213, 0.4) 0%, rgba(255, 159, 213, 0.08) 68%, transparent 100%);
 }
 
 .gachapon-box {
   position: relative;
-  width: 240px;
-  height: 260px;
-  border-radius: 14px;
-  background: linear-gradient(180deg, #f9b05f 0 58%, #eb5b8b 58% 100%);
-  border: 4px solid #35153d;
-  box-shadow: 0 12px 0 #1f0b25, 0 20px 32px rgba(31, 11, 37, 0.45);
+  width: clamp(210px, 70vw, 250px);
+  height: clamp(220px, 76vw, 270px);
+  border-radius: 2.25rem;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(246, 240, 255, 0.95) 55%, rgba(255, 226, 246, 0.95) 100%);
+  border: 2px solid rgba(136, 124, 255, 0.35);
+  box-shadow: 0 24px 45px rgba(124, 105, 255, 0.2), 0 8px 18px rgba(255, 255, 255, 0.8) inset;
   overflow: hidden;
   transition: transform 0.2s ease, opacity 0.2s ease;
-  image-rendering: pixelated;
 }
 
 .gachapon-box::before,
@@ -30,14 +52,15 @@
 }
 
 .gachapon-box::before {
-  background: repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.12) 0 6px, transparent 6px 12px);
-  mix-blend-mode: lighten;
+  background: linear-gradient(130deg, rgba(255, 255, 255, 0.75) 0%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0) 80%);
+  opacity: 0.9;
 }
 
 .gachapon-box::after {
-  inset: 14px;
-  border-radius: 6px;
-  border: 2px solid rgba(255, 236, 214, 0.7);
+  inset: 18px;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  box-shadow: 0 1px 12px rgba(124, 105, 255, 0.12) inset;
 }
 
 .gachapon-box--shake {
@@ -69,27 +92,26 @@
 
 .gachapon-explosion {
   position: absolute;
-  width: 120px;
-  height: 120px;
-  border-radius: 4px;
-  background: radial-gradient(circle, #ffe066 0 38%, #ff9b4b 38% 68%, rgba(0, 0, 0, 0) 70%);
-  animation: gachapon-explosion-burst 0.5s steps(6) forwards;
+  width: clamp(96px, 38vw, 128px);
+  height: clamp(96px, 38vw, 128px);
+  border-radius: 32% 68% 52% 48%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.85) 0%, rgba(255, 226, 246, 0.7) 40%, rgba(127, 114, 255, 0.45) 70%, transparent 100%);
+  animation: gachapon-explosion-burst 0.55s ease-out forwards;
   pointer-events: none;
-  filter: contrast(1.1) saturate(1.15);
-  image-rendering: pixelated;
+  filter: drop-shadow(0 18px 25px rgba(124, 105, 255, 0.35));
 }
 
 @keyframes gachapon-explosion-burst {
   0% {
     transform: scale(0.4);
-    opacity: 0.9;
+    opacity: 0.8;
   }
   60% {
-    transform: scale(1.8);
+    transform: scale(1.9);
     opacity: 1;
   }
   100% {
-    transform: scale(3.2);
+    transform: scale(3.1);
     opacity: 0;
   }
 }
@@ -99,26 +121,25 @@
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
-  width: 120px;
-  height: 120px;
+  width: clamp(96px, 36vw, 128px);
+  height: clamp(96px, 36vw, 128px);
   border-radius: 48% 48% 60% 60%;
-  border: 4px solid #35153d;
-  background: linear-gradient(180deg, #56d0c5 0 48%, #fbe8a6 48% 100%);
-  box-shadow: 0 8px 0 #1f0b25, 0 14px 22px rgba(31, 11, 37, 0.35);
+  border: 2px solid rgba(136, 124, 255, 0.35);
+  background: linear-gradient(185deg, rgba(132, 214, 255, 0.95) 0%, rgba(255, 225, 246, 0.95) 60%, rgba(255, 246, 255, 0.95) 100%);
+  box-shadow: 0 18px 40px rgba(124, 105, 255, 0.28);
   transition: transform 0.4s ease, opacity 0.4s ease;
-  image-rendering: pixelated;
 }
 
 .gachapon-capsule::before {
   content: '';
   position: absolute;
-  top: 16%;
-  left: 16%;
+  top: 18%;
+  left: 18%;
   width: 28%;
   height: 24%;
-  background: rgba(255, 255, 255, 0.65);
-  border-radius: 3px;
-  box-shadow: 6px 6px 0 rgba(255, 255, 255, 0.25);
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.45));
+  border-radius: 10px;
+  box-shadow: 10px 10px 18px rgba(255, 255, 255, 0.45);
 }
 
 .gachapon-capsule--hidden {
@@ -128,25 +149,24 @@
 
 .gachapon-capsule-display {
   position: relative;
-  width: 112px;
-  height: 112px;
+  width: clamp(92px, 35vw, 120px);
+  height: clamp(92px, 35vw, 120px);
   border-radius: 48% 48% 60% 60%;
-  border: 4px solid #35153d;
-  box-shadow: 0 8px 0 #1f0b25, 0 12px 24px rgba(31, 11, 37, 0.35);
+  border: 2px solid rgba(136, 124, 255, 0.35);
+  box-shadow: 0 18px 38px rgba(124, 105, 255, 0.22);
   overflow: hidden;
-  image-rendering: pixelated;
 }
 
 .gachapon-capsule-display::before {
   content: '';
   position: absolute;
-  top: 16%;
-  left: 16%;
+  top: 18%;
+  left: 18%;
   width: 28%;
   height: 24%;
-  background: rgba(255, 255, 255, 0.65);
-  border-radius: 3px;
-  box-shadow: 6px 6px 0 rgba(255, 255, 255, 0.25);
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.45));
+  border-radius: 10px;
+  box-shadow: 10px 10px 18px rgba(255, 255, 255, 0.45);
 }
 
 .gachapon-start-button {
@@ -154,28 +174,29 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 1rem 3rem;
-  border: 4px solid #35153d;
-  border-radius: 10px;
-  background: repeating-linear-gradient(180deg, #ffe066 0 6px, #ffd54f 6px 12px);
-  color: #35153d;
-  font-size: 1.15rem;
+  padding: clamp(0.85rem, 3vw, 1.1rem) clamp(2.1rem, 6vw, 3.25rem);
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(120deg, #7e5bff 0%, #ff7fc8 50%, #ffc27d 100%);
+  color: #ffffff;
+  font-size: clamp(1rem, 3.6vw, 1.15rem);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   line-height: 1.1;
   cursor: pointer;
-  box-shadow: 0 8px 0 #1f0b25, 0 16px 24px rgba(31, 11, 37, 0.35);
-  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
-  image-rendering: pixelated;
+  box-shadow: 0 22px 36px rgba(130, 112, 255, 0.35);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
 }
 
 .gachapon-start-button::before {
   content: '';
   position: absolute;
-  inset: 4px;
-  border: 2px solid rgba(255, 236, 214, 0.7);
+  inset: 6px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.28), rgba(255, 255, 255, 0));
   pointer-events: none;
+  transition: opacity 0.18s ease;
 }
 
 .gachapon-start-button span {
@@ -184,27 +205,27 @@
 }
 
 .gachapon-start-button:hover:not(:disabled) {
-  transform: translateY(-2px);
-  box-shadow: 0 10px 0 #1f0b25, 0 18px 26px rgba(31, 11, 37, 0.4);
+  transform: translateY(-3px) scale(1.01);
+  box-shadow: 0 26px 44px rgba(124, 105, 255, 0.4);
   filter: brightness(1.05);
 }
 
 .gachapon-start-button:active:not(:disabled) {
-  transform: translateY(4px);
-  box-shadow: 0 4px 0 #1f0b25, 0 8px 16px rgba(31, 11, 37, 0.35);
+  transform: translateY(3px) scale(0.99);
+  box-shadow: 0 14px 28px rgba(124, 105, 255, 0.32);
 }
 
 .gachapon-start-button:disabled {
   cursor: not-allowed;
-  filter: saturate(0.6) brightness(0.9);
-  box-shadow: 0 6px 0 #1f0b25, 0 12px 18px rgba(31, 11, 37, 0.25);
+  filter: saturate(0.7) brightness(0.95);
+  box-shadow: 0 12px 22px rgba(148, 163, 184, 0.28);
 }
 
 .gachapon-start-button:disabled::before {
-  background: repeating-linear-gradient(180deg, rgba(255, 236, 214, 0.5) 0 6px, rgba(255, 236, 214, 0.2) 6px 12px);
+  opacity: 0.4;
 }
 
 .gachapon-start-button:focus-visible {
-  outline: 4px solid rgba(253, 224, 71, 0.7);
+  outline: 4px solid rgba(129, 124, 255, 0.35);
   outline-offset: 6px;
 }

--- a/src/games/gachapon-game/gachapon-game.js
+++ b/src/games/gachapon-game/gachapon-game.js
@@ -4,20 +4,60 @@ import gachaponConfig from './config';
 import { attemptGachapon, fetchAvailablePrizes } from './gachapon-api';
 import './gachapon-game.css';
 
-const rarityAccentClasses = {
-  common: 'border-gray-300 text-gray-200',
-  uncommon: 'border-emerald-300 text-emerald-200',
-  rare: 'border-sky-300 text-sky-200',
-  epic: 'border-violet-300 text-violet-200',
-  legendary: 'border-amber-200 text-amber-100',
+const defaultCardStyle = {
+  card: 'border-slate-200/80 bg-gradient-to-br from-white via-slate-50 to-white/70 text-slate-600 shadow-[0_20px_45px_rgba(148,163,184,0.2)]',
+  accentBlob: 'from-slate-200/60 via-white/50 to-transparent',
+  rarityBadge: 'bg-slate-200 text-slate-700',
+  dropBadge: 'bg-slate-100 text-slate-700',
+  title: 'text-slate-900',
+  body: 'text-slate-600',
+  accent: 'text-slate-500',
 };
 
-const rarityBackground = {
-  common: 'bg-slate-800/40',
-  uncommon: 'bg-emerald-500/10',
-  rare: 'bg-sky-500/10',
-  epic: 'bg-violet-500/10',
-  legendary: 'bg-amber-500/10',
+const rarityStyles = {
+  common: {
+    ...defaultCardStyle,
+  },
+  uncommon: {
+    ...defaultCardStyle,
+    card: 'border-emerald-200/70 bg-gradient-to-br from-white via-emerald-50 to-teal-50/70 text-emerald-700 shadow-[0_22px_45px_rgba(45,212,191,0.16)]',
+    accentBlob: 'from-emerald-200/60 via-teal-100/40 to-transparent',
+    rarityBadge: 'bg-emerald-200 text-emerald-800',
+    dropBadge: 'bg-emerald-100 text-emerald-700',
+    title: 'text-emerald-900',
+    body: 'text-emerald-600',
+    accent: 'text-emerald-500',
+  },
+  rare: {
+    ...defaultCardStyle,
+    card: 'border-sky-200/70 bg-gradient-to-br from-white via-sky-50 to-cyan-50/70 text-sky-700 shadow-[0_22px_45px_rgba(56,189,248,0.18)]',
+    accentBlob: 'from-sky-200/60 via-cyan-100/40 to-transparent',
+    rarityBadge: 'bg-sky-200 text-sky-800',
+    dropBadge: 'bg-sky-100 text-sky-700',
+    title: 'text-sky-900',
+    body: 'text-sky-600',
+    accent: 'text-sky-500',
+  },
+  epic: {
+    ...defaultCardStyle,
+    card: 'border-violet-200/70 bg-gradient-to-br from-white via-violet-50 to-fuchsia-50/70 text-violet-700 shadow-[0_22px_48px_rgba(167,139,250,0.22)]',
+    accentBlob: 'from-violet-200/60 via-fuchsia-100/40 to-transparent',
+    rarityBadge: 'bg-violet-200 text-violet-800',
+    dropBadge: 'bg-violet-100 text-violet-700',
+    title: 'text-violet-900',
+    body: 'text-violet-600',
+    accent: 'text-violet-500',
+  },
+  legendary: {
+    ...defaultCardStyle,
+    card: 'border-amber-200/70 bg-gradient-to-br from-white via-amber-50 to-orange-50/70 text-amber-700 shadow-[0_22px_48px_rgba(251,191,36,0.22)]',
+    accentBlob: 'from-amber-200/60 via-orange-100/40 to-transparent',
+    rarityBadge: 'bg-amber-200 text-amber-800',
+    dropBadge: 'bg-amber-100 text-amber-700',
+    title: 'text-amber-900',
+    body: 'text-amber-600',
+    accent: 'text-amber-500',
+  },
 };
 
 const defaultRarityLabels = {
@@ -112,21 +152,26 @@ const formatDropRate = (weight, totalWeight) => {
 };
 
 const PrizeCard = ({ prize, dropRate }) => {
-  const accentClass = rarityAccentClasses[prize.rarity] ?? 'border-slate-500 text-slate-200';
-  const backgroundClass = rarityBackground[prize.rarity] ?? 'bg-slate-800/40';
+  const style = rarityStyles[prize.rarity] ?? defaultCardStyle;
 
   return (
     <div
-      className={`flex h-full flex-col justify-between rounded-xl border ${accentClass} ${backgroundClass} p-4 shadow-lg shadow-slate-900/30`}
+      className={`relative flex h-full flex-col justify-between overflow-hidden rounded-3xl border p-6 transition-shadow duration-150 hover:shadow-[0_28px_48px_rgba(129,140,248,0.18)] ${style.card}`}
     >
-      <div>
-        <p className="text-sm uppercase tracking-wide text-slate-400">{prize.rarityLabel}</p>
-        <h3 className="mt-1 text-xl font-semibold text-white">{prize.name}</h3>
-        <p className="mt-2 text-sm text-slate-300">{prize.description}</p>
+      <div
+        className={`pointer-events-none absolute -right-14 top-12 h-28 w-28 rounded-full bg-gradient-to-br blur-3xl ${style.accentBlob}`}
+      />
+      <div className="pointer-events-none absolute -left-12 top-16 h-20 w-20 rounded-full bg-white/60 blur-3xl" />
+      <div className="flex flex-col gap-3">
+        <span className={`inline-flex w-max items-center rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${style.rarityBadge}`}>
+          {prize.rarityLabel}
+        </span>
+        <h3 className={`text-2xl font-semibold ${style.title}`}>{prize.name}</h3>
+        <p className={`text-sm leading-relaxed ${style.body}`}>{prize.description}</p>
       </div>
-      <div className="mt-4 flex items-center justify-between text-sm text-slate-400">
+      <div className={`mt-6 flex items-center justify-between text-[0.7rem] font-semibold uppercase tracking-[0.2em] ${style.accent}`}>
         <span>Drop Rate</span>
-        <span className="font-semibold text-slate-100">{dropRate}</span>
+        <span className={`rounded-full px-3 py-1 text-sm font-semibold tracking-normal ${style.dropBadge}`}>{dropRate}</span>
       </div>
     </div>
   );
@@ -366,36 +411,36 @@ const GachaponGame = ({ config = gachaponConfig }) => {
   const capsuleColor = result?.prize?.capsuleColor ?? normalisedConfig.defaultCapsuleColor ?? '#38bdf8';
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-slate-950 py-12 text-white">
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-[#f6f5ff] via-[#fff5f8] to-[#f1fbff] py-12 text-slate-700">
       <div className="pointer-events-none absolute inset-0">
-        <div className="absolute -top-16 left-16 h-60 w-60 rounded-full bg-indigo-500/25 blur-3xl" />
-        <div className="absolute top-1/3 right-12 h-72 w-72 rounded-full bg-violet-500/20 blur-3xl" />
-        <div className="absolute bottom-0 left-1/4 h-72 w-72 rounded-full bg-fuchsia-500/15 blur-3xl" />
+        <div className="absolute -top-32 left-10 h-72 w-72 rounded-full bg-[radial-gradient(circle_at_center,_rgba(129,140,248,0.35),_rgba(129,140,248,0))] blur-3xl" />
+        <div className="absolute top-1/3 right-0 h-80 w-80 rounded-full bg-[radial-gradient(circle_at_center,_rgba(236,72,153,0.18),_rgba(236,72,153,0))] blur-3xl" />
+        <div className="absolute bottom-[-6rem] left-1/4 h-96 w-96 rounded-full bg-[radial-gradient(circle_at_center,_rgba(56,189,248,0.18),_rgba(56,189,248,0))] blur-3xl" />
       </div>
 
       <div className="relative mx-auto flex w-full max-w-5xl flex-col items-center px-4">
         <div className="text-center">
           {normalisedConfig.tagline ? (
-            <p className="text-sm uppercase tracking-[0.35em] text-indigo-300">{normalisedConfig.tagline}</p>
+            <p className="text-sm uppercase tracking-[0.35em] text-sky-500">{normalisedConfig.tagline}</p>
           ) : null}
-          <h1 className="mt-2 text-4xl font-semibold text-white sm:text-5xl">
+          <h1 className="mt-2 text-4xl font-semibold text-slate-900 sm:text-5xl">
             {normalisedConfig.title ?? 'Gachapon Game'}
           </h1>
           {normalisedConfig.description ? (
-            <p className="mt-4 max-w-2xl text-sm text-slate-300 sm:text-base">
+            <p className="mt-4 max-w-2xl text-sm text-slate-600 sm:text-base">
               {normalisedConfig.description}
             </p>
           ) : null}
         </div>
 
-        <div className="mt-10 w-full max-w-3xl overflow-hidden rounded-[2.5rem] border border-indigo-400/30 bg-slate-900/80 p-10 text-center shadow-2xl shadow-indigo-900/40 backdrop-blur">
+        <div className="mt-10 w-full max-w-3xl overflow-hidden rounded-[2.75rem] border border-white/70 bg-white/80 p-10 text-center shadow-[0_30px_70px_rgba(99,102,241,0.12)] backdrop-blur">
           <div className="flex flex-col items-center gap-8">
             {normalisedConfig.capsuleMachineLabel ? (
-              <p className="text-xs uppercase tracking-[0.35em] text-indigo-300">
+              <p className="text-xs uppercase tracking-[0.35em] text-sky-500">
                 {normalisedConfig.capsuleMachineLabel}
               </p>
             ) : null}
-            <div className="gachapon-stage relative flex h-80 w-full max-w-md items-center justify-center rounded-[2rem] border border-indigo-400/30 bg-slate-950/70 p-8 shadow-[0_24px_45px_rgba(15,23,42,0.55)]">
+            <div className="gachapon-stage relative flex h-80 w-full max-w-md items-center justify-center rounded-[2.25rem] border border-transparent bg-white/80 p-8 shadow-[0_35px_60px_rgba(129,140,248,0.18)]">
               <div className="relative flex h-full w-full flex-col items-center justify-center">
                 <div
                   className={`gachapon-box ${
@@ -408,7 +453,7 @@ const GachaponGame = ({ config = gachaponConfig }) => {
                     }`}
                     style={{ background: capsuleColor }}
                   />
-                  <div className="absolute inset-x-8 bottom-6 rounded-full bg-slate-800/80 py-3 text-xs uppercase tracking-[0.3em] text-slate-400">
+                  <div className="absolute inset-x-8 bottom-6 rounded-full bg-white/80 py-3 text-xs uppercase tracking-[0.3em] text-slate-500">
                     {capsuleStatusLabel}
                   </div>
                 </div>
@@ -416,10 +461,10 @@ const GachaponGame = ({ config = gachaponConfig }) => {
               </div>
             </div>
             {normalisedConfig.capsuleDescription ? (
-              <p className="max-w-lg text-sm text-indigo-100/80">{normalisedConfig.capsuleDescription}</p>
+              <p className="max-w-lg text-sm text-slate-500">{normalisedConfig.capsuleDescription}</p>
             ) : null}
             {attemptError ? (
-              <p className="w-full rounded-2xl border border-rose-500/40 bg-rose-500/10 px-5 py-3 text-sm text-rose-200" role="status">
+              <p className="w-full rounded-2xl border border-rose-200 bg-rose-50 px-5 py-3 text-sm text-rose-700" role="status">
                 {attemptError}
               </p>
             ) : null}
@@ -437,30 +482,30 @@ const GachaponGame = ({ config = gachaponConfig }) => {
           </button>
           <button
             type="button"
-            className="rounded-full border border-slate-700/70 px-6 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:text-white"
+            className="rounded-full border border-slate-300/80 px-6 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-800"
             onClick={() => navigate('/')}
           >
             Back to Store
           </button>
         </div>
 
-        <div className="mt-12 w-full overflow-hidden rounded-[2.5rem] border border-slate-800/70 bg-slate-900/80 p-8 shadow-2xl shadow-indigo-900/30 backdrop-blur">
+        <div className="mt-12 w-full overflow-hidden rounded-[2.75rem] border border-white/70 bg-white/80 p-8 shadow-[0_30px_70px_rgba(148,163,184,0.18)] backdrop-blur">
           <div className="flex flex-col gap-6">
             <div className="flex flex-col items-center justify-between gap-3 text-center sm:flex-row sm:text-left">
               <div>
-                <h2 className="text-lg font-semibold text-white sm:text-xl">{normalisedConfig.prizeShowcaseTitle}</h2>
+                <h2 className="text-lg font-semibold text-slate-900 sm:text-xl">{normalisedConfig.prizeShowcaseTitle}</h2>
                 {normalisedConfig.prizeShowcaseDescription ? (
-                  <p className="mt-1 text-sm text-slate-400">{normalisedConfig.prizeShowcaseDescription}</p>
+                  <p className="mt-1 text-sm text-slate-500">{normalisedConfig.prizeShowcaseDescription}</p>
                 ) : null}
               </div>
-              <span className="rounded-full border border-slate-700/60 bg-slate-950/60 px-4 py-1 text-xs uppercase tracking-[0.3em] text-slate-300">
+              <span className="rounded-full border border-slate-200 bg-white px-4 py-1 text-xs uppercase tracking-[0.3em] text-slate-500">
                 {prizes.length} Rewards
               </span>
             </div>
             {loadingPrizes ? (
-              <p className="text-sm text-slate-400">{normalisedConfig.prizeListLoadingText}</p>
+              <p className="text-sm text-slate-500">{normalisedConfig.prizeListLoadingText}</p>
             ) : prizeError ? (
-              <p className="text-sm text-rose-300">{prizeError}</p>
+              <p className="text-sm text-rose-500">{prizeError}</p>
             ) : (
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 {prizes.map((prize) => (
@@ -477,27 +522,27 @@ const GachaponGame = ({ config = gachaponConfig }) => {
       </div>
 
       {showResultModal && result ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4 py-10 backdrop-blur">
-          <div className="w-full max-w-lg rounded-3xl border border-indigo-400/40 bg-slate-900/90 p-8 shadow-2xl shadow-indigo-900/50">
-            <p className="text-sm uppercase tracking-[0.25em] text-indigo-300">{normalisedConfig.resultModalTitle}</p>
-            <h3 className="mt-2 text-3xl font-semibold text-white">{result.prize.name}</h3>
-            <p className="mt-1 text-sm text-slate-400">{result.prize.rarityLabel}</p>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/20 px-4 py-10 backdrop-blur-md">
+          <div className="w-full max-w-lg rounded-3xl border border-white/70 bg-white/90 p-8 shadow-[0_35px_70px_rgba(129,140,248,0.25)]">
+            <p className="text-sm uppercase tracking-[0.25em] text-sky-500">{normalisedConfig.resultModalTitle}</p>
+            <h3 className="mt-2 text-3xl font-semibold text-slate-900">{result.prize.name}</h3>
+            <p className="mt-1 text-sm text-slate-500">{result.prize.rarityLabel}</p>
             <div className="mt-5 flex items-center justify-center">
               <div className="gachapon-capsule-display" style={{ background: result.prize.capsuleColor }} />
             </div>
-            <p className="mt-6 text-sm text-slate-300">{result.prize.description}</p>
-            <p className="mt-4 text-sm text-indigo-200">{result.flairText ?? normalisedConfig.defaultFlairText}</p>
+            <p className="mt-6 text-sm text-slate-600">{result.prize.description}</p>
+            <p className="mt-4 text-sm text-sky-600">{result.flairText ?? normalisedConfig.defaultFlairText}</p>
             <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-end">
               <button
                 type="button"
-                className="rounded-full border border-slate-600 px-5 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-400 hover:text-white"
+                className="rounded-full border border-slate-300 px-5 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-800"
                 onClick={closeModal}
               >
                 {normalisedConfig.ctaLabel ?? 'Start Gachapon'}
               </button>
               <button
                 type="button"
-                className="rounded-full bg-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400"
+                className="rounded-full bg-gradient-to-r from-sky-500 to-indigo-500 px-6 py-2 text-sm font-semibold text-white transition hover:brightness-110"
                 onClick={() => navigate('/')}
               >
                 Back to Store


### PR DESCRIPTION
## Summary
- restyled both gachapon implementations with a brighter gradient backdrop, softer typography, and updated capsule staging to match the requested playful aesthetic
- redesigned prize cards with rarity-specific pastel treatments, floating badges, and refined drop-rate presentation for a cleaner layout
- refreshed the result modal and supporting controls so navigation and messaging follow the new light, modern visual language

## Testing
- npm run start:lan

------
https://chatgpt.com/codex/tasks/task_e_68e4d732ad40832a8f4ac421632d1813