### PR TITLE
Fix scratch card foil reveal layout

### DIFF
--- a/src/games/scratch-card-classic/scratch-card-classic.css
+++ b/src/games/scratch-card-classic/scratch-card-classic.css
@@ -58,7 +58,6 @@
   .scratch-classic-header {
     flex-direction: row;
     align-items: center;
-    justify-content: space-between;
   }
 }
 
@@ -104,6 +103,14 @@
   display: flex;
   gap: 0.75rem;
   align-items: center;
+}
+
+.scratch-classic-actions--footer {
+  justify-content: center;
+  flex-wrap: wrap;
+  width: 100%;
+  margin: 0 auto;
+  max-width: 440px;
 }
 
 .scratch-classic-primary,
@@ -164,18 +171,16 @@
   padding: clamp(1.75rem, 3vw, 2.75rem);
   border: 1px solid rgba(var(--scratch-foreground-rgb, 255, 248, 232), 0.18);
   box-shadow: 0 40px 90px -35px rgba(var(--scratch-tertiary-rgb, 10, 10, 10), 0.55);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem;
 }
 
 .scratch-classic-card-wrapper {
-  display: grid;
-  gap: 2rem;
-}
-
-@media (min-width: 900px) {
-  .scratch-classic-card-wrapper {
-    grid-template-columns: minmax(0, 1fr) 280px;
-    align-items: stretch;
-  }
+  display: flex;
+  justify-content: center;
+  width: 100%;
 }
 
 .scratch-classic-card {
@@ -260,6 +265,12 @@
   transition: opacity 0.45s ease, transform 0.45s ease, box-shadow 0.45s ease;
   background-size: cover;
   background-position: center;
+}
+
+.scratch-classic-card--idle .scratch-classic-reward,
+.scratch-classic-card--preparing .scratch-classic-reward,
+.scratch-classic-card--ready .scratch-classic-reward {
+  opacity: 0;
 }
 
 .scratch-classic-card--revealed .scratch-classic-reward {
@@ -412,6 +423,10 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  width: 100%;
+  max-width: 420px;
+  align-items: center;
+  text-align: center;
 }
 
 .scratch-classic-status__badge {
@@ -428,6 +443,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  width: 100%;
 }
 
 .scratch-classic-progress__track {
@@ -435,6 +451,7 @@
   border-radius: 999px;
   background: rgba(var(--scratch-foreground-rgb, 255, 248, 232), 0.25);
   overflow: hidden;
+  width: 100%;
 }
 
 .scratch-classic-progress__fill {
@@ -455,6 +472,7 @@
   font-size: 0.85rem;
   line-height: 1.6;
   opacity: 0.85;
+  text-align: center;
 }
 
 .scratch-classic-status__detail span {

--- a/src/games/scratch-card-classic/scratch-card-classic.js
+++ b/src/games/scratch-card-classic/scratch-card-classic.js
@@ -513,44 +513,46 @@ const ScratchCardClassicGame = ({ config }) => {
               <p className="scratch-classic-description">{mergedConfig.description}</p>
             </div>
           </div>
-          <div className="scratch-classic-actions">
-            <button type="button" className="scratch-classic-secondary" onClick={() => navigate(-1)}>
-              Back to store
-            </button>
-            <button
-              type="button"
-              className="scratch-classic-primary"
-              onClick={handleAttempt}
-              disabled={buttonDisabled}
-            >
-              {buttonLabel}
-            </button>
-          </div>
         </header>
 
         <main className="scratch-classic-layout">
           <section className="scratch-classic-stage">
+            <aside className="scratch-classic-status">
+              <div className="scratch-classic-status__badge">{statusText}</div>
+              {showProgress ? (
+                <div className="scratch-classic-progress">
+                  <div className="scratch-classic-progress__track">
+                    <div
+                      className="scratch-classic-progress__fill"
+                      style={{ width: `${progressPercent}%` }}
+                    />
+                  </div>
+                  <span className="scratch-classic-progress__label">{progressPercent}% revealed</span>
+                </div>
+              ) : null}
+              {cardState === 'revealed' && result ? (
+                <p className="scratch-classic-status__detail">
+                  You uncovered the <span>{result.prize.name}</span>!
+                </p>
+              ) : null}
+              {attemptError ? <div className="scratch-classic-error">{attemptError}</div> : null}
+            </aside>
+
             <div className="scratch-classic-card-wrapper">
               <div className={cardClassName}>
                 <div className="scratch-classic-card__inner" ref={surfaceRef}>
                   <div className="scratch-classic-reward" style={rewardImageStyle}>
                     <div className="scratch-classic-reward__glow" style={glowStyle} />
-                    <div className="scratch-classic-reward__body">
-                      <p className="scratch-classic-reward__rarity">
-                        {hasRevealed && result ? result.prize.rarityLabel : 'Mystery Reward'}
-                      </p>
-                      <h3 className="scratch-classic-reward__title">
-                        {hasRevealed && result
-                          ? result.prize.name
-                          : cardState === 'ready'
-                          ? 'Scratch to reveal'
-                          : 'Awaiting scratch'}
-                      </h3>
-                      <p className="scratch-classic-reward__helper">
-                        {hasRevealed && result
-                          ? result.flairText || 'The prize gleams brilliantly!'
-                          : 'Drag across the foil to lift the shimmer.'}
-                      </p>
+                    <div className="scratch-classic-reward__body" aria-live="polite">
+                      {hasRevealed && result ? (
+                        <>
+                          <p className="scratch-classic-reward__rarity">{result.prize.rarityLabel}</p>
+                          <h3 className="scratch-classic-reward__title">{result.prize.name}</h3>
+                          <p className="scratch-classic-reward__helper">
+                            {result.flairText || 'The prize gleams brilliantly!'}
+                          </p>
+                        </>
+                      ) : null}
                     </div>
                   </div>
                   <div className={foilClassName}>
@@ -578,26 +580,20 @@ const ScratchCardClassicGame = ({ config }) => {
                   </div>
                 </div>
               </div>
-              <aside className="scratch-classic-status">
-                <div className="scratch-classic-status__badge">{statusText}</div>
-                {showProgress ? (
-                  <div className="scratch-classic-progress">
-                    <div className="scratch-classic-progress__track">
-                      <div
-                        className="scratch-classic-progress__fill"
-                        style={{ width: `${progressPercent}%` }}
-                      />
-                    </div>
-                    <span className="scratch-classic-progress__label">{progressPercent}% revealed</span>
-                  </div>
-                ) : null}
-                {cardState === 'revealed' && result ? (
-                  <p className="scratch-classic-status__detail">
-                    You uncovered the <span>{result.prize.name}</span>!
-                  </p>
-                ) : null}
-                {attemptError ? <div className="scratch-classic-error">{attemptError}</div> : null}
-              </aside>
+            </div>
+
+            <div className="scratch-classic-actions scratch-classic-actions--footer">
+              <button type="button" className="scratch-classic-secondary" onClick={() => navigate(-1)}>
+                Back to store
+              </button>
+              <button
+                type="button"
+                className="scratch-classic-primary"
+                onClick={handleAttempt}
+                disabled={buttonDisabled}
+              >
+                {buttonLabel}
+              </button>
             </div>
           </section>
 


### PR DESCRIPTION
## Summary
- move the scratch card status panel above the card and relocate the controls beneath it
- hide prize copy until the foil is cleared so the cover fully obscures the card
- center the scratch card stage layout while keeping revealed prize imagery and text

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e51586ca34832aa385a0bbe950239d