### PR TITLE
Simplify gachapon prize configuration

### DIFF
--- a/src/games/gachapon-game/config/index.js
+++ b/src/games/gachapon-game/config/index.js
@@ -2,50 +2,35 @@ const gachaponPrizes = [
   {
     id: 'luminous-orb',
     name: 'Luminous Orb',
-    rarity: 'common',
-    rarityLabel: 'Common',
     description: 'A softly glowing orb that keeps your camp lit through the night.',
-    weight: 45,
     capsuleColor: '#E5E7EB',
     flairText: 'The orb hums gently as it rolls into your hands.'
   },
   {
     id: 'ember-charm',
     name: 'Ember Charm',
-    rarity: 'uncommon',
-    rarityLabel: 'Uncommon',
     description: 'A flickering charm that warms nearby allies by a few cozy degrees.',
-    weight: 30,
     capsuleColor: '#86EFAC',
     flairText: 'Sparks of emberlight trace the capsule as it opens.'
   },
   {
     id: 'aurora-cape',
     name: 'Aurora Cape',
-    rarity: 'rare',
-    rarityLabel: 'Rare',
     description: 'Shimmers with the northern lights and lets you glide short distances.',
-    weight: 18,
     capsuleColor: '#93C5FD',
     flairText: 'The cape unfurls with a cascade of aurora hues.'
   },
   {
     id: 'celestial-compass',
     name: 'Celestial Compass',
-    rarity: 'epic',
-    rarityLabel: 'Epic',
     description: 'Always points toward the nearest secret, no matter where you roam.',
-    weight: 6,
     capsuleColor: '#C4B5FD',
     flairText: 'Starlit runes ignite as the compass clicks into place.'
   },
   {
     id: 'dragon-heartfire',
     name: 'Dragon Heartfire',
-    rarity: 'legendary',
-    rarityLabel: 'Legendary',
     description: "A fragment of dragon flame that grants a surge of courage to its bearer.",
-    weight: 1,
     capsuleColor: '#FDE68A',
     flairText: "A plume of golden flame roars from the capsule's core."
   }
@@ -57,7 +42,7 @@ const gachaponConfig = {
   title: 'Celestial Capsule Gachapon',
   tagline: 'Arcade Feature',
   description:
-    'Pull the lever to see what treasure is sealed within the capsule. Every attempt draws from the same prize pool, and your luck determines the rarity of your reward.',
+    'Pull the lever to see what treasure is sealed within the capsule. Every attempt reveals one colourful surprise from the same prize pool.',
   ctaLabel: 'Start Gachapon',
   preparingLabel: 'Dispensing…',
   resultModalTitle: 'Gachapon Result',

--- a/src/games/gachapon-game/config/template.json
+++ b/src/games/gachapon-game/config/template.json
@@ -10,7 +10,7 @@
   "defaults": {
     "title": "Celestial Capsule Gachapon",
     "tagline": "Arcade Feature",
-    "description": "Pull the lever to see what treasure is sealed within the capsule. Every attempt draws from the same prize pool, and your luck determines the rarity of your reward.",
+    "description": "Pull the lever to see what treasure is sealed within the capsule. Every attempt reveals one colourful surprise from the same prize pool.",
     "ctaLabel": "Start Gachapon",
     "preparingLabel": "Dispensing…",
     "resultModalTitle": "Gachapon Result",
@@ -35,50 +35,35 @@
       {
         "id": "luminous-orb",
         "name": "Luminous Orb",
-        "rarity": "common",
-        "rarityLabel": "Common",
         "description": "A softly glowing orb that keeps your camp lit through the night.",
-        "weight": 45,
         "capsuleColor": "#E5E7EB",
         "flairText": "The orb hums gently as it rolls into your hands."
       },
       {
         "id": "ember-charm",
         "name": "Ember Charm",
-        "rarity": "uncommon",
-        "rarityLabel": "Uncommon",
         "description": "A flickering charm that warms nearby allies by a few cozy degrees.",
-        "weight": 30,
         "capsuleColor": "#86EFAC",
         "flairText": "Sparks of emberlight trace the capsule as it opens."
       },
       {
         "id": "aurora-cape",
         "name": "Aurora Cape",
-        "rarity": "rare",
-        "rarityLabel": "Rare",
         "description": "Shimmers with the northern lights and lets you glide short distances.",
-        "weight": 18,
         "capsuleColor": "#93C5FD",
         "flairText": "The cape unfurls with a cascade of aurora hues."
       },
       {
         "id": "celestial-compass",
         "name": "Celestial Compass",
-        "rarity": "epic",
-        "rarityLabel": "Epic",
         "description": "Always points toward the nearest secret, no matter where you roam.",
-        "weight": 6,
         "capsuleColor": "#C4B5FD",
         "flairText": "Starlit runes ignite as the compass clicks into place."
       },
       {
         "id": "dragon-heartfire",
         "name": "Dragon Heartfire",
-        "rarity": "legendary",
-        "rarityLabel": "Legendary",
         "description": "A fragment of dragon flame that grants a surge of courage to its bearer.",
-        "weight": 1,
         "capsuleColor": "#FDE68A",
         "flairText": "A plume of golden flame roars from the capsule's core."
       }
@@ -275,11 +260,11 @@
       "type": "array",
       "scope": "admin",
       "required": true,
-      "description": "Defines the prize pool, rarities, and odds for the capsule machine.",
+      "description": "Defines the prize pool and capsule colours for the capsule machine.",
       "merchantEditableFields": [
         "name",
         "description",
-        "rarityLabel",
+        "capsuleColor",
         "flairText"
       ],
       "item": {
@@ -287,10 +272,7 @@
         "fields": [
           { "name": "id", "type": "string", "required": true },
           { "name": "name", "type": "string", "required": true },
-          { "name": "rarity", "type": "string", "required": true },
-          { "name": "rarityLabel", "type": "string", "required": true },
           { "name": "description", "type": "string", "required": true },
-          { "name": "weight", "type": "number", "required": true },
           { "name": "capsuleColor", "type": "color", "required": true },
           { "name": "flairText", "type": "string", "required": false }
         ]

--- a/src/games/gachapon-game/gachapon-api.js
+++ b/src/games/gachapon-game/gachapon-api.js
@@ -5,7 +5,6 @@ const ATTEMPT_DELAY_MS = 1100;
 
 const clonePrize = (prize) => ({
   ...prize,
-  weight: Number.isFinite(prize?.weight) && prize.weight > 0 ? prize.weight : 0,
 });
 
 const getPrizesFromConfig = (config) => {
@@ -17,27 +16,13 @@ const getPrizesFromConfig = (config) => {
   return rawPrizes.map((prize) => clonePrize(prize));
 };
 
-const pickWeightedPrize = (weightedPrizes) => {
-  if (!Array.isArray(weightedPrizes) || weightedPrizes.length === 0) {
+const pickRandomPrize = (prizes) => {
+  if (!Array.isArray(prizes) || prizes.length === 0) {
     return null;
   }
 
-  const totalWeight = weightedPrizes.reduce((sum, entry) => sum + entry.weight, 0);
-
-  if (totalWeight <= 0) {
-    return weightedPrizes[0];
-  }
-
-  let threshold = Math.random() * totalWeight;
-
-  for (const entry of weightedPrizes) {
-    threshold -= entry.weight;
-    if (threshold <= 0) {
-      return entry;
-    }
-  }
-
-  return weightedPrizes[weightedPrizes.length - 1];
+  const index = Math.floor(Math.random() * prizes.length);
+  return prizes[index] ?? prizes[0];
 };
 
 const resolveFlairText = (prize, config) => {
@@ -76,16 +61,7 @@ export const attemptGachapon = (config = gachaponConfig) =>
       return;
     }
 
-    const weightedPrizes = prizes.map((prize) => ({ prize, weight: prize.weight }));
-    const totalWeight = weightedPrizes.reduce((sum, entry) => sum + entry.weight, 0);
-
-    if (totalWeight <= 0) {
-      reject(new Error('Gachapon prizes require a positive weight'));
-      return;
-    }
-
-    const selectedEntry = pickWeightedPrize(weightedPrizes) ?? weightedPrizes[0];
-    const selectedPrize = selectedEntry?.prize ?? prizes[0];
+    const selectedPrize = pickRandomPrize(prizes) ?? prizes[0];
     const flairText = resolveFlairText(selectedPrize, config);
 
     setTimeout(() => {

--- a/src/games/gachapon-game/gachapon-game.js
+++ b/src/games/gachapon-game/gachapon-game.js
@@ -7,74 +7,53 @@ import './gachapon-game.css';
 const defaultCardStyle = {
   card: 'border-slate-200/80 bg-gradient-to-br from-white via-slate-50 to-white/70 text-slate-600 shadow-[0_20px_45px_rgba(148,163,184,0.2)]',
   accentBlob: 'from-slate-200/60 via-white/50 to-transparent',
-  rarityBadge: 'bg-slate-200 text-slate-700',
-  dropBadge: 'bg-slate-100 text-slate-700',
+  highlight: 'bg-slate-100 text-slate-700',
   title: 'text-slate-900',
   body: 'text-slate-600',
   accent: 'text-slate-500',
 };
 
-const rarityStyles = {
-  common: {
+const cardThemes = [
+  {
     ...defaultCardStyle,
   },
-  uncommon: {
+  {
     ...defaultCardStyle,
     card: 'border-emerald-200/70 bg-gradient-to-br from-white via-emerald-50 to-teal-50/70 text-emerald-700 shadow-[0_22px_45px_rgba(45,212,191,0.16)]',
     accentBlob: 'from-emerald-200/60 via-teal-100/40 to-transparent',
-    rarityBadge: 'bg-emerald-200 text-emerald-800',
-    dropBadge: 'bg-emerald-100 text-emerald-700',
+    highlight: 'bg-emerald-100 text-emerald-700',
     title: 'text-emerald-900',
     body: 'text-emerald-600',
     accent: 'text-emerald-500',
   },
-  rare: {
+  {
     ...defaultCardStyle,
     card: 'border-sky-200/70 bg-gradient-to-br from-white via-sky-50 to-cyan-50/70 text-sky-700 shadow-[0_22px_45px_rgba(56,189,248,0.18)]',
     accentBlob: 'from-sky-200/60 via-cyan-100/40 to-transparent',
-    rarityBadge: 'bg-sky-200 text-sky-800',
-    dropBadge: 'bg-sky-100 text-sky-700',
+    highlight: 'bg-sky-100 text-sky-700',
     title: 'text-sky-900',
     body: 'text-sky-600',
     accent: 'text-sky-500',
   },
-  epic: {
+  {
     ...defaultCardStyle,
     card: 'border-violet-200/70 bg-gradient-to-br from-white via-violet-50 to-fuchsia-50/70 text-violet-700 shadow-[0_22px_48px_rgba(167,139,250,0.22)]',
     accentBlob: 'from-violet-200/60 via-fuchsia-100/40 to-transparent',
-    rarityBadge: 'bg-violet-200 text-violet-800',
-    dropBadge: 'bg-violet-100 text-violet-700',
+    highlight: 'bg-violet-100 text-violet-700',
     title: 'text-violet-900',
     body: 'text-violet-600',
     accent: 'text-violet-500',
   },
-  legendary: {
+  {
     ...defaultCardStyle,
     card: 'border-amber-200/70 bg-gradient-to-br from-white via-amber-50 to-orange-50/70 text-amber-700 shadow-[0_22px_48px_rgba(251,191,36,0.22)]',
     accentBlob: 'from-amber-200/60 via-orange-100/40 to-transparent',
-    rarityBadge: 'bg-amber-200 text-amber-800',
-    dropBadge: 'bg-amber-100 text-amber-700',
+    highlight: 'bg-amber-100 text-amber-700',
     title: 'text-amber-900',
     body: 'text-amber-600',
     accent: 'text-amber-500',
   },
-};
-
-const defaultRarityLabels = {
-  common: 'Common',
-  uncommon: 'Uncommon',
-  rare: 'Rare',
-  epic: 'Epic',
-  legendary: 'Legendary',
-};
-
-const defaultRarityCapsuleColors = {
-  common: '#E5E7EB',
-  uncommon: '#86EFAC',
-  rare: '#93C5FD',
-  epic: '#C4B5FD',
-  legendary: '#FDE68A',
-};
+];
 
 const toNonNegativeInteger = (value, fallback) => {
   const parsed = Math.floor(Number(value));
@@ -83,6 +62,8 @@ const toNonNegativeInteger = (value, fallback) => {
   }
   return fallback;
 };
+
+const fallbackCapsulePalette = ['#38bdf8', '#86EFAC', '#93C5FD', '#C4B5FD', '#FDE68A'];
 
 const normalisePrizes = (rawPrizes, fallbackPrizes, fallbackFlairText, defaultCapsuleColor) => {
   const basePrizes = Array.isArray(rawPrizes) ? rawPrizes.filter((prize) => prize && typeof prize === 'object') : [];
@@ -98,9 +79,6 @@ const normalisePrizes = (rawPrizes, fallbackPrizes, fallbackFlairText, defaultCa
         id: 'gachapon-placeholder-1',
         name: 'Mystery Capsule',
         description: 'Configure gachapon prizes to replace this placeholder reward.',
-        rarity: 'common',
-        rarityLabel: 'Mystery',
-        weight: 1,
         capsuleColor: defaultCapsuleColor,
         flairText: fallbackFlairText,
       },
@@ -108,19 +86,10 @@ const normalisePrizes = (rawPrizes, fallbackPrizes, fallbackFlairText, defaultCa
   }
 
   return effectivePrizes.map((prize, index) => {
-    const rarityValue =
-      typeof prize.rarity === 'string' && prize.rarity.trim()
-        ? prize.rarity.trim().toLowerCase()
-        : 'common';
-    const rarityLabel =
-      typeof prize.rarityLabel === 'string' && prize.rarityLabel.trim()
-        ? prize.rarityLabel
-        : defaultRarityLabels[rarityValue] ?? rarityValue.charAt(0).toUpperCase() + rarityValue.slice(1);
-    const weight = Number.isFinite(prize.weight) && prize.weight > 0 ? prize.weight : 1;
     const capsuleColor =
       typeof prize.capsuleColor === 'string' && prize.capsuleColor.trim()
         ? prize.capsuleColor
-        : defaultRarityCapsuleColors[rarityValue] ?? defaultCapsuleColor;
+        : fallbackCapsulePalette[index % fallbackCapsulePalette.length] ?? defaultCapsuleColor;
     const flairText =
       typeof prize.flairText === 'string' && prize.flairText.trim() ? prize.flairText : fallbackFlairText;
 
@@ -129,50 +98,41 @@ const normalisePrizes = (rawPrizes, fallbackPrizes, fallbackFlairText, defaultCa
       id: prize.id ?? `gachapon-prize-${index}`,
       name: prize.name ?? `Prize ${index + 1}`,
       description: prize.description ?? 'Configure prize details in the template options.',
-      rarity: rarityValue,
-      rarityLabel,
-      weight,
       capsuleColor,
       flairText,
+      themeIndex: index % cardThemes.length,
     };
   });
 };
 
-const formatDropRate = (weight, totalWeight) => {
-  if (!totalWeight) {
-    return '—';
-  }
-
-  const percentage = (weight / totalWeight) * 100;
-  if (percentage < 0.1) {
-    return '<0.1%';
-  }
-
-  return `${percentage.toFixed(1)}%`;
-};
-
-const PrizeCard = ({ prize, dropRate }) => {
-  const style = rarityStyles[prize.rarity] ?? defaultCardStyle;
+const PrizeCard = ({ prize }) => {
+  const theme = cardThemes[prize.themeIndex ?? 0] ?? defaultCardStyle;
 
   return (
     <div
-      className={`relative flex h-full flex-col justify-between overflow-hidden rounded-3xl border p-6 transition-shadow duration-150 hover:shadow-[0_28px_48px_rgba(129,140,248,0.18)] ${style.card}`}
+      className={`relative flex h-full flex-col justify-between overflow-hidden rounded-3xl border p-6 transition-shadow duration-150 hover:shadow-[0_28px_48px_rgba(129,140,248,0.18)] ${theme.card}`}
     >
       <div
-        className={`pointer-events-none absolute -right-14 top-12 h-28 w-28 rounded-full bg-gradient-to-br blur-3xl ${style.accentBlob}`}
+        className={`pointer-events-none absolute -right-14 top-12 h-28 w-28 rounded-full bg-gradient-to-br blur-3xl ${theme.accentBlob}`}
       />
       <div className="pointer-events-none absolute -left-12 top-16 h-20 w-20 rounded-full bg-white/60 blur-3xl" />
       <div className="flex flex-col gap-3">
-        <span className={`inline-flex w-max items-center rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${style.rarityBadge}`}>
-          {prize.rarityLabel}
+        <h3 className={`text-2xl font-semibold ${theme.title}`}>{prize.name}</h3>
+        <p className={`text-sm leading-relaxed ${theme.body}`}>{prize.description}</p>
+      </div>
+      <div className={`mt-6 flex items-center justify-between text-[0.7rem] font-semibold uppercase tracking-[0.2em] ${theme.accent}`}>
+        <span>Capsule Colour</span>
+        <span className={`flex items-center gap-2 rounded-full px-3 py-1 text-sm font-semibold tracking-normal ${theme.highlight}`}>
+          <span
+            className="h-3 w-3 rounded-full border border-white/60"
+            style={{ background: prize.capsuleColor }}
+          />
+          {prize.capsuleColor}
         </span>
-        <h3 className={`text-2xl font-semibold ${style.title}`}>{prize.name}</h3>
-        <p className={`text-sm leading-relaxed ${style.body}`}>{prize.description}</p>
       </div>
-      <div className={`mt-6 flex items-center justify-between text-[0.7rem] font-semibold uppercase tracking-[0.2em] ${style.accent}`}>
-        <span>Drop Rate</span>
-        <span className={`rounded-full px-3 py-1 text-sm font-semibold tracking-normal ${style.dropBadge}`}>{dropRate}</span>
-      </div>
+      {prize.flairText ? (
+        <p className={`mt-4 text-xs leading-relaxed ${theme.body}`}>{prize.flairText}</p>
+      ) : null}
     </div>
   );
 };
@@ -323,8 +283,6 @@ const GachaponGame = ({ config = gachaponConfig }) => {
       cancelled = true;
     };
   }, [normalisedConfig]);
-
-  const totalWeight = useMemo(() => prizes.reduce((sum, prize) => sum + (prize.weight ?? 0), 0), [prizes]);
 
   const queueTimeout = (callback, delay) => {
     const timeoutId = setTimeout(callback, delay);
@@ -509,11 +467,7 @@ const GachaponGame = ({ config = gachaponConfig }) => {
             ) : (
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 {prizes.map((prize) => (
-                  <PrizeCard
-                    key={prize.id}
-                    prize={prize}
-                    dropRate={formatDropRate(prize.weight ?? 0, totalWeight)}
-                  />
+                  <PrizeCard key={prize.id} prize={prize} />
                 ))}
               </div>
             )}
@@ -526,7 +480,6 @@ const GachaponGame = ({ config = gachaponConfig }) => {
           <div className="w-full max-w-lg rounded-3xl border border-white/70 bg-white/90 p-8 shadow-[0_35px_70px_rgba(129,140,248,0.25)]">
             <p className="text-sm uppercase tracking-[0.25em] text-sky-500">{normalisedConfig.resultModalTitle}</p>
             <h3 className="mt-2 text-3xl font-semibold text-slate-900">{result.prize.name}</h3>
-            <p className="mt-1 text-sm text-slate-500">{result.prize.rarityLabel}</p>
             <div className="mt-5 flex items-center justify-center">
               <div className="gachapon-capsule-display" style={{ background: result.prize.capsuleColor }} />
             </div>

--- a/src/games/gachapon-game/gachapon-theme-preview.js
+++ b/src/games/gachapon-game/gachapon-theme-preview.js
@@ -60,9 +60,7 @@ const GachaponThemePreview = ({ config }) => {
       const fallback = DEFAULT_PRIZES[index] ?? {};
       const color = pickColor(prize?.capsuleColor, fallback.capsuleColor, capsuleColor);
       const label =
-        toCleanString(prize?.rarityLabel) ||
         toCleanString(prize?.name) ||
-        toCleanString(fallback.rarityLabel) ||
         toCleanString(fallback.name) ||
         `Prize ${index + 1}`;
       const flair = toCleanString(prize?.flairText) || toCleanString(fallback.flairText) || heroFlair;


### PR DESCRIPTION
## Summary
- remove rarity and weighting metadata from the gachapon template and default prizes to keep the capsule pool simple
- refresh the gachapon UI logic to cycle colour themes per prize, drop odds messaging, and display capsule colours instead
- adjust the gachapon API helper and theme preview to treat prizes as uniformly random and reflect the streamlined fields

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68e51c4dde20832abb48f6a4e69c400e