### PR TITLE
Add precision timer game module

### DIFF
--- a/src/game_modules/precision-timer-module/index.js
+++ b/src/game_modules/precision-timer-module/index.js
@@ -1,0 +1,124 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import PrecisionTimerGame from './precision-timer-game';
+import samplePrecisionTimerGameDocument from './sample-game-document';
+
+const mockFetchPrecisionTimerConfig = () =>
+  new Promise((resolve, reject) => {
+    try {
+      setTimeout(() => {
+        if (typeof structuredClone === 'function') {
+          resolve(structuredClone(samplePrecisionTimerGameDocument));
+          return;
+        }
+
+        resolve(JSON.parse(JSON.stringify(samplePrecisionTimerGameDocument)));
+      }, 250);
+    } catch (error) {
+      reject(error);
+    }
+  });
+
+const ErrorState = ({ message, onBack }) => (
+  <div className="p-6 text-center">
+    <h3 className="text-xl font-semibold text-slate-100">Unable to launch Precision Timer</h3>
+    <p className="mt-2 text-slate-300">{message}</p>
+    {onBack && (
+      <button
+        type="button"
+        onClick={onBack}
+        className="mt-4 rounded-full bg-slate-900 px-4 py-2 text-white shadow"
+      >
+        Back to library
+      </button>
+    )}
+  </div>
+);
+
+const LoadingState = () => (
+  <div className="flex items-center justify-center p-10 text-slate-200">Loading configuration…</div>
+);
+
+export default function PrecisionTimerGameInit({
+  config: externalConfig,
+  onBack,
+  fetchConfig = mockFetchPrecisionTimerConfig,
+}) {
+  const [config, setConfig] = useState(() => externalConfig || null);
+  const [error, setError] = useState(null);
+  const [isLoading, setIsLoading] = useState(() => !externalConfig);
+
+  const loadConfig = useMemo(
+    () => (typeof fetchConfig === 'function' ? fetchConfig : mockFetchPrecisionTimerConfig),
+    [fetchConfig],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (externalConfig) {
+      setConfig(externalConfig);
+      setError(null);
+      setIsLoading(false);
+
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setConfig(null);
+    setIsLoading(true);
+    setError(null);
+
+    loadConfig()
+      .then((data) => {
+        if (cancelled) {
+          return;
+        }
+
+        if (!data) {
+          throw new Error('The Precision Timer configuration was not found.');
+        }
+
+        setConfig(data);
+        setIsLoading(false);
+      })
+      .catch((fetchError) => {
+        if (cancelled) {
+          return;
+        }
+
+        const message =
+          fetchError instanceof Error
+            ? fetchError.message || 'Failed to fetch the Precision Timer configuration.'
+            : 'Failed to fetch the Precision Timer configuration.';
+
+        setError(message);
+        setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [externalConfig, loadConfig]);
+
+  if (error) {
+    return <ErrorState message={error} onBack={onBack} />;
+  }
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (!config?.game_template_id && !config?.game_template_name) {
+    return (
+      <ErrorState
+        message="This Precision Timer experience is missing a template id. Check the configuration and try again."
+        onBack={onBack}
+      />
+    );
+  }
+
+  return <PrecisionTimerGame config={config} onBack={onBack} />;
+}
+
+export { default as samplePrecisionTimerGameDocument } from './sample-game-document';

--- a/src/game_modules/precision-timer-module/precision-timer-game.js
+++ b/src/game_modules/precision-timer-module/precision-timer-game.js
@@ -1,0 +1,319 @@
+import React, { useEffect, useRef, useState } from 'react';
+import ResultsScreen from './results-screen';
+import samplePrecisionTimerGameDocument from './sample-game-document';
+
+const formatSeconds = (value) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return '0.000';
+  }
+  return numeric.toFixed(3);
+};
+
+const parseCountdownSeconds = (value) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return 5;
+  }
+  return numeric;
+};
+
+const resolveConfigValue = (config, keys, fallback) => {
+  for (const key of keys) {
+    if (config && Object.prototype.hasOwnProperty.call(config, key)) {
+      return config[key];
+    }
+  }
+  return fallback;
+};
+
+const PrecisionTimerGame = ({ config = samplePrecisionTimerGameDocument, onBack }) => {
+  const countdownSeconds = parseCountdownSeconds(
+    resolveConfigValue(config, ['countdownSeconds', 'countdown_seconds'], 5),
+  );
+  const startLabel =
+    resolveConfigValue(config, ['startButtonLabel', 'start_button_label'], null) || 'Start';
+  const stopLabel =
+    resolveConfigValue(config, ['stopButtonLabel', 'stop_button_label'], null) || 'Stop';
+
+  const [displaySeconds, setDisplaySeconds] = useState(() => formatSeconds(countdownSeconds));
+  const [status, setStatus] = useState('idle');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [result, setResult] = useState(null);
+
+  const startTimeRef = useRef(null);
+  const targetTimeRef = useRef(null);
+  const intervalRef = useRef(null);
+  const hasFinalisedRef = useRef(false);
+
+  useEffect(() => () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status === 'idle') {
+      setDisplaySeconds(formatSeconds(countdownSeconds));
+    }
+  }, [countdownSeconds, status]);
+
+  const startCountdown = () => {
+    if (status !== 'idle') {
+      return;
+    }
+
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    const now = Date.now();
+    startTimeRef.current = now;
+    targetTimeRef.current = now + countdownSeconds * 1000;
+    hasFinalisedRef.current = false;
+
+    setDisplaySeconds(formatSeconds(countdownSeconds));
+    setStatus('counting');
+
+    intervalRef.current = setInterval(() => {
+      const remainingMs = targetTimeRef.current - Date.now();
+
+      if (remainingMs <= 0) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+        setDisplaySeconds('0.000');
+        finaliseResult({ reason: 'timeout', stopTime: targetTimeRef.current });
+        return;
+      }
+
+      setDisplaySeconds(formatSeconds(remainingMs / 1000));
+    }, 50);
+  };
+
+  const stopCountdown = () => {
+    if (status !== 'counting' || hasFinalisedRef.current) {
+      return;
+    }
+
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    const stopTime = Date.now();
+    const remainingMs = targetTimeRef.current - stopTime;
+    setDisplaySeconds(formatSeconds(remainingMs / 1000));
+    finaliseResult({ reason: 'player', stopTime });
+  };
+
+  const finaliseResult = ({ reason, stopTime }) => {
+    if (hasFinalisedRef.current) {
+      return;
+    }
+
+    hasFinalisedRef.current = true;
+    setStatus('submitting');
+    setIsSubmitting(true);
+
+    const startedAt = startTimeRef.current || stopTime;
+    const resolvedStopTime = stopTime || Date.now();
+
+    let pressedAtSeconds = null;
+    let timeRemainingSeconds = null;
+    let score = null;
+
+    if (reason === 'timeout') {
+      timeRemainingSeconds = 0;
+      score = Number(countdownSeconds.toFixed(3));
+    } else {
+      const deltaMs = targetTimeRef.current - resolvedStopTime;
+      timeRemainingSeconds = Number((deltaMs / 1000).toFixed(3));
+      pressedAtSeconds = Number(((resolvedStopTime - startedAt) / 1000).toFixed(3));
+      score = Number(Math.abs(deltaMs / 1000).toFixed(3));
+    }
+
+    const payload = {
+      gameId: resolveConfigValue(config, ['gameId', 'game_id'], ''),
+      gameType: resolveConfigValue(config, ['gameType', 'game_type'], 'precision-timer'),
+      gameTitle: config?.title,
+      outcome: reason === 'timeout' ? 'Missed' : 'Completed',
+      countdownSeconds,
+      pressedAtSeconds,
+      timeRemainingSeconds,
+      score,
+    };
+
+    const endpoint =
+      resolveConfigValue(config, ['submissionEndpoint', 'submission_endpoint'], null) ||
+      `/api/${payload.gameType || 'precision-timer'}/${payload.gameId || 'demo'}`;
+
+    mockSubmitResults(endpoint, payload)
+      .then((response) => {
+        setResult(response);
+        setStatus('submitted');
+      })
+      .catch((error) => {
+        console.warn('[PrecisionTimer] Failed to submit results, falling back to mock payload.', error);
+        setResult({ ...payload, submissionEndpoint: endpoint, submittedAt: new Date().toISOString() });
+        setStatus('submitted');
+      })
+      .finally(() => {
+        setIsSubmitting(false);
+      });
+  };
+
+  const handlePlayAgain = () => {
+    setResult(null);
+    setStatus('idle');
+    setDisplaySeconds(formatSeconds(countdownSeconds));
+    startTimeRef.current = null;
+    targetTimeRef.current = null;
+    hasFinalisedRef.current = false;
+  };
+
+  const statusLabels = {
+    idle: 'Ready',
+    counting: 'Counting down',
+    submitting: 'Submitting',
+    submitted: 'Complete',
+  };
+
+  const statusMessage = (() => {
+    switch (status) {
+      case 'counting':
+        return 'Trust your instincts and stop the countdown as close to zero as you can.';
+      case 'submitting':
+        return 'Locking in your timing—hang tight while we record the results.';
+      case 'submitted':
+        return 'Great timing! Review your summary below.';
+      default:
+        return 'Start the countdown when you are ready and aim for absolute precision.';
+    }
+  })();
+
+  if (result) {
+    return (
+      <ResultsScreen
+        config={config}
+        result={result}
+        onPlayAgain={handlePlayAgain}
+        onBack={onBack}
+      />
+    );
+  }
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 py-16 px-4 text-white">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-24 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-sky-500/25 blur-3xl" />
+        <div className="absolute bottom-0 right-12 h-72 w-72 rounded-full bg-violet-500/20 blur-3xl" />
+        <div className="absolute -bottom-20 left-8 h-64 w-64 rounded-full bg-emerald-500/20 blur-3xl" />
+      </div>
+
+      <div className="relative mx-auto flex w-full max-w-4xl flex-col items-center gap-10">
+        <header className="space-y-3 text-center">
+          <p className="text-sm uppercase tracking-[0.35em] text-sky-300">Precision Timer</p>
+          <h2 className="text-4xl font-semibold text-white drop-shadow">{config?.title}</h2>
+          {config?.subtitle && <p className="text-lg text-slate-300">{config.subtitle}</p>}
+          {config?.description && (
+            <p className="mx-auto max-w-2xl text-base text-slate-400">{config.description}</p>
+          )}
+        </header>
+
+        <div className="relative w-full overflow-hidden rounded-[2rem] border border-slate-800/60 bg-slate-900/70 p-10 text-center shadow-2xl shadow-sky-900/30 backdrop-blur">
+          <div className="absolute inset-x-16 top-0 h-px bg-gradient-to-r from-transparent via-sky-400/60 to-transparent" />
+          <div className="flex flex-col items-center gap-10">
+            <div className="flex flex-col items-center gap-4">
+              <span className="rounded-full border border-sky-400/60 bg-slate-900/80 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-sky-200">
+                {statusLabels[status] || statusLabels.idle}
+              </span>
+              <div className="relative">
+                <div className="absolute inset-0 -translate-y-6 scale-125 rounded-full bg-sky-500/25 blur-3xl" />
+                <div className="relative flex h-56 w-56 items-center justify-center rounded-full border border-sky-400/40 bg-slate-950/80 shadow-[0_22px_45px_rgba(15,23,42,0.55)]">
+                  <div className="absolute inset-4 rounded-full border border-sky-500/20 bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900 shadow-inner shadow-[inset_0_-8px_18px_rgba(15,23,42,0.55)]" />
+                  <span className="relative text-6xl font-mono font-semibold tabular-nums text-sky-100">{displaySeconds}</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="grid w-full gap-4 text-left text-sm text-slate-300 sm:grid-cols-2">
+              <div className="rounded-2xl border border-slate-800 bg-slate-950/60 p-5">
+                <h3 className="text-xs uppercase tracking-[0.25em] text-slate-400">Challenge</h3>
+                <p className="mt-2 text-slate-200">
+                  Stop the timer as close to zero as possible. Every millisecond counts towards your final score.
+                </p>
+              </div>
+              <div className="flex items-center justify-between rounded-2xl border border-slate-800 bg-slate-950/60 p-5">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.25em] text-slate-400">Countdown duration</p>
+                  <p className="mt-2 text-2xl font-semibold text-white">{formatSeconds(countdownSeconds)}s</p>
+                </div>
+                <div className="text-right text-xs text-slate-500">
+                  <p>Press stop the moment you sense the final second vanish.</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center justify-center gap-4">
+              <button
+                type="button"
+                onClick={startCountdown}
+                disabled={status !== 'idle'}
+                className="group relative inline-flex items-center justify-center overflow-hidden rounded-full bg-gradient-to-r from-emerald-400 via-sky-500 to-indigo-500 px-8 py-3 text-lg font-semibold text-white shadow-[0_18px_35px_rgba(14,116,144,0.45)] transition-transform disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                <span className="relative drop-shadow-[0_2px_6px_rgba(6,182,212,0.5)]">{startLabel}</span>
+              </button>
+              <button
+                type="button"
+                onClick={stopCountdown}
+                disabled={status !== 'counting'}
+                className="group relative inline-flex items-center justify-center overflow-hidden rounded-full bg-gradient-to-r from-rose-500 via-orange-500 to-amber-500 px-8 py-3 text-lg font-semibold text-white shadow-[0_18px_35px_rgba(190,24,93,0.45)] transition-transform disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                <span className="relative drop-shadow-[0_2px_6px_rgba(249,115,22,0.5)]">{stopLabel}</span>
+              </button>
+            </div>
+
+            <div className="w-full rounded-2xl border border-slate-800 bg-slate-950/60 p-5 text-sm text-slate-200">
+              <p>{statusMessage}</p>
+              {status === 'counting' && (
+                <p className="mt-2 text-xs uppercase tracking-[0.25em] text-slate-500">
+                  Countdown began at {formatSeconds(countdownSeconds)} seconds
+                </p>
+              )}
+              {isSubmitting && !result && (
+                <p className="mt-2 text-xs font-semibold uppercase tracking-[0.3em] text-sky-300" role="status" aria-live="polite">
+                  Submitting results…
+                </p>
+              )}
+            </div>
+
+            {typeof onBack === 'function' && (
+              <button
+                type="button"
+                onClick={onBack}
+                className="mt-2 text-sm font-medium text-slate-300 underline-offset-2 hover:text-white hover:underline"
+              >
+                Back to games
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const mockSubmitResults = (url, payload) =>
+  new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        ...payload,
+        submissionEndpoint: url,
+        submittedAt: new Date().toISOString(),
+      });
+    }, 600);
+  });
+
+export default PrecisionTimerGame;

--- a/src/game_modules/precision-timer-module/results-screen.js
+++ b/src/game_modules/precision-timer-module/results-screen.js
@@ -1,0 +1,152 @@
+import React from 'react';
+
+const formatSeconds = (value) => {
+  if (value === null || typeof value === 'undefined') {
+    return '—';
+  }
+
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return '—';
+  }
+
+  return numeric.toFixed(3);
+};
+
+const buildTheme = (config) => {
+  const defaults = {
+    background: '#020617',
+    panel: 'rgba(15, 23, 42, 0.85)',
+    highlight: '#38bdf8',
+    accent: '#f97316',
+    text: '#f8fafc',
+  };
+
+  return {
+    ...defaults,
+    ...(config?.theme || {}),
+  };
+};
+
+const PrecisionTimerResultsScreen = ({ config, result, onPlayAgain, onBack }) => {
+  const theme = buildTheme(config);
+  const heading = config?.results_heading || 'Countdown Results';
+  const retryLabel = config?.retry_button_label || 'Play again';
+  const backLabel = config?.back_button_label || 'Back to games';
+
+  const metrics = [
+    result?.countdownSeconds != null
+      ? { label: 'Countdown duration', value: `${formatSeconds(result.countdownSeconds)}s` }
+      : null,
+    result?.pressedAtSeconds != null
+      ? { label: 'Pressed at', value: `${formatSeconds(result.pressedAtSeconds)}s` }
+      : null,
+    result?.timeRemainingSeconds != null
+      ? { label: 'Time remaining', value: `${formatSeconds(result.timeRemainingSeconds)}s` }
+      : null,
+    result?.score != null
+      ? { label: 'Accuracy score', value: `${formatSeconds(result.score)}s` }
+      : null,
+  ].filter(Boolean);
+
+  const rewards = Array.isArray(config?.rewards) ? config.rewards : [];
+
+  return (
+    <div
+      className="flex min-h-screen items-center justify-center px-4 py-16"
+      style={{
+        background: theme.background,
+        color: theme.text,
+      }}
+    >
+      <div
+        className="w-full max-w-3xl space-y-8 rounded-3xl border border-slate-800/60 p-10 text-center shadow-2xl"
+        style={{
+          background: theme.panel,
+        }}
+      >
+        <div className="space-y-3">
+          <p className="text-xs uppercase tracking-[0.35em]" style={{ color: theme.highlight }}>
+            Precision Timer
+          </p>
+          <h2 className="text-3xl font-semibold text-white">{heading}</h2>
+          {result?.outcome && (
+            <p className="text-sm text-slate-300" style={{ color: theme.text }}>
+              Outcome: {result.outcome}
+            </p>
+          )}
+        </div>
+
+        {metrics.length > 0 && (
+          <dl className="grid gap-4 text-left sm:grid-cols-2">
+            {metrics.map((metric) => (
+              <div
+                key={metric.label}
+                className="rounded-2xl border border-slate-800/60 bg-slate-950/40 p-6"
+                style={{ borderColor: `${theme.highlight}33` }}
+              >
+                <dt className="text-xs uppercase tracking-[0.25em] text-slate-400">{metric.label}</dt>
+                <dd className="mt-3 text-2xl font-semibold text-white">{metric.value}</dd>
+              </div>
+            ))}
+          </dl>
+        )}
+
+        {rewards.length > 0 && (
+          <section className="space-y-3">
+            <h3 className="text-sm uppercase tracking-[0.3em]" style={{ color: theme.highlight }}>
+              Reward thresholds
+            </h3>
+            <ul className="grid gap-3 text-left sm:grid-cols-2">
+              {rewards.map((reward) => (
+                <li
+                  key={`${reward.threshold}-${reward.title}`}
+                  className="rounded-2xl border border-slate-800/60 bg-slate-950/40 p-5"
+                  style={{ borderColor: `${theme.accent}33` }}
+                >
+                  <p className="text-sm font-semibold text-white">
+                    {reward.title || 'Reward'}
+                  </p>
+                  {reward.description && (
+                    <p className="mt-1 text-sm text-slate-300" style={{ color: `${theme.text}cc` }}>
+                      {reward.description}
+                    </p>
+                  )}
+                  {typeof reward.threshold === 'number' && (
+                    <p className="mt-2 text-xs uppercase tracking-[0.25em]" style={{ color: theme.accent }}>
+                      &le; {formatSeconds(reward.threshold)}s
+                    </p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={onPlayAgain}
+            className="w-full rounded-full px-6 py-2 text-sm font-semibold text-slate-950 shadow sm:w-auto"
+            style={{ background: theme.highlight }}
+          >
+            {retryLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onBack}
+            className="w-full rounded-full border px-6 py-2 text-sm font-semibold sm:w-auto"
+            style={{
+              borderColor: `${theme.text}33`,
+              color: theme.text,
+            }}
+          >
+            {backLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PrecisionTimerResultsScreen;

--- a/src/game_modules/precision-timer-module/sample-game-document.js
+++ b/src/game_modules/precision-timer-module/sample-game-document.js
@@ -1,0 +1,38 @@
+const samplePrecisionTimerGameDocument = {
+  game_id: 'precision-timer-demo-001',
+  game_template_id: 'precision-timer-classic',
+  game_type: 'precision-timer',
+  merchant_id: 'nthlabs-demo',
+  name: 'Precision Countdown Demo',
+  title: 'Precision Countdown Challenge',
+  subtitle: 'Stop the clock exactly when you feel it hits zero.',
+  description:
+    'Launch the countdown, trust your instincts, and tap stop the instant you think the timer reaches zero. Each millisecond away from perfect adds to your score.',
+  sample_thumbnail:
+    'https://images.unsplash.com/photo-1522199755839-a2bacb67c546?auto=format&fit=crop&w=600&q=80',
+  countdown_seconds: 5,
+  start_button_label: 'Start Countdown',
+  stop_button_label: 'Stop at Zero',
+  retry_button_label: 'Try Again',
+  results_heading: 'Countdown Summary',
+  theme: {
+    background: '#020617',
+    highlight: '#38bdf8',
+    accent: '#f59e0b',
+    text: '#f8fafc',
+  },
+  rewards: [
+    {
+      threshold: 0.15,
+      title: 'Crystal Focus Pin',
+      description: 'Awarded for stopping within 0.15s of zero.',
+    },
+    {
+      threshold: 0.05,
+      title: 'Chronomaster Patch',
+      description: 'Stop within 0.05s and earn this limited run patch.',
+    },
+  ],
+};
+
+export default samplePrecisionTimerGameDocument;

--- a/src/game_modules/registry.js
+++ b/src/game_modules/registry.js
@@ -12,6 +12,9 @@ import OverworldExplorerInit, {
 import DinoJumpGameInit, {
   sampleDinoJumpGameDocument,
 } from "./dino-jump-module";
+import PrecisionTimerGameInit, {
+  samplePrecisionTimerGameDocument,
+} from "./precision-timer-module";
 
 /**
  * Keys should match what's coming from backend:
@@ -41,6 +44,10 @@ export const GAME_MODULES = {
   // Dino jump endless runner
   "dino-jump-canyon-run": DinoJumpGameInit,
   "dino-jump": DinoJumpGameInit,
+
+  // Precision timer challenge
+  "precision-timer-classic": PrecisionTimerGameInit,
+  "precision-timer": PrecisionTimerGameInit,
 
   // Example for future templates:
   // "spinthewheel-v1": SpinTheWheelInit,
@@ -110,6 +117,17 @@ export const GAME_LIBRARY = [
       game_type: sampleDinoJumpGameDocument.game_type || "dino-jump",
     },
     sampleConfig: sampleDinoJumpGameDocument,
+  },
+  {
+    slug: "precision-timer-classic",
+    title: samplePrecisionTimerGameDocument.title || "Precision Countdown Challenge",
+    subtitle: samplePrecisionTimerGameDocument.subtitle,
+    thumbnail: samplePrecisionTimerGameDocument.sample_thumbnail,
+    launchPayload: {
+      game_template_id: "precision-timer-classic",
+      game_type: samplePrecisionTimerGameDocument.game_type || "precision-timer",
+    },
+    sampleConfig: samplePrecisionTimerGameDocument,
   },
 ];
 


### PR DESCRIPTION
## Summary
- add a precision timer game module with mocked configuration loading and countdown gameplay
- provide a sample precision timer game document and dedicated results screen
- register the new module so precision timer templates can launch from the library

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e539f2e7f4832aa3dd3bc852387a74