### PR TITLE
Refine scratch card module layout

### DIFF
--- a/src/game_modules/scratch-card-module/scratch-card.css
+++ b/src/game_modules/scratch-card-module/scratch-card.css
@@ -163,32 +163,9 @@ body {
 .scratch-card__reward {
   position: relative;
   z-index: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  color: #1f2937;
   width: 100%;
-}
-
-.scratch-card__reward-rarity {
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  letter-spacing: 0.2em;
-  color: #6b7280;
-}
-
-.scratch-card__reward-name {
-  margin: 0;
-  font-size: 1.5rem;
-  font-weight: 600;
-  color: #111827;
-}
-
-.scratch-card__reward-helper {
-  margin: 0;
-  font-size: 0.9rem;
-  color: #4b5563;
-  line-height: 1.4;
+  height: 100%;
+  border-radius: 12px;
 }
 
 .scratch-card__overlay {
@@ -197,11 +174,7 @@ body {
   border-radius: 14px;
   background: linear-gradient(135deg, #cbd5f5, #f1f5f9);
   border: 1px dashed rgba(99, 102, 241, 0.3);
-  display: flex;
-  align-items: flex-end;
-  justify-content: center;
-  padding: 16px;
-  box-sizing: border-box;
+  display: block;
   transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
@@ -232,36 +205,7 @@ body {
   pointer-events: none;
 }
 
-.scratch-card__overlay-message {
-  position: relative;
-  width: 100%;
-  text-align: center;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  background: rgba(255, 255, 255, 0.85);
-  color: #374151;
-  border-radius: 999px;
-  padding: 10px 16px;
-  opacity: 0;
-  transform: translateY(8px);
-  transition: opacity 0.3s ease, transform 0.3s ease;
-  pointer-events: none;
-}
 
-.scratch-card__overlay-message.is-visible {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-.scratch-card__overlay-detail {
-  display: block;
-  margin-top: 4px;
-  font-size: 0.72rem;
-  letter-spacing: 0.08em;
-  text-transform: none;
-  color: #6b7280;
-}
 
 .scratch-status {
   width: 100%;
@@ -413,11 +357,46 @@ body {
   color: #6b7280;
 }
 
-.scratch-footer-actions {
+.scratch-card-instructions {
+  width: 100%;
+  max-width: 360px;
+  background: #ffffff;
+  border: 1px solid #d1d5db;
+  border-radius: 16px;
+  box-shadow: 0 10px 24px rgba(148, 163, 184, 0.18);
+  padding: 16px 18px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.scratch-card-instructions__headline {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: #111827;
+}
+
+.scratch-card-instructions__body {
+  margin: 0;
+  color: #4b5563;
+  line-height: 1.5;
+}
+
+.scratch-card-instructions__detail {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.scratch-card-controls {
+  width: 100%;
+  max-width: 360px;
   display: flex;
   flex-direction: column;
   gap: 12px;
-  align-items: center;
+  align-items: stretch;
 }
 
 .scratch-modal {
@@ -534,7 +513,7 @@ body {
 }
 
 @media (min-width: 640px) {
-  .scratch-footer-actions {
+  .scratch-card-controls {
     flex-direction: row;
     justify-content: center;
   }


### PR DESCRIPTION
## Summary
- remove all text overlays from the scratch surface and present guidance in a dedicated panel beneath the card
- move the back/cta controls under the scratchable area and refresh styles to support the new layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e51bd6f988832abc70095107e2c732